### PR TITLE
feat: new 'active code' clicked step for mobile accessibility

### DIFF
--- a/src/components/pages/grades-curriculares/discipline-node.tsx
+++ b/src/components/pages/grades-curriculares/discipline-node.tsx
@@ -28,7 +28,7 @@ type DisciplineNodeProps = {
   isHighlighted: boolean;
   isFaded: boolean;
   isClicked: boolean;
-  onClick: () => void;
+  onClick?: (e: React.MouseEvent<HTMLElement>) => void;
   onMouseEnter: () => void;
   onMouseLeave: () => void;
 };


### PR DESCRIPTION
## 📝 Descrição

Adiciona um novo step para visualizar a disciplina no grafo, fazendo com que a navegação fique mais fácil para usuários mobile. Também adiciona um botão "Ver mais" para que o usuário clique novamente no card, abrindo mais detalhes.

## 🔗 Issue Relacionada

Closes #110 

## 🧪 Testes

- [X] Testes unitários passam
- [X] Testes de integração passam
- [X] Testes E2E passam
- [X] Testes manuais concluídos

## 📸 Screenshots (se aplicável)

<img width="414" height="884" alt="image" src="https://github.com/user-attachments/assets/60a48da3-6b9c-4017-8f66-ea4b0f56eea3" />

## 📋 Checklist

- [X] Código segue as diretrizes de estilo do projeto
- [X] Revisão própria concluída
- [X] Código está devidamente comentado
- [X] Nenhum console.log deixado no código
- [X] Todos os testes passam localmente
- [X] Build passa sem erros

## 🚀 Notas de Deploy

## 📚 Contexto Adicional

