### PR TITLE
Add: Map at Entidade page

### DIFF
--- a/src/app/entidade/[slug]/page.tsx
+++ b/src/app/entidade/[slug]/page.tsx
@@ -72,7 +72,6 @@ export default function EntidadeDetailPage({ params }: { params: Promise<{ slug:
         <EntidadeMapSection entidade={entidade} />
 
         <EntidadeOtherEntitiesSection currentEntidade={entidade} otherEntidades={otherEntidades} />
-        
       </div>
 
       {/* Edit Dialog */}

--- a/src/components/pages/entidades/entidade-map-section.tsx
+++ b/src/components/pages/entidades/entidade-map-section.tsx
@@ -23,7 +23,9 @@ export function EntidadeMapSection({ entidade }: EntidadeMapSectionProps) {
   const [isDetailsOpen, setIsDetailsOpen] = useState(false);
 
   const foundLocation = useMemo(() => {
-    if (!mapsData) return null;
+    if (!mapsData) {
+      return null;
+    }
 
     console.log("Searching map for entity:", {
       name: entidade.name,
@@ -35,15 +37,15 @@ export function EntidadeMapSection({ entidade }: EntidadeMapSectionProps) {
       for (const floor of building.floors) {
         for (const room of floor.rooms) {
           if (isLabResearch(room)) {
-             if (room.labs?.includes(entidade.slug || "")) {
-                console.log("Found by slug match:", room);
-                return { building, floor, room };
-             }
+            if (room.labs?.includes(entidade.slug || "")) {
+              console.log("Found by slug match:", room);
+              return { building, floor, room };
+            }
           }
-          
+
           if (entidade.location && room.location === entidade.location) {
-             console.log("Found by location match:", room);
-             return { building, floor, room };
+            console.log("Found by location match:", room);
+            return { building, floor, room };
           }
         }
       }
@@ -72,13 +74,13 @@ export function EntidadeMapSection({ entidade }: EntidadeMapSectionProps) {
   }
   if (!foundLocation) {
     if (entidade.location) {
-        return null; 
+      return null;
     }
     return null;
   }
 
   const { building, floor: foundFloor, room: foundRoom } = foundLocation;
-  
+
   const currentFloorId = selectedFloorId || foundFloor.id;
   const displayFloor = building.floors.find(f => f.id === currentFloorId) || foundFloor;
 
@@ -91,23 +93,23 @@ export function EntidadeMapSection({ entidade }: EntidadeMapSectionProps) {
     <div className="px-6 md:px-8 lg:px-16 py-8 border-t border-border/40">
       <div className="flex flex-col gap-6">
         <div className="flex flex-col gap-1">
-            <h2 className="text-2xl font-bold flex items-center gap-2">
-              <MapPin className="w-6 h-6 text-primary" />
-              Localização
-            </h2>
-            <p className="text-muted-foreground">
-              {building.name} • {displayFloor.name} • Sala {foundRoom.location}
-            </p>
+          <h2 className="text-2xl font-bold flex items-center gap-2">
+            <MapPin className="w-6 h-6 text-primary" />
+            Localização
+          </h2>
+          <p className="text-muted-foreground">
+            {building.name} • {displayFloor.name} • Sala {foundRoom.location}
+          </p>
         </div>
 
         <InteractiveMap
-            building={building}
-            initialFloorId={foundFloor.id}
-            selectedFloorId={currentFloorId}
-            onFloorChange={setSelectedFloorId}
-            highlightedRoomId={foundRoom.id}
-            isDark={isDark}
-            onRoomClick={handleRoomClick}
+          building={building}
+          initialFloorId={foundFloor.id}
+          selectedFloorId={currentFloorId}
+          onFloorChange={setSelectedFloorId}
+          highlightedRoomId={foundRoom.id}
+          isDark={isDark}
+          onRoomClick={handleRoomClick}
         />
       </div>
 

--- a/src/components/pages/mapas/interactive-map.tsx
+++ b/src/components/pages/mapas/interactive-map.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { Building, Room } from "@/lib/client/mapas/types";
 import BlueprintViewer from "@/components/pages/mapas/blueprint-viewer";
 import { MapFloorSelector } from "@/components/pages/mapas/map-floor-selector";
-
 
 type InteractiveMapProps = {
   building: Building;
@@ -13,7 +12,7 @@ type InteractiveMapProps = {
   onFloorChange?: (floorId: string) => void;
   highlightedRoomId?: string;
   isDark?: boolean;
-  onRoomClick?: (room: Room) => void;
+  onRoomClick: (room: Room) => void;
   className?: string;
 };
 
@@ -32,7 +31,9 @@ export function InteractiveMap({
   );
 
   const isControlled = controlledSelectedFloorId !== undefined;
-  const effectiveSelectedFloorId = isControlled ? controlledSelectedFloorId : internalSelectedFloorId;
+  const effectiveSelectedFloorId = isControlled
+    ? controlledSelectedFloorId
+    : internalSelectedFloorId;
 
   const handleFloorChange = (id: string) => {
     if (!isControlled) {
@@ -42,10 +43,11 @@ export function InteractiveMap({
   };
 
   const displayFloor =
-    building.floors.find((f) => f.id === effectiveSelectedFloorId) ||
-    building.floors[0];
+    building.floors.find(f => f.id === effectiveSelectedFloorId) || building.floors[0];
 
-  if (!displayFloor) return null;
+  if (!displayFloor) {
+    return null;
+  }
 
   return (
     <div className={"flex flex-col gap-6 mt-6" + className}>
@@ -56,7 +58,7 @@ export function InteractiveMap({
             selectedFloorId={displayFloor.id}
             onSelectFloor={handleFloorChange}
             isDark={isDark}
-            roomFloorId={initialFloorId} 
+            roomFloorId={initialFloorId}
           />
         </div>
       </div>
@@ -66,9 +68,7 @@ export function InteractiveMap({
           floor={displayFloor}
           onRoomClick={onRoomClick}
           isDark={isDark}
-          highlightedRoomId={
-            displayFloor.id === initialFloorId ? highlightedRoomId : undefined
-          }
+          highlightedRoomId={displayFloor.id === initialFloorId ? highlightedRoomId : undefined}
           compact={false}
         />
       </div>


### PR DESCRIPTION
Seção de Mapa na Página da Entidade (EntidadeMapSection)
Adicionada uma seção "Localização" na página de detalhes da entidade (src/app/entidade/[slug]/page.tsx).
Busca automaticamente a localização da entidade nos dados do mapa, associando pelo slug (em laboratórios de pesquisa) ou pelo nome da location.
Exibe o nome do prédio, andar e sala.

Componente de Mapa Interativo (InteractiveMap)
Criado um componente reutilizável (src/components/pages/mapas/interactive-map.tsx) que encapsula a lógica de exibição do mapa e controle de andares.
Permite selecionar qual andar visualizar através de botões no canto superior direito.
Destaca automaticamente a sala da entidade ao carregar.
<img width="1912" height="948" alt="image" src="https://github.com/user-attachments/assets/aceecde5-cae8-4286-90d8-c049cb2e497f" />
