### PR TITLE
feat(grades): add export grade as PNG image button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Grades Curriculares**: Botão para exportar grade curricular como imagem PNG (#169)
 - **UI**: DatePicker component with Calendar popover, pt-BR locale, and date range constraints
 - **Search**: Global search command palette (Ctrl+K) with unified search across pages, guides, entities, jobs, disciplines, courses, and user profiles
 - **Search**: PostgreSQL Full-Text Search with `unaccent` extension for accent-insensitive Brazilian Portuguese search, ranked by relevance with `ts_rank`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Grades Curriculares**: Botão para exportar grade curricular como imagem PNG com 3 modos — "Com meu progresso" (barra de progresso e stats), "Próximas disponíveis" (destaca disciplinas desbloqueadas) e "Grade limpa" (#169)
+- **Grades Curriculares**: Botão para exportar grade curricular como imagem PNG — "Com meu progresso" (barra de progresso e stats) e "Grade limpa" (#169)
 - **UI**: DatePicker component with Calendar popover, pt-BR locale, and date range constraints
 - **Search**: Global search command palette (Ctrl+K) with unified search across pages, guides, entities, jobs, disciplines, courses, and user profiles
 - **Search**: PostgreSQL Full-Text Search with `unaccent` extension for accent-insensitive Brazilian Portuguese search, ranked by relevance with `ts_rank`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Grades Curriculares**: Botão para exportar grade curricular como imagem PNG (#169)
+- **Grades Curriculares**: Botão para exportar grade curricular como imagem PNG com 3 modos — "Com meu progresso" (barra de progresso e stats), "Próximas disponíveis" (destaca disciplinas desbloqueadas) e "Grade limpa" (#169)
 - **UI**: DatePicker component with Calendar popover, pt-BR locale, and date range constraints
 - **Search**: Global search command palette (Ctrl+K) with unified search across pages, guides, entities, jobs, disciplines, courses, and user profiles
 - **Search**: PostgreSQL Full-Text Search with `unaccent` extension for accent-insensitive Brazilian Portuguese search, ranked by relevance with `ts_rank`

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "cmdk": "^1.1.1",
         "date-fns": "^3.6.0",
         "dompurify": "^3.2.6",
+        "html-to-image": "^1.11.13",
         "ics": "^3.8.1",
         "jsonwebtoken": "^9.0.2",
         "lucide-react": "^0.427.0",
@@ -12030,6 +12031,12 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
       "license": "MIT"
     },
     "node_modules/html-to-text": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "cmdk": "^1.1.1",
     "date-fns": "^3.6.0",
     "dompurify": "^3.2.6",
+    "html-to-image": "^1.11.13",
     "ics": "^3.8.1",
     "jsonwebtoken": "^9.0.2",
     "lucide-react": "^0.427.0",

--- a/src/analytics/posthog-events.ts
+++ b/src/analytics/posthog-events.ts
@@ -66,10 +66,9 @@ export type CalendarioAcademicoEvent =
   | { name: "calendario_academico_view_changed"; view: "lista" | "calendario" }
   | { name: "calendario_academico_semestre_changed"; semestre_nome: string };
 
-export type GradesCurricularesEvent = {
-  name: "grade_curricular_curso_selected";
-  curso_nome: string;
-};
+export type GradesCurricularesEvent =
+  | { name: "grade_curricular_curso_selected"; curso_nome: string }
+  | { name: "grade_curricular_export_image_click" };
 
 export type MapasEvent = {
   name: "mapa_room_clicked";

--- a/src/components/pages/grades-curriculares/curriculum-graph.tsx
+++ b/src/components/pages/grades-curriculares/curriculum-graph.tsx
@@ -27,14 +27,13 @@ import {
   ChevronDown,
   CircleDot,
   Download,
-  Sparkles,
 } from "lucide-react";
 import { exportGradeAsImage } from "@/lib/client/grades-curriculares/export";
 import { trackEvent } from "@/analytics/posthog-client";
 import { toast } from "sonner";
 
 /** Export modes — union type prevents invalid state combinations */
-type ExportMode = "progress" | "blank" | "available" | null;
+type ExportMode = "progress" | "blank" | null;
 
 function computeHighlightChain(
   code: string,
@@ -375,23 +374,6 @@ export function CurriculumGraph({
     return locked;
   }, [disciplinas, completedDisciplinaIds, selectionSet]);
 
-  // Available disciplines: not locked, not completed, not cursando
-  const availableCodes = useMemo(() => {
-    if (!completedDisciplinaIds) {
-      return new Set<string>();
-    }
-    const available = new Set<string>();
-    for (const d of visibleDisciplinas) {
-      const isCompleted = completedDisciplinaIds.has(d.disciplinaId);
-      const isCursando = cursandoDisciplinaIds?.has(d.disciplinaId);
-      const isLocked = lockedCodes.has(d.codigo);
-      if (!isCompleted && !isCursando && !isLocked) {
-        available.add(d.codigo);
-      }
-    }
-    return available;
-  }, [visibleDisciplinas, completedDisciplinaIds, cursandoDisciplinaIds, lockedCodes]);
-
   // Progress stats
   const progressStats = useMemo(() => {
     if (!completedDisciplinaIds) {
@@ -514,9 +496,6 @@ export function CurriculumGraph({
                 <Button variant="outline" size="sm" disabled={isExporting} className="gap-2">
                   <Download className="w-4 h-4" />
                   {isExporting ? "Exportando..." : "Exportar Imagem"}
-                  {!showOptativas && !isExporting && (
-                    <span className="text-[10px] text-muted-foreground">(sem optativas)</span>
-                  )}
                   <ChevronDown className="w-3 h-3" />
                 </Button>
               </DropdownMenuTrigger>
@@ -524,10 +503,6 @@ export function CurriculumGraph({
                 <DropdownMenuItem onClick={() => void handleExportImage("progress")}>
                   <CheckCircle2 className="w-3.5 h-3.5 mr-2 text-green-600" />
                   Com meu progresso
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => void handleExportImage("available")}>
-                  <Sparkles className="w-3.5 h-3.5 mr-2 text-blue-500" />
-                  Próximas disponíveis
                 </DropdownMenuItem>
                 <DropdownMenuItem onClick={() => void handleExportImage("blank")}>
                   <BookOpen className="w-3.5 h-3.5 mr-2 text-muted-foreground" />
@@ -545,9 +520,6 @@ export function CurriculumGraph({
             >
               <Download className="w-4 h-4" />
               {isExporting ? "Exportando..." : "Exportar Imagem"}
-              {!showOptativas && !isExporting && (
-                <span className="text-[10px] text-muted-foreground">(sem optativas)</span>
-              )}
             </Button>
           )}
           {isLoggedIn && onSelectionModeChange && (
@@ -586,7 +558,7 @@ export function CurriculumGraph({
               <span className="w-0.5 h-3 rounded-full bg-blue-400 dark:bg-blue-500" />
               Obrigatória
             </span>
-            {showOptativas && (
+            {hasOptativas && (
               <>
                 <span className="flex items-center gap-1.5">
                   <span className="w-0.5 h-3 rounded-full bg-amber-400 dark:bg-amber-500" />
@@ -703,17 +675,6 @@ export function CurriculumGraph({
                       </span>
                     </>
                   )}
-                  {/* Available legend — available mode */}
-                  {exportMode === "available" && (
-                    <>
-                      <span className="flex items-center gap-1 font-medium text-emerald-600 dark:text-emerald-400">
-                        ● Disponível
-                      </span>
-                      <span className="flex items-center gap-1 text-muted-foreground">
-                        ○ Indisponível
-                      </span>
-                    </>
-                  )}
                 </div>
               </div>
               {/* Progress stats bar — only in progress mode */}
@@ -740,12 +701,6 @@ export function CurriculumGraph({
                   </div>
                 </div>
               )}
-              {/* Available count — only in available mode */}
-              {exportMode === "available" && (
-                <p className="mt-1 text-[10px] text-muted-foreground">
-                  {availableCodes.size} disciplina(s) disponível(is) para matrícula
-                </p>
-              )}
             </div>
           )}
 
@@ -770,18 +725,14 @@ export function CurriculumGraph({
                   ref={el => setNodeRef(disc.codigo, el)}
                   discipline={disc}
                   isHighlighted={
-                    exportMode === "available"
-                      ? availableCodes.has(disc.codigo)
-                      : !isExporting &&
-                        activeHighlightedCodes !== null &&
-                        activeHighlightedCodes.has(disc.codigo)
+                    !isExporting &&
+                    activeHighlightedCodes !== null &&
+                    activeHighlightedCodes.has(disc.codigo)
                   }
                   isFaded={
-                    exportMode === "available"
-                      ? !availableCodes.has(disc.codigo)
-                      : !isExporting &&
-                        activeHighlightedCodes !== null &&
-                        !activeHighlightedCodes.has(disc.codigo)
+                    !isExporting &&
+                    activeHighlightedCodes !== null &&
+                    !activeHighlightedCodes.has(disc.codigo)
                   }
                   isClicked={!isExporting && clickedCode === disc.codigo}
                   isHovered={!isExporting && canHover && hoveredCode === disc.codigo}

--- a/src/components/pages/grades-curriculares/curriculum-graph.tsx
+++ b/src/components/pages/grades-curriculares/curriculum-graph.tsx
@@ -650,6 +650,8 @@ export function CurriculumGraph({
                     <span className="w-0.5 h-2.5 rounded-full bg-blue-400 dark:bg-blue-500" />
                     Obrigatória
                   </span>
+                  {/* Uses showOptativas (not hasOptativas) because the exported image
+                      only contains optativas when the toggle is active */}
                   {showOptativas && (
                     <>
                       <span className="flex items-center gap-1">

--- a/src/components/pages/grades-curriculares/curriculum-graph.tsx
+++ b/src/components/pages/grades-curriculares/curriculum-graph.tsx
@@ -27,10 +27,14 @@ import {
   ChevronDown,
   CircleDot,
   Download,
+  Sparkles,
 } from "lucide-react";
 import { exportGradeAsImage } from "@/lib/client/grades-curriculares/export";
 import { trackEvent } from "@/analytics/posthog-client";
 import { toast } from "sonner";
+
+/** Export modes — union type prevents invalid state combinations */
+type ExportMode = "progress" | "blank" | "available" | null;
 
 function computeHighlightChain(
   code: string,
@@ -119,8 +123,8 @@ export function CurriculumGraph({
   // Selection set for bulk mode (keyed on disciplinaId)
   const [selectionSet, setSelectionSet] = useState<Set<string>>(new Set());
 
-  const [isExporting, setIsExporting] = useState(false);
-  const [isBlankExport, setIsBlankExport] = useState(false);
+  const [exportMode, setExportMode] = useState<ExportMode>(null);
+  const isExporting = exportMode !== null;
 
   const containerRef = useRef<HTMLDivElement>(null);
   const scrollWrapperRef = useRef<HTMLDivElement>(null);
@@ -225,17 +229,14 @@ export function CurriculumGraph({
   }, []);
 
   const handleExportImage = useCallback(
-    async (blank: boolean) => {
+    async (mode: NonNullable<ExportMode>) => {
       if (!containerRef.current || !scrollWrapperRef.current) {
         toast.error("Erro ao exportar a grade curricular");
         return;
       }
 
       trackEvent("grade_curricular_export_image_click");
-      setIsExporting(true);
-      if (blank) {
-        setIsBlankExport(true);
-      }
+      setExportMode(mode);
 
       const wrapper = scrollWrapperRef.current;
       const originalMaxHeight = wrapper.style.maxHeight;
@@ -262,9 +263,8 @@ export function CurriculumGraph({
       } finally {
         wrapper.style.maxHeight = originalMaxHeight;
         wrapper.style.overflow = originalOverflow;
-        setIsBlankExport(false);
+        setExportMode(null);
         measureNodes();
-        setIsExporting(false);
       }
     },
     [cursoNome, curriculoCodigo, measureNodes]
@@ -375,6 +375,23 @@ export function CurriculumGraph({
     return locked;
   }, [disciplinas, completedDisciplinaIds, selectionSet]);
 
+  // Available disciplines: not locked, not completed, not cursando
+  const availableCodes = useMemo(() => {
+    if (!completedDisciplinaIds) {
+      return new Set<string>();
+    }
+    const available = new Set<string>();
+    for (const d of visibleDisciplinas) {
+      const isCompleted = completedDisciplinaIds.has(d.disciplinaId);
+      const isCursando = cursandoDisciplinaIds?.has(d.disciplinaId);
+      const isLocked = lockedCodes.has(d.codigo);
+      if (!isCompleted && !isCursando && !isLocked) {
+        available.add(d.codigo);
+      }
+    }
+    return available;
+  }, [visibleDisciplinas, completedDisciplinaIds, cursandoDisciplinaIds, lockedCodes]);
+
   // Progress stats
   const progressStats = useMemo(() => {
     if (!completedDisciplinaIds) {
@@ -404,6 +421,9 @@ export function CurriculumGraph({
       totalHoras,
     };
   }, [visibleDisciplinas, completedDisciplinaIds]);
+
+  // Status colors visible in normal view + progress export mode
+  const showStatus = exportMode === null || exportMode === "progress";
 
   const hasOptativas = disciplinas.some(d => d.natureza !== "OBRIGATORIA");
 
@@ -494,15 +514,22 @@ export function CurriculumGraph({
                 <Button variant="outline" size="sm" disabled={isExporting} className="gap-2">
                   <Download className="w-4 h-4" />
                   {isExporting ? "Exportando..." : "Exportar Imagem"}
+                  {!showOptativas && !isExporting && (
+                    <span className="text-[10px] text-muted-foreground">(sem optativas)</span>
+                  )}
                   <ChevronDown className="w-3 h-3" />
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={() => void handleExportImage(false)}>
+                <DropdownMenuItem onClick={() => void handleExportImage("progress")}>
                   <CheckCircle2 className="w-3.5 h-3.5 mr-2 text-green-600" />
                   Com meu progresso
                 </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => void handleExportImage(true)}>
+                <DropdownMenuItem onClick={() => void handleExportImage("available")}>
+                  <Sparkles className="w-3.5 h-3.5 mr-2 text-blue-500" />
+                  Próximas disponíveis
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => void handleExportImage("blank")}>
                   <BookOpen className="w-3.5 h-3.5 mr-2 text-muted-foreground" />
                   Grade limpa
                 </DropdownMenuItem>
@@ -512,12 +539,15 @@ export function CurriculumGraph({
             <Button
               variant="outline"
               size="sm"
-              onClick={() => void handleExportImage(false)}
+              onClick={() => void handleExportImage("blank")}
               disabled={isExporting}
               className="gap-2"
             >
               <Download className="w-4 h-4" />
               {isExporting ? "Exportando..." : "Exportar Imagem"}
+              {!showOptativas && !isExporting && (
+                <span className="text-[10px] text-muted-foreground">(sem optativas)</span>
+              )}
             </Button>
           )}
           {isLoggedIn && onSelectionModeChange && (
@@ -629,48 +659,93 @@ export function CurriculumGraph({
         {isExporting && <div className="absolute inset-0 z-50 cursor-wait" />}
         <div
           ref={containerRef}
-          className={`relative flex gap-8 min-w-max p-3 ${isExporting ? "pt-12" : ""}`}
+          className={`relative flex gap-8 min-w-max p-3 ${exportMode === "progress" && progressStats ? "pt-16" : isExporting ? "pt-12" : ""}`}
           onClick={handleContainerClick}
         >
-          {/* Export-only header: course name + legend (visible only during capture) */}
+          {/* Export-only header: course name + stats + legend (visible only during capture) */}
           {isExporting && (
-            <div className="absolute top-0 left-0 right-0 z-[2] flex items-center justify-between gap-4 px-3 pt-2 pb-3 min-w-max">
-              <div>
-                <h2 className="text-sm font-semibold text-[#0e3a6c] dark:text-[#C8E6FA]">
-                  {cursoNome}
-                </h2>
-                <p className="text-[10px] text-muted-foreground">Currículo: {curriculoCodigo}</p>
+            <div className="absolute top-0 left-0 right-0 z-[2] px-3 pt-2 pb-3 min-w-max">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h2 className="text-sm font-semibold text-[#0e3a6c] dark:text-[#C8E6FA]">
+                    {cursoNome}
+                  </h2>
+                  <p className="text-[10px] text-muted-foreground">Currículo: {curriculoCodigo}</p>
+                </div>
+                <div className="flex items-center gap-3 text-[10px] flex-wrap">
+                  {/* Natureza legend — always shown */}
+                  <span className="flex items-center gap-1">
+                    <span className="w-0.5 h-2.5 rounded-full bg-blue-400 dark:bg-blue-500" />
+                    Obrigatória
+                  </span>
+                  {showOptativas && (
+                    <>
+                      <span className="flex items-center gap-1">
+                        <span className="w-0.5 h-2.5 rounded-full bg-amber-400 dark:bg-amber-500" />
+                        Optativa
+                      </span>
+                      <span className="flex items-center gap-1">
+                        <span className="w-0.5 h-2.5 rounded-full bg-teal-400 dark:bg-teal-500" />
+                        Complementar
+                      </span>
+                    </>
+                  )}
+                  {/* Status legend — progress mode */}
+                  {exportMode === "progress" && (
+                    <>
+                      <span className="flex items-center gap-1">
+                        <span className="w-0.5 h-2.5 rounded-full bg-green-500 dark:bg-green-400" />
+                        Concluída
+                      </span>
+                      <span className="flex items-center gap-1">
+                        <span className="w-0.5 h-2.5 rounded-full bg-purple-500 dark:bg-purple-400" />
+                        Cursando
+                      </span>
+                    </>
+                  )}
+                  {/* Available legend — available mode */}
+                  {exportMode === "available" && (
+                    <>
+                      <span className="flex items-center gap-1 font-medium text-emerald-600 dark:text-emerald-400">
+                        ● Disponível
+                      </span>
+                      <span className="flex items-center gap-1 text-muted-foreground">
+                        ○ Indisponível
+                      </span>
+                    </>
+                  )}
+                </div>
               </div>
-              <div className="flex items-center gap-3 text-[10px] flex-wrap">
-                <span className="flex items-center gap-1">
-                  <span className="w-0.5 h-2.5 rounded-full bg-blue-400 dark:bg-blue-500" />
-                  Obrigatória
-                </span>
-                {showOptativas && (
-                  <>
-                    <span className="flex items-center gap-1">
-                      <span className="w-0.5 h-2.5 rounded-full bg-amber-400 dark:bg-amber-500" />
-                      Optativa
+              {/* Progress stats bar — only in progress mode */}
+              {exportMode === "progress" && progressStats && (
+                <div className="mt-1.5 flex items-center gap-3 text-[10px]">
+                  <span className="font-medium text-[#0e3a6c] dark:text-[#C8E6FA]">
+                    {progressStats.completedObrigatorias}/{progressStats.obrigatorias} obrigatórias
+                    ({progressStats.percentObrigatorias}%)
+                  </span>
+                  <span className="text-muted-foreground">
+                    {progressStats.totalHorasCompleted}h / {progressStats.totalHoras}h
+                  </span>
+                  {progressStats.totalCompleted > progressStats.completedObrigatorias && (
+                    <span className="text-muted-foreground">
+                      +{progressStats.totalCompleted - progressStats.completedObrigatorias}{" "}
+                      optativa(s)
                     </span>
-                    <span className="flex items-center gap-1">
-                      <span className="w-0.5 h-2.5 rounded-full bg-teal-400 dark:bg-teal-500" />
-                      Complementar
-                    </span>
-                  </>
-                )}
-                {isLoggedIn && !isBlankExport && (
-                  <>
-                    <span className="flex items-center gap-1">
-                      <span className="w-0.5 h-2.5 rounded-full bg-green-500 dark:bg-green-400" />
-                      Concluída
-                    </span>
-                    <span className="flex items-center gap-1">
-                      <span className="w-0.5 h-2.5 rounded-full bg-purple-500 dark:bg-purple-400" />
-                      Cursando
-                    </span>
-                  </>
-                )}
-              </div>
+                  )}
+                  <div className="flex-1 h-1.5 rounded-full bg-slate-200 dark:bg-slate-700 max-w-[200px]">
+                    <div
+                      className="h-full rounded-full bg-green-500 dark:bg-green-400"
+                      style={{ width: `${progressStats.percentObrigatorias}%` }}
+                    />
+                  </div>
+                </div>
+              )}
+              {/* Available count — only in available mode */}
+              {exportMode === "available" && (
+                <p className="mt-1 text-[10px] text-muted-foreground">
+                  {availableCodes.size} disciplina(s) disponível(is) para matrícula
+                </p>
+              )}
             </div>
           )}
 
@@ -695,20 +770,24 @@ export function CurriculumGraph({
                   ref={el => setNodeRef(disc.codigo, el)}
                   discipline={disc}
                   isHighlighted={
-                    !isExporting &&
-                    activeHighlightedCodes !== null &&
-                    activeHighlightedCodes.has(disc.codigo)
+                    exportMode === "available"
+                      ? availableCodes.has(disc.codigo)
+                      : !isExporting &&
+                        activeHighlightedCodes !== null &&
+                        activeHighlightedCodes.has(disc.codigo)
                   }
                   isFaded={
-                    !isExporting &&
-                    activeHighlightedCodes !== null &&
-                    !activeHighlightedCodes.has(disc.codigo)
+                    exportMode === "available"
+                      ? !availableCodes.has(disc.codigo)
+                      : !isExporting &&
+                        activeHighlightedCodes !== null &&
+                        !activeHighlightedCodes.has(disc.codigo)
                   }
                   isClicked={!isExporting && clickedCode === disc.codigo}
                   isHovered={!isExporting && canHover && hoveredCode === disc.codigo}
-                  isCompleted={!isBlankExport && !!completedDisciplinaIds?.has(disc.disciplinaId)}
-                  isCursando={!isBlankExport && !!cursandoDisciplinaIds?.has(disc.disciplinaId)}
-                  isLocked={!isBlankExport && lockedCodes.has(disc.codigo)}
+                  isCompleted={showStatus && !!completedDisciplinaIds?.has(disc.disciplinaId)}
+                  isCursando={showStatus && !!cursandoDisciplinaIds?.has(disc.disciplinaId)}
+                  isLocked={showStatus && lockedCodes.has(disc.codigo)}
                   selectionMode={!isExporting && selectionMode}
                   isSelected={!isExporting && selectionSet.has(disc.disciplinaId)}
                   onClick={e => handleNodeClick(disc, e)}

--- a/src/components/pages/grades-curriculares/curriculum-graph.tsx
+++ b/src/components/pages/grades-curriculares/curriculum-graph.tsx
@@ -558,7 +558,7 @@ export function CurriculumGraph({
               <span className="w-0.5 h-3 rounded-full bg-blue-400 dark:bg-blue-500" />
               Obrigatória
             </span>
-            {hasOptativas && (
+            {showOptativas && (
               <>
                 <span className="flex items-center gap-1.5">
                   <span className="w-0.5 h-3 rounded-full bg-amber-400 dark:bg-amber-500" />

--- a/src/components/pages/grades-curriculares/curriculum-graph.tsx
+++ b/src/components/pages/grades-curriculares/curriculum-graph.tsx
@@ -26,7 +26,11 @@ import {
   BookOpen,
   ChevronDown,
   CircleDot,
+  Download,
 } from "lucide-react";
+import { exportGradeAsImage } from "@/lib/client/grades-curriculares/export";
+import { trackEvent } from "@/analytics/posthog-client";
+import { toast } from "sonner";
 
 function computeHighlightChain(
   code: string,
@@ -115,7 +119,11 @@ export function CurriculumGraph({
   // Selection set for bulk mode (keyed on disciplinaId)
   const [selectionSet, setSelectionSet] = useState<Set<string>>(new Set());
 
+  const [isExporting, setIsExporting] = useState(false);
+  const [isBlankExport, setIsBlankExport] = useState(false);
+
   const containerRef = useRef<HTMLDivElement>(null);
+  const scrollWrapperRef = useRef<HTMLDivElement>(null);
   const nodeRefsMap = useRef<Map<string, HTMLButtonElement>>(new Map());
 
   // Detect hover-capable devices (desktop) vs touch-only (mobile)
@@ -215,6 +223,52 @@ export function CurriculumGraph({
       nodeRefsMap.current.delete(code);
     }
   }, []);
+
+  const handleExportImage = useCallback(
+    async (blank: boolean) => {
+      if (!containerRef.current || !scrollWrapperRef.current) {
+        toast.error("Erro ao exportar a grade curricular");
+        return;
+      }
+
+      trackEvent("grade_curricular_export_image_click");
+      setIsExporting(true);
+      if (blank) {
+        setIsBlankExport(true);
+      }
+
+      const wrapper = scrollWrapperRef.current;
+      const originalMaxHeight = wrapper.style.maxHeight;
+      const originalOverflow = wrapper.style.overflow;
+
+      try {
+        // Expand the scroll container so the full grade is visible for capture
+        wrapper.style.maxHeight = "none";
+        wrapper.style.overflow = "visible";
+
+        // Double-rAF: first frame applies styles, second guarantees layout reflow
+        await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+        measureNodes();
+        // Wait for React to re-render with the updated node measurements
+        await new Promise(resolve => requestAnimationFrame(resolve));
+
+        await exportGradeAsImage({
+          graphElement: containerRef.current,
+          cursoNome,
+          curriculoCodigo,
+        });
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : "Erro ao exportar a grade curricular");
+      } finally {
+        wrapper.style.maxHeight = originalMaxHeight;
+        wrapper.style.overflow = originalOverflow;
+        setIsBlankExport(false);
+        measureNodes();
+        setIsExporting(false);
+      }
+    },
+    [cursoNome, curriculoCodigo, measureNodes]
+  );
 
   const handleNodeClick = useCallback(
     (disc: GradeDisciplinaNode, e: React.MouseEvent) => {
@@ -434,6 +488,38 @@ export function CurriculumGraph({
           <p className="text-sm text-muted-foreground">Currículo: {curriculoCodigo}</p>
         </div>
         <div className="flex items-center gap-6 flex-wrap">
+          {isLoggedIn && (completedDisciplinaIds?.size || cursandoDisciplinaIds?.size) ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" size="sm" disabled={isExporting} className="gap-2">
+                  <Download className="w-4 h-4" />
+                  {isExporting ? "Exportando..." : "Exportar Imagem"}
+                  <ChevronDown className="w-3 h-3" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={() => void handleExportImage(false)}>
+                  <CheckCircle2 className="w-3.5 h-3.5 mr-2 text-green-600" />
+                  Com meu progresso
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => void handleExportImage(true)}>
+                  <BookOpen className="w-3.5 h-3.5 mr-2 text-muted-foreground" />
+                  Grade limpa
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => void handleExportImage(false)}
+              disabled={isExporting}
+              className="gap-2"
+            >
+              <Download className="w-4 h-4" />
+              {isExporting ? "Exportando..." : "Exportar Imagem"}
+            </Button>
+          )}
           {isLoggedIn && onSelectionModeChange && (
             <Button
               variant={selectionMode ? "default" : "outline"}
@@ -535,22 +621,66 @@ export function CurriculumGraph({
 
       {/* Graph container — fixed height, scrollable both axes */}
       <div
-        className="overflow-auto rounded-lg border border-slate-200 dark:border-white/10"
+        ref={scrollWrapperRef}
+        className="relative overflow-auto rounded-lg border border-slate-200 dark:border-white/10"
         style={{ maxHeight: "70vh" }}
         onScroll={measureNodes}
       >
+        {isExporting && <div className="absolute inset-0 z-50 cursor-wait" />}
         <div
           ref={containerRef}
-          className="relative flex gap-8 min-w-max p-3"
+          className={`relative flex gap-8 min-w-max p-3 ${isExporting ? "pt-12" : ""}`}
           onClick={handleContainerClick}
         >
+          {/* Export-only header: course name + legend (visible only during capture) */}
+          {isExporting && (
+            <div className="absolute top-0 left-0 right-0 z-[2] flex items-center justify-between gap-4 px-3 pt-2 pb-3 min-w-max">
+              <div>
+                <h2 className="text-sm font-semibold text-[#0e3a6c] dark:text-[#C8E6FA]">
+                  {cursoNome}
+                </h2>
+                <p className="text-[10px] text-muted-foreground">Currículo: {curriculoCodigo}</p>
+              </div>
+              <div className="flex items-center gap-3 text-[10px] flex-wrap">
+                <span className="flex items-center gap-1">
+                  <span className="w-0.5 h-2.5 rounded-full bg-blue-400 dark:bg-blue-500" />
+                  Obrigatória
+                </span>
+                {showOptativas && (
+                  <>
+                    <span className="flex items-center gap-1">
+                      <span className="w-0.5 h-2.5 rounded-full bg-amber-400 dark:bg-amber-500" />
+                      Optativa
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <span className="w-0.5 h-2.5 rounded-full bg-teal-400 dark:bg-teal-500" />
+                      Complementar
+                    </span>
+                  </>
+                )}
+                {isLoggedIn && !isBlankExport && (
+                  <>
+                    <span className="flex items-center gap-1">
+                      <span className="w-0.5 h-2.5 rounded-full bg-green-500 dark:bg-green-400" />
+                      Concluída
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <span className="w-0.5 h-2.5 rounded-full bg-purple-500 dark:bg-purple-400" />
+                      Cursando
+                    </span>
+                  </>
+                )}
+              </div>
+            </div>
+          )}
+
           {/* SVG edge overlay */}
           <GraphEdges
             disciplines={visibleDisciplinas}
             nodeRefs={nodeRects}
             containerRect={containerRect}
-            highlightedCodes={activeHighlightedCodes}
-            hoveredCode={hoveredCode}
+            highlightedCodes={isExporting ? null : activeHighlightedCodes}
+            hoveredCode={isExporting ? null : hoveredCode}
           />
 
           {/* Period columns */}
@@ -565,18 +695,22 @@ export function CurriculumGraph({
                   ref={el => setNodeRef(disc.codigo, el)}
                   discipline={disc}
                   isHighlighted={
-                    activeHighlightedCodes !== null && activeHighlightedCodes.has(disc.codigo)
+                    !isExporting &&
+                    activeHighlightedCodes !== null &&
+                    activeHighlightedCodes.has(disc.codigo)
                   }
                   isFaded={
-                    activeHighlightedCodes !== null && !activeHighlightedCodes.has(disc.codigo)
+                    !isExporting &&
+                    activeHighlightedCodes !== null &&
+                    !activeHighlightedCodes.has(disc.codigo)
                   }
-                  isClicked={clickedCode === disc.codigo}
-                  isHovered={canHover && hoveredCode === disc.codigo}
-                  isCompleted={!!completedDisciplinaIds?.has(disc.disciplinaId)}
-                  isCursando={!!cursandoDisciplinaIds?.has(disc.disciplinaId)}
-                  isLocked={lockedCodes.has(disc.codigo)}
-                  selectionMode={selectionMode}
-                  isSelected={selectionSet.has(disc.disciplinaId)}
+                  isClicked={!isExporting && clickedCode === disc.codigo}
+                  isHovered={!isExporting && canHover && hoveredCode === disc.codigo}
+                  isCompleted={!isBlankExport && !!completedDisciplinaIds?.has(disc.disciplinaId)}
+                  isCursando={!isBlankExport && !!cursandoDisciplinaIds?.has(disc.disciplinaId)}
+                  isLocked={!isBlankExport && lockedCodes.has(disc.codigo)}
+                  selectionMode={!isExporting && selectionMode}
+                  isSelected={!isExporting && selectionSet.has(disc.disciplinaId)}
                   onClick={e => handleNodeClick(disc, e)}
                   onMouseEnter={() => {
                     if (canHover) {

--- a/src/lib/client/grades-curriculares/export.ts
+++ b/src/lib/client/grades-curriculares/export.ts
@@ -1,0 +1,52 @@
+import { toBlob } from "html-to-image";
+
+type ExportGradeOptions = {
+  /** The inner graph container element to capture */
+  graphElement: HTMLElement;
+  /** Course name for the filename */
+  cursoNome: string;
+  /** Curriculum code for the filename */
+  curriculoCodigo: string;
+};
+
+/**
+ * Exports the curriculum grade visualization as a PNG image.
+ * Expects the scroll container to already be expanded by the caller
+ * (so the full grade is visible for capture).
+ */
+export async function exportGradeAsImage({
+  graphElement,
+  cursoNome,
+  curriculoCodigo,
+}: ExportGradeOptions): Promise<void> {
+  const pixelRatio = Math.min(window.devicePixelRatio || 1, 2);
+
+  const blob = await toBlob(graphElement, {
+    pixelRatio,
+    backgroundColor: getComputedStyle(graphElement).backgroundColor || "#ffffff",
+  });
+
+  if (!blob) {
+    throw new Error("Falha ao gerar a imagem da grade curricular");
+  }
+
+  const sanitizedName = cursoNome
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `grade-${sanitizedName}-${curriculoCodigo}.png`;
+  link.style.display = "none";
+  document.body.appendChild(link);
+  link.click();
+
+  setTimeout(() => {
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }, 200);
+}


### PR DESCRIPTION
## 📝 Descrição

  Esse PR adiciona o botão de exportar a grade curricular como imagem PNG que foi pedido na issue #169 .

  Basicamente o usuário agora consegue baixar a grade como imagem — se ele tiver progresso salvo, aparece um
  dropdown com 2 opções:
  - **Com meu progresso** — exporta com as cores de concluída/cursando + uma barrinha de progresso no topo da
  imagem (tipo X/Y obrigatórias, horas, etc)
  - **Grade limpa** — exporta sem status nenhum, só as cores de natureza (obrigatória, optativa, complementar)

  Se o usuário não tiver logado ou não tiver progresso, aparece só o botão direto que exporta a grade limpa.

  Implementei esses modos por agora mas to aberto a sugestões do que mais poderia ter, se alguém ideia de
  outros modos de exportação ou informações pode mandar ou discutir aqui não sei
  
  ## 🔗 Issue Relacionada

  Closes #169

  ## 🧪 Testes

  - [x] Testes unitários passam
  - [ ] Testes de integração passam
  - [x] Testes manuais concluídos
  - [ ] Testes E2E passam

  ## 📸 Screenshots (se aplicável)

### Na hora de exportar com TODAS as disciplinas a imagem fica gigantesca, 
<img width="290" height="527" alt="image" src="https://github.com/user-attachments/assets/519e664d-7914-417e-b643-0a7ed5fb7ed1" />

### Exportada sem optativas
<img width="1486" height="990" alt="image" src="https://github.com/user-attachments/assets/07659451-64a1-4cc1-93a3-f03a29c43b67" />


  ## 📋 Checklist

  - [x] Código segue as diretrizes de estilo do projeto
  - [x] Revisão própria concluída
  - [x] Código está devidamente comentado
  - [x] Nenhum console.log deixado no código
  - [x] Todos os testes passam localmente
  - [x] Build passa sem erros

  ## 🚀 Notas de Deploy

  Nenhuma — só adiciona a dependência `html-to-image` que já está no package-lock.

  ## 📚 Contexto Adicional

  - O evento de analytics `grade_curricular_export_image_click` é disparado em qualquer modo de export.
  - Ao **marcar/desmarcar** "Mostrar optativas", os itens da legenda **(Optativa, Complementar, Concluída, Cursando, Trancada)** **aparecem/somem**, mudando o tamanho da legenda e empurrando os elementos pra baixo ou pra cima. Quando deslogado o shift é imperceptível porque a legenda só tem **Obrigatória/Optativa/Complementar** (menos itens). Se incomodar da pra mudar movendo toda a legenda + botões pra baixo do título do curso em uma linha própria separada...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Grades Curriculares: Export the curricular grid as a PNG image with two views — "Com meu progresso" (shows progress, stats and export progress indicator) and "Grade limpa" (clean grid).
  * Search: Recent search history stored locally, keeping up to 8 previous searches for quick access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->