### PR TITLE
fix(calendario): correct exported image rendering for multi-slot classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Search**: Sanitize `limit` query parameter as bounded integer to prevent invalid SQL LIMIT values
 - **Search**: Guard against null `entidade.slug` to prevent navigation to `/entidade/null`
 - **Search**: Fix Prettier formatting and ESLint curly-brace violations across search files
+- **Calendário**: Fix exported calendar image for classes spanning multiple time slots — blocks now correctly occupy their full height instead of being clipped to a single row
+- **Calendário**: Fix inconsistent time label font sizes in exported calendar image caused by unreset Canvas font state
 
 ## [1.4.0] - 2026-03-08
 

--- a/src/lib/client/calendario/export.ts
+++ b/src/lib/client/calendario/export.ts
@@ -107,14 +107,11 @@ export function exportCalendarAsImage({
       CALENDAR_TIME_SLOTS.forEach((timeSlot, slotIndex) => {
         const rowY = tableY + headerHeight + slotIndex * rowHeight;
 
-        // Draw row background
-        ctx.fillStyle = cellBgColor;
-        ctx.fillRect(tableX, rowY, tableWidth, rowHeight);
-
         // Draw time slot label
         ctx.fillStyle = headerBgColor;
         ctx.fillRect(tableX, rowY, timeColumnWidth, rowHeight);
         ctx.fillStyle = textColor;
+        ctx.font = "12px system-ui, -apple-system, sans-serif";
         ctx.textAlign = "left";
         ctx.fillText(timeSlot.label, tableX + 10, rowY + 20);
 
@@ -125,6 +122,7 @@ export function exportCalendarAsImage({
           const slotData = dayData?.get(timeSlot.index);
 
           // Skip if this is part of a merged block but not the start
+          // Do NOT draw background here — it would overwrite the merged cell
           if (slotData && slotData.rowSpan > 1 && !slotData.isStartOfMerge) {
             return;
           }
@@ -133,6 +131,10 @@ export function exportCalendarAsImage({
           const rowSpan = slotData?.rowSpan || 1;
           const cellHeight = rowSpan * rowHeight;
           const hasConflict = classes.length > 1;
+
+          // Draw cell background per column (not full row) to avoid overwriting merged cells
+          ctx.fillStyle = cellBgColor;
+          ctx.fillRect(cellX, rowY, dayColumnWidth, rowHeight);
 
           // Draw cell border
           ctx.strokeStyle = hasConflict ? conflictBorderColor : borderColor;
@@ -150,10 +152,8 @@ export function exportCalendarAsImage({
             const blockPadding = 4;
             const blockSpacing = 2;
             const availableHeight = cellHeight - blockPadding * 2;
-            const blockHeight = Math.min(
-              (availableHeight - (classes.length - 1) * blockSpacing) / classes.length,
-              50
-            );
+            const blockHeight =
+              (availableHeight - (classes.length - 1) * blockSpacing) / classes.length;
 
             classes.forEach((classItem, classIndex) => {
               const blockY = rowY + blockPadding + classIndex * (blockHeight + blockSpacing);


### PR DESCRIPTION
## 📝 Descrição

A imagem PNG exportada do calendário renderizava disciplinas que ocupam múltiplos horários (ex: 08:00–10:00) como se ocupassem apenas um slot.

**Causa raiz:** O código Canvas desenhava um fundo branco de largura total para CADA linha do calendário, sobrescrevendo os blocos mesclados já desenhados nas linhas anteriores (painter's algorithm).

**Correções:**
- Substituído fundo full-width por fundo por coluna que respeita cells mescladas
- Removido `Math.min(50)` que limitava a altura dos blocos
- Adicionado reset de `ctx.font` no loop para corrigir tamanho inconsistente dos labels de horário

## 🔗 Issue Relacionada

Closes #65

## 🧪 Testes

- [x] Testes unitários passam
- [x] Testes de integração passam
- [ ] Testes E2E passam
- [x] Testes manuais concluídos

## 📸 Screenshots

### Antes
<img width="950" height="1200" alt="imagem-teste" src="https://github.com/user-attachments/assets/56cc89d4-5b75-4e84-a03d-492f1ffbe98d" />

### Depois
<img width="950" height="1230" alt="imagem-pos-fix" src="https://github.com/user-attachments/assets/83a06ddf-ac0b-49ce-bd88-5c56ada3a961" />

## 📋 Checklist

- [x] Código segue as diretrizes de estilo do projeto
- [x] Revisão própria concluída
- [x] Código está devidamente comentado
- [x] Nenhum console.log deixado no código
- [x] Todos os testes passam localmente
- [x] Build passa sem erros

## 🚀 Notas de Deploy

Nenhuma consideração especial. Mudança apenas em código client-side.

## 📚 Contexto Adicional

Arquivo alterado: `src/lib/client/calendario/export.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed calendar blocks being clipped to a single row when classes span multiple time slots in exported images
  * Fixed inconsistent time label font sizes in exported calendar images

<!-- end of auto-generated comment: release notes by coderabbit.ai -->