### PR TITLE
test: add server-side and onboarding test coverage (129 tests)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Tests**: Server-side auth service tests — authenticate, register, verify-email, reset-password, forgot-password, resend-verification, and middleware (66 new tests)
+- **Tests**: Admin mutation tests — merge-facade-user service (12 tests), user deletion route, role update route, entity member add/update/delete routes (33 tests)
 - **Grades Curriculares**: Botão para exportar grade curricular como imagem PNG — "Com meu progresso" (barra de progresso e stats) e "Grade limpa" (#169)
 - **UI**: DatePicker component with Calendar popover, pt-BR locale, and date range constraints
 - **Search**: Global search command palette (Ctrl+K) with unified search across pages, guides, entities, jobs, disciplines, courses, and user profiles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Tests**: Server-side auth service tests — authenticate, register, verify-email, reset-password, forgot-password, resend-verification, and middleware (66 new tests)
 - **Tests**: Admin mutation tests — merge-facade-user service (12 tests), user deletion route, role update route, entity member add/update/delete routes (33 tests)
+- **Tests**: Onboarding state machine integration tests — step ordering, conditional visibility, PAAS availability, semester-based logic, completion/skip mutations (18 tests)
 - **Grades Curriculares**: Botão para exportar grade curricular como imagem PNG — "Com meu progresso" (barra de progresso e stats) e "Grade limpa" (#169)
 - **UI**: DatePicker component with Calendar popover, pt-BR locale, and date range constraints
 - **Search**: Global search command palette (Ctrl+K) with unified search across pages, guides, entities, jobs, disciplines, courses, and user profiles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Tests**: Server-side auth service tests — authenticate, register, verify-email, reset-password, forgot-password, resend-verification, and middleware (66 new tests)
 - **Grades Curriculares**: Botão para exportar grade curricular como imagem PNG — "Com meu progresso" (barra de progresso e stats) e "Grade limpa" (#169)
 - **UI**: DatePicker component with Calendar popover, pt-BR locale, and date range constraints
 - **Search**: Global search command palette (Ctrl+K) with unified search across pages, guides, entities, jobs, disciplines, courses, and user profiles

--- a/src/app/api/entidades/[id]/membros/[membroId]/__tests__/manage-member.test.ts
+++ b/src/app/api/entidades/[id]/membros/[membroId]/__tests__/manage-member.test.ts
@@ -1,0 +1,260 @@
+/**
+ * @jest-environment node
+ */
+import type { UsuarioWithRelations } from "@/lib/server/db/interfaces/types";
+
+const mockVerifyToken = jest.fn();
+const mockUserFindById = jest.fn();
+const mockEntidadeFindById = jest.fn();
+const mockFindByEntidadeAndMembro = jest.fn();
+const mockCargoExistsInEntidade = jest.fn();
+const mockMembroUpdate = jest.fn();
+const mockMembroDelete = jest.fn();
+
+jest.mock("@/lib/server/services/jwt/jwt", () => ({
+  verifyToken: (...args: unknown[]) => mockVerifyToken(...args),
+}));
+
+jest.mock("@/lib/server/container", () => ({
+  getContainer: () => ({
+    usuariosRepository: { findById: mockUserFindById },
+    entidadesRepository: { findById: mockEntidadeFindById },
+    membrosRepository: {
+      findByEntidadeAndMembro: mockFindByEntidadeAndMembro,
+      cargoExistsInEntidade: mockCargoExistsInEntidade,
+      update: mockMembroUpdate,
+      delete: mockMembroDelete,
+    },
+  }),
+}));
+
+import { PUT, DELETE } from "../route";
+
+function makeUsuario(overrides: Partial<UsuarioWithRelations> = {}): UsuarioWithRelations {
+  return {
+    id: "caller-1",
+    nome: "Caller",
+    papelPlataforma: "MASTER_ADMIN",
+    eFacade: false,
+    centro: { id: "c1", nome: "CI", sigla: "CI", descricao: null, campusId: "campus-1" },
+    curso: { id: "k1", nome: "CC", centroId: "c1", criadoEm: new Date(), atualizadoEm: new Date() },
+    ...overrides,
+  } as unknown as UsuarioWithRelations;
+}
+
+function makeEntidade(membros: Array<{ usuario: { id: string }; papel: string }> = []) {
+  return { id: "ent-1", nome: "Test Entidade", slug: "test-entidade", membros };
+}
+
+function makeMembro() {
+  return {
+    id: "membro-1",
+    usuario: {
+      id: "member-user",
+      nome: "Member",
+      slug: "member",
+      urlFotoPerfil: null,
+      eFacade: false,
+      curso: { nome: "CC" },
+    },
+    papel: "MEMBRO",
+    cargo: null,
+    startedAt: new Date("2024-01-01"),
+    endedAt: null,
+  };
+}
+
+function makeContext(entidadeId: string, membroId: string) {
+  return { params: Promise.resolve({ id: entidadeId, membroId }) };
+}
+
+function makePutRequest(body: Record<string, unknown>): Request {
+  return new Request("http://localhost/api/entidades/ent-1/membros/membro-1", {
+    method: "PUT",
+    headers: {
+      Authorization: "Bearer valid-token",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeDeleteRequest(): Request {
+  return new Request("http://localhost/api/entidades/ent-1/membros/membro-1", {
+    method: "DELETE",
+    headers: { Authorization: "Bearer valid-token" },
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockVerifyToken.mockReturnValue({ sub: "caller-1" });
+  mockUserFindById.mockResolvedValue(makeUsuario());
+  mockEntidadeFindById.mockResolvedValue(makeEntidade());
+  mockFindByEntidadeAndMembro.mockResolvedValue(makeMembro());
+  mockCargoExistsInEntidade.mockResolvedValue(true);
+  mockMembroUpdate.mockResolvedValue(makeMembro());
+  mockMembroDelete.mockResolvedValue(undefined);
+});
+
+describe("PUT /api/entidades/[id]/membros/[membroId]", () => {
+  it("updates member role successfully", async () => {
+    const updatedMembro = { ...makeMembro(), papel: "ADMIN" };
+    mockMembroUpdate.mockResolvedValue(updatedMembro);
+
+    const response = await PUT(
+      makePutRequest({ papel: "ADMIN" }),
+      makeContext("ent-1", "membro-1")
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.papel).toBe("ADMIN");
+    expect(mockMembroUpdate).toHaveBeenCalledWith(
+      "membro-1",
+      expect.objectContaining({ papel: "ADMIN" })
+    );
+  });
+
+  it("allows entity ADMIN to update members", async () => {
+    const entityAdmin = makeUsuario({ id: "caller-1", papelPlataforma: "USER" });
+    mockUserFindById.mockResolvedValue(entityAdmin);
+    mockEntidadeFindById.mockResolvedValue(
+      makeEntidade([{ usuario: { id: "caller-1" }, papel: "ADMIN" }])
+    );
+
+    const response = await PUT(
+      makePutRequest({ papel: "ADMIN" }),
+      makeContext("ent-1", "membro-1")
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  it("returns 403 for non-admin users", async () => {
+    const regularUser = makeUsuario({ id: "caller-1", papelPlataforma: "USER" });
+    mockUserFindById.mockResolvedValue(regularUser);
+    mockEntidadeFindById.mockResolvedValue(
+      makeEntidade([{ usuario: { id: "caller-1" }, papel: "MEMBRO" }])
+    );
+
+    const response = await PUT(
+      makePutRequest({ papel: "ADMIN" }),
+      makeContext("ent-1", "membro-1")
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 404 when entidade not found", async () => {
+    mockEntidadeFindById.mockResolvedValue(null);
+
+    const response = await PUT(
+      makePutRequest({ papel: "ADMIN" }),
+      makeContext("ent-1", "membro-1")
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 404 when membership not found", async () => {
+    mockFindByEntidadeAndMembro.mockResolvedValue(null);
+
+    const response = await PUT(
+      makePutRequest({ papel: "ADMIN" }),
+      makeContext("ent-1", "nonexistent")
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 400 when cargo does not belong to entity", async () => {
+    mockCargoExistsInEntidade.mockResolvedValue(false);
+
+    const response = await PUT(
+      makePutRequest({ cargoId: "00000000-0000-0000-0000-000000000099" }),
+      makeContext("ent-1", "membro-1")
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("handles date updates", async () => {
+    const response = await PUT(
+      makePutRequest({
+        startedAt: "2023-06-01T00:00:00.000Z",
+        endedAt: "2024-01-01T00:00:00.000Z",
+      }),
+      makeContext("ent-1", "membro-1")
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockMembroUpdate).toHaveBeenCalledWith(
+      "membro-1",
+      expect.objectContaining({
+        startedAt: expect.any(Date),
+        endedAt: expect.any(Date),
+      })
+    );
+  });
+});
+
+describe("DELETE /api/entidades/[id]/membros/[membroId]", () => {
+  it("deletes membership successfully as platform admin", async () => {
+    const response = await DELETE(makeDeleteRequest(), makeContext("ent-1", "membro-1"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.message).toContain("deletada");
+    expect(mockMembroDelete).toHaveBeenCalledWith("membro-1");
+  });
+
+  it("deletes membership as entity admin", async () => {
+    const entityAdmin = makeUsuario({ id: "caller-1", papelPlataforma: "USER" });
+    mockUserFindById.mockResolvedValue(entityAdmin);
+    mockEntidadeFindById.mockResolvedValue(
+      makeEntidade([{ usuario: { id: "caller-1" }, papel: "ADMIN" }])
+    );
+
+    const response = await DELETE(makeDeleteRequest(), makeContext("ent-1", "membro-1"));
+
+    expect(response.status).toBe(200);
+  });
+
+  it("returns 403 for non-admin users", async () => {
+    const regularUser = makeUsuario({ id: "caller-1", papelPlataforma: "USER" });
+    mockUserFindById.mockResolvedValue(regularUser);
+    mockEntidadeFindById.mockResolvedValue(makeEntidade());
+
+    const response = await DELETE(makeDeleteRequest(), makeContext("ent-1", "membro-1"));
+
+    expect(response.status).toBe(403);
+    expect(mockMembroDelete).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when entidade not found", async () => {
+    mockEntidadeFindById.mockResolvedValue(null);
+
+    const response = await DELETE(makeDeleteRequest(), makeContext("ent-1", "membro-1"));
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 404 when membership not found", async () => {
+    mockFindByEntidadeAndMembro.mockResolvedValue(null);
+
+    const response = await DELETE(makeDeleteRequest(), makeContext("ent-1", "nonexistent"));
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const request = new Request("http://localhost/api/entidades/ent-1/membros/membro-1", {
+      method: "DELETE",
+    });
+
+    const response = await DELETE(request, makeContext("ent-1", "membro-1"));
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/src/app/api/entidades/[id]/membros/__tests__/add-member.test.ts
+++ b/src/app/api/entidades/[id]/membros/__tests__/add-member.test.ts
@@ -1,0 +1,201 @@
+/**
+ * @jest-environment node
+ */
+import type { UsuarioWithRelations } from "@/lib/server/db/interfaces/types";
+
+const mockVerifyToken = jest.fn();
+const mockUserFindById = jest.fn();
+const mockEntidadeFindById = jest.fn();
+const mockUsuarioExists = jest.fn();
+const mockFindActiveByUsuarioAndEntidade = jest.fn();
+const mockCargoExistsInEntidade = jest.fn();
+const mockMembroCreate = jest.fn();
+
+jest.mock("@/lib/server/services/jwt/jwt", () => ({
+  verifyToken: (...args: unknown[]) => mockVerifyToken(...args),
+}));
+
+jest.mock("@/lib/server/container", () => ({
+  getContainer: () => ({
+    usuariosRepository: { findById: mockUserFindById },
+    entidadesRepository: { findById: mockEntidadeFindById },
+    membrosRepository: {
+      usuarioExists: mockUsuarioExists,
+      findActiveByUsuarioAndEntidade: mockFindActiveByUsuarioAndEntidade,
+      cargoExistsInEntidade: mockCargoExistsInEntidade,
+      create: mockMembroCreate,
+    },
+  }),
+}));
+
+import { POST } from "../route";
+
+function makeUsuario(overrides: Partial<UsuarioWithRelations> = {}): UsuarioWithRelations {
+  return {
+    id: "caller-1",
+    nome: "Caller",
+    email: "caller@academico.ufpb.br",
+    papelPlataforma: "MASTER_ADMIN",
+    eFacade: false,
+    centro: { id: "c1", nome: "CI", sigla: "CI", descricao: null, campusId: "campus-1" },
+    curso: { id: "k1", nome: "CC", centroId: "c1", criadoEm: new Date(), atualizadoEm: new Date() },
+    ...overrides,
+  } as unknown as UsuarioWithRelations;
+}
+
+function makeEntidade(membros: Array<{ usuario: { id: string }; papel: string }> = []) {
+  return {
+    id: "ent-1",
+    nome: "Test Entidade",
+    slug: "test-entidade",
+    membros,
+  };
+}
+
+function makeCreatedMembro() {
+  return {
+    id: "new-membro-1",
+    usuario: {
+      id: "new-user-1",
+      nome: "New Member",
+      slug: "new-member",
+      urlFotoPerfil: null,
+      eFacade: false,
+      curso: { nome: "CC" },
+    },
+    papel: "MEMBRO",
+    cargo: null,
+    startedAt: new Date("2024-01-01"),
+    endedAt: null,
+  };
+}
+
+function makeRequest(body: Record<string, unknown>): Request {
+  return new Request("http://localhost/api/entidades/ent-1/membros", {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer valid-token",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeContext(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+const validBody = {
+  usuarioId: "00000000-0000-0000-0000-000000000001",
+  papel: "MEMBRO" as const,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockVerifyToken.mockReturnValue({ sub: "caller-1" });
+  mockUserFindById.mockResolvedValue(makeUsuario());
+  mockEntidadeFindById.mockResolvedValue(makeEntidade());
+  mockUsuarioExists.mockResolvedValue(true);
+  mockFindActiveByUsuarioAndEntidade.mockResolvedValue(null);
+  mockCargoExistsInEntidade.mockResolvedValue(true);
+  mockMembroCreate.mockResolvedValue(makeCreatedMembro());
+});
+
+describe("POST /api/entidades/[id]/membros", () => {
+  it("adds member successfully as MASTER_ADMIN", async () => {
+    const response = await POST(makeRequest(validBody), makeContext("ent-1"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.id).toBe("new-membro-1");
+    expect(body.papel).toBe("MEMBRO");
+    expect(mockMembroCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        usuarioId: validBody.usuarioId,
+        entidadeId: "ent-1",
+        papel: "MEMBRO",
+      })
+    );
+  });
+
+  it("adds member as entity ADMIN (not platform admin)", async () => {
+    const entityAdmin = makeUsuario({ id: "caller-1", papelPlataforma: "USER" });
+    mockUserFindById.mockResolvedValue(entityAdmin);
+    mockEntidadeFindById.mockResolvedValue(
+      makeEntidade([{ usuario: { id: "caller-1" }, papel: "ADMIN" }])
+    );
+
+    const response = await POST(makeRequest(validBody), makeContext("ent-1"));
+
+    expect(response.status).toBe(200);
+  });
+
+  it("returns 403 when user is neither platform admin nor entity admin", async () => {
+    const regularUser = makeUsuario({ id: "caller-1", papelPlataforma: "USER" });
+    mockUserFindById.mockResolvedValue(regularUser);
+    mockEntidadeFindById.mockResolvedValue(
+      makeEntidade([{ usuario: { id: "caller-1" }, papel: "MEMBRO" }])
+    );
+
+    const response = await POST(makeRequest(validBody), makeContext("ent-1"));
+
+    expect(response.status).toBe(403);
+    expect(mockMembroCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when entidade does not exist", async () => {
+    mockEntidadeFindById.mockResolvedValue(null);
+
+    const response = await POST(makeRequest(validBody), makeContext("nonexistent"));
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 404 when target user does not exist", async () => {
+    mockUsuarioExists.mockResolvedValue(false);
+
+    const response = await POST(makeRequest(validBody), makeContext("ent-1"));
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 409 when user is already an active member", async () => {
+    mockFindActiveByUsuarioAndEntidade.mockResolvedValue({ id: "existing-membro" });
+
+    const response = await POST(makeRequest(validBody), makeContext("ent-1"));
+
+    expect(response.status).toBe(409);
+  });
+
+  it("returns 400 when cargo does not belong to entity", async () => {
+    mockCargoExistsInEntidade.mockResolvedValue(false);
+
+    const response = await POST(
+      makeRequest({ ...validBody, cargoId: "00000000-0000-0000-0000-000000000099" }),
+      makeContext("ent-1")
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 on invalid input (missing papel)", async () => {
+    const response = await POST(
+      makeRequest({ usuarioId: "00000000-0000-0000-0000-000000000001" }),
+      makeContext("ent-1")
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const request = new Request("http://localhost/api/entidades/ent-1/membros", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(validBody),
+    });
+
+    const response = await POST(request, makeContext("ent-1"));
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/src/app/api/usuarios/[id]/__tests__/delete-user.test.ts
+++ b/src/app/api/usuarios/[id]/__tests__/delete-user.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @jest-environment node
+ */
+import type { UsuarioWithRelations } from "@/lib/server/db/interfaces/types";
+
+const mockFindById = jest.fn();
+const mockDelete = jest.fn();
+const mockVerifyToken = jest.fn();
+
+jest.mock("@/lib/server/services/jwt/jwt", () => ({
+  verifyToken: (...args: unknown[]) => mockVerifyToken(...args),
+}));
+
+jest.mock("@/lib/server/container", () => ({
+  getContainer: () => ({
+    usuariosRepository: {
+      findById: mockFindById,
+      delete: mockDelete,
+    },
+  }),
+}));
+
+// Import after mocks
+import { DELETE } from "../route";
+
+function makeUsuario(overrides: Partial<UsuarioWithRelations> = {}): UsuarioWithRelations {
+  return {
+    id: "user-1",
+    nome: "Test User",
+    email: "test@academico.ufpb.br",
+    papelPlataforma: "MASTER_ADMIN",
+    eFacade: false,
+    centro: { id: "c1", nome: "CI", sigla: "CI", descricao: null, campusId: "campus-1" },
+    curso: { id: "k1", nome: "CC", centroId: "c1", criadoEm: new Date(), atualizadoEm: new Date() },
+    ...overrides,
+  } as unknown as UsuarioWithRelations;
+}
+
+function makeRequest(): Request {
+  return new Request("http://localhost/api/usuarios/target-user", {
+    method: "DELETE",
+    headers: { Authorization: "Bearer valid-token" },
+  });
+}
+
+function makeContext(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockVerifyToken.mockReturnValue({ sub: "admin-1" });
+  mockDelete.mockResolvedValue(undefined);
+});
+
+describe("DELETE /api/usuarios/[id]", () => {
+  it("deletes user successfully as admin", async () => {
+    const admin = makeUsuario({ id: "admin-1", papelPlataforma: "MASTER_ADMIN" });
+    const target = makeUsuario({ id: "target-user" });
+
+    mockFindById.mockImplementation((id: string) => {
+      if (id === "admin-1") return Promise.resolve(admin);
+      if (id === "target-user") return Promise.resolve(target);
+      return Promise.resolve(null);
+    });
+
+    const response = await DELETE(makeRequest(), makeContext("target-user"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.message).toContain("deletado");
+    expect(mockDelete).toHaveBeenCalledWith("target-user");
+  });
+
+  it("prevents self-deletion", async () => {
+    const admin = makeUsuario({ id: "admin-1", papelPlataforma: "MASTER_ADMIN" });
+    mockFindById.mockResolvedValue(admin);
+
+    const response = await DELETE(makeRequest(), makeContext("admin-1"));
+
+    expect(response.status).toBe(400);
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when target user does not exist", async () => {
+    const admin = makeUsuario({ id: "admin-1", papelPlataforma: "MASTER_ADMIN" });
+    mockFindById.mockImplementation((id: string) => {
+      if (id === "admin-1") return Promise.resolve(admin);
+      return Promise.resolve(null);
+    });
+
+    const response = await DELETE(makeRequest(), makeContext("nonexistent"));
+
+    expect(response.status).toBe(404);
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when no token provided", async () => {
+    const request = new Request("http://localhost/api/usuarios/target-user", {
+      method: "DELETE",
+    });
+
+    const response = await DELETE(request, makeContext("target-user"));
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 403 when user is not admin", async () => {
+    const regularUser = makeUsuario({ id: "admin-1", papelPlataforma: "USER" });
+    mockFindById.mockResolvedValue(regularUser);
+
+    const response = await DELETE(makeRequest(), makeContext("target-user"));
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/src/app/api/usuarios/[id]/__tests__/delete-user.test.ts
+++ b/src/app/api/usuarios/[id]/__tests__/delete-user.test.ts
@@ -59,8 +59,12 @@ describe("DELETE /api/usuarios/[id]", () => {
     const target = makeUsuario({ id: "target-user" });
 
     mockFindById.mockImplementation((id: string) => {
-      if (id === "admin-1") return Promise.resolve(admin);
-      if (id === "target-user") return Promise.resolve(target);
+      if (id === "admin-1") {
+        return Promise.resolve(admin);
+      }
+      if (id === "target-user") {
+        return Promise.resolve(target);
+      }
       return Promise.resolve(null);
     });
 
@@ -85,7 +89,9 @@ describe("DELETE /api/usuarios/[id]", () => {
   it("returns 404 when target user does not exist", async () => {
     const admin = makeUsuario({ id: "admin-1", papelPlataforma: "MASTER_ADMIN" });
     mockFindById.mockImplementation((id: string) => {
-      if (id === "admin-1") return Promise.resolve(admin);
+      if (id === "admin-1") {
+        return Promise.resolve(admin);
+      }
       return Promise.resolve(null);
     });
 

--- a/src/app/api/usuarios/[id]/role/__tests__/update-role.test.ts
+++ b/src/app/api/usuarios/[id]/role/__tests__/update-role.test.ts
@@ -1,0 +1,152 @@
+/**
+ * @jest-environment node
+ */
+import type { UsuarioWithRelations } from "@/lib/server/db/interfaces/types";
+
+const mockFindById = jest.fn();
+const mockUpdatePapelPlataforma = jest.fn();
+const mockVerifyToken = jest.fn();
+
+jest.mock("@/lib/server/services/jwt/jwt", () => ({
+  verifyToken: (...args: unknown[]) => mockVerifyToken(...args),
+}));
+
+jest.mock("@/lib/server/container", () => ({
+  getContainer: () => ({
+    usuariosRepository: {
+      findById: mockFindById,
+      updatePapelPlataforma: mockUpdatePapelPlataforma,
+    },
+  }),
+}));
+
+import { PATCH } from "../route";
+
+function makeUsuario(overrides: Partial<UsuarioWithRelations> = {}): UsuarioWithRelations {
+  return {
+    id: "user-1",
+    nome: "Test User",
+    email: "test@academico.ufpb.br",
+    papelPlataforma: "MASTER_ADMIN",
+    eVerificado: true,
+    eFacade: false,
+    urlFotoPerfil: null,
+    permissoes: [],
+    centro: { id: "c1", nome: "CI", sigla: "CI", descricao: null, campusId: "campus-1" },
+    curso: { id: "k1", nome: "CC", centroId: "c1", criadoEm: new Date(), atualizadoEm: new Date() },
+    ...overrides,
+  } as unknown as UsuarioWithRelations;
+}
+
+function makeRequest(body: Record<string, unknown>): Request {
+  return new Request("http://localhost/api/usuarios/target-user/role", {
+    method: "PATCH",
+    headers: {
+      Authorization: "Bearer valid-token",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeContext(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockVerifyToken.mockReturnValue({ sub: "admin-1" });
+  mockUpdatePapelPlataforma.mockResolvedValue(undefined);
+});
+
+describe("PATCH /api/usuarios/[id]/role", () => {
+  it("updates user role to MASTER_ADMIN", async () => {
+    const admin = makeUsuario({ id: "admin-1", papelPlataforma: "MASTER_ADMIN" });
+    const target = makeUsuario({ id: "target-user", papelPlataforma: "USER" });
+    const updatedTarget = makeUsuario({ id: "target-user", papelPlataforma: "MASTER_ADMIN" });
+
+    mockFindById
+      .mockResolvedValueOnce(admin) // withAdmin lookup
+      .mockResolvedValueOnce(target) // check target exists
+      .mockResolvedValueOnce(updatedTarget); // return updated user
+
+    const response = await PATCH(
+      makeRequest({ papelPlataforma: "MASTER_ADMIN" }),
+      makeContext("target-user")
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.papelPlataforma).toBe("MASTER_ADMIN");
+    expect(mockUpdatePapelPlataforma).toHaveBeenCalledWith("target-user", "MASTER_ADMIN");
+  });
+
+  it("demotes user from MASTER_ADMIN to USER", async () => {
+    const admin = makeUsuario({ id: "admin-1", papelPlataforma: "MASTER_ADMIN" });
+    const target = makeUsuario({ id: "target-user", papelPlataforma: "MASTER_ADMIN" });
+    const updatedTarget = makeUsuario({ id: "target-user", papelPlataforma: "USER" });
+
+    mockFindById
+      .mockResolvedValueOnce(admin)
+      .mockResolvedValueOnce(target)
+      .mockResolvedValueOnce(updatedTarget);
+
+    const response = await PATCH(
+      makeRequest({ papelPlataforma: "USER" }),
+      makeContext("target-user")
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.papelPlataforma).toBe("USER");
+  });
+
+  it("prevents self-demotion", async () => {
+    const admin = makeUsuario({ id: "admin-1", papelPlataforma: "MASTER_ADMIN" });
+    mockFindById.mockResolvedValue(admin);
+
+    const response = await PATCH(makeRequest({ papelPlataforma: "USER" }), makeContext("admin-1"));
+
+    expect(response.status).toBe(400);
+    expect(mockUpdatePapelPlataforma).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when target user does not exist", async () => {
+    const admin = makeUsuario({ id: "admin-1", papelPlataforma: "MASTER_ADMIN" });
+    mockFindById
+      .mockResolvedValueOnce(admin) // withAdmin lookup
+      .mockResolvedValueOnce(null); // target not found
+
+    const response = await PATCH(
+      makeRequest({ papelPlataforma: "MASTER_ADMIN" }),
+      makeContext("nonexistent")
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 403 when caller is not admin", async () => {
+    const regularUser = makeUsuario({ id: "admin-1", papelPlataforma: "USER" });
+    mockFindById.mockResolvedValue(regularUser);
+
+    const response = await PATCH(
+      makeRequest({ papelPlataforma: "MASTER_ADMIN" }),
+      makeContext("target-user")
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("rejects invalid role values", async () => {
+    const admin = makeUsuario({ id: "admin-1", papelPlataforma: "MASTER_ADMIN" });
+    mockFindById.mockResolvedValue(admin);
+
+    const response = await PATCH(
+      makeRequest({ papelPlataforma: "SUPERADMIN" }),
+      makeContext("target-user")
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockUpdatePapelPlataforma).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/client/hooks/__tests__/use-onboarding.integration.test.tsx
+++ b/src/lib/client/hooks/__tests__/use-onboarding.integration.test.tsx
@@ -1,0 +1,487 @@
+/**
+ * Integration tests for useOnboarding hook
+ * Tests the onboarding state machine: step ordering, conditional steps,
+ * PAAS availability, semester-based logic, and step completion/skipping.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { waitFor } from "@testing-library/react";
+import { renderHookWithProviders } from "@/__tests__/utils/test-providers";
+import type { OnboardingMetadata } from "@/lib/shared/types";
+
+// Mock auth context
+vi.mock("@/contexts/auth-context", () => ({
+  useAuth: vi.fn(() => ({
+    token: "test-token",
+    isAuthenticated: true,
+    isLoading: false,
+  })),
+}));
+
+// Mock child hooks
+vi.mock("@/lib/client/hooks/use-usuarios", () => ({
+  useCurrentUser: vi.fn(() => ({
+    data: {
+      id: "user-1",
+      nome: "Test User",
+      periodoAtual: null,
+      centro: { sigla: "CI" },
+    },
+  })),
+}));
+
+vi.mock("@/lib/client/hooks/use-calendario-academico", () => ({
+  useSemestreAtivo: vi.fn(() => ({
+    data: { id: "sem-1", nome: "2025.1" },
+  })),
+}));
+
+vi.mock("@/lib/client/hooks/use-paas-calendar", () => ({
+  usePaasCalendar: vi.fn(() => ({
+    data: { description: "2025.1" },
+  })),
+}));
+
+// Mock usuarios service
+vi.mock("@/lib/client/api/usuarios", () => ({
+  usuariosService: {
+    getOnboardingMetadata: vi.fn(),
+    updateOnboardingMetadata: vi.fn(),
+    getCurrentUser: vi.fn(),
+  },
+}));
+
+import { useOnboarding } from "../use-onboarding";
+import { usuariosService } from "@/lib/client/api/usuarios";
+import { useCurrentUser } from "../use-usuarios";
+import { useSemestreAtivo } from "../use-calendario-academico";
+import { usePaasCalendar } from "../use-paas-calendar";
+
+const mockGetMetadata = vi.mocked(usuariosService.getOnboardingMetadata);
+const mockUpdateMetadata = vi.mocked(usuariosService.updateOnboardingMetadata);
+const mockUseCurrentUser = vi.mocked(useCurrentUser);
+const mockUseSemestreAtivo = vi.mocked(useSemestreAtivo);
+const mockUsePaasCalendar = vi.mocked(usePaasCalendar);
+
+function freshMetadata(overrides: Partial<OnboardingMetadata> = {}): OnboardingMetadata {
+  return { ...overrides };
+}
+
+describe("useOnboarding", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Reset to default mocks
+    mockUseCurrentUser.mockReturnValue({
+      data: {
+        id: "user-1",
+        nome: "Test User",
+        periodoAtual: null,
+        centro: { sigla: "CI" },
+      },
+    } as ReturnType<typeof useCurrentUser>);
+
+    mockUseSemestreAtivo.mockReturnValue({
+      data: { id: "sem-1", nome: "2025.1" },
+    } as ReturnType<typeof useSemestreAtivo>);
+
+    mockUsePaasCalendar.mockReturnValue({
+      data: { description: "2025.1" },
+    } as ReturnType<typeof usePaasCalendar>);
+  });
+
+  describe("step ordering and visibility", () => {
+    it("shows all steps for a fresh user with active semester and PAAS", async () => {
+      const meta = freshMetadata();
+      mockGetMetadata.mockResolvedValue(meta);
+
+      const { result } = renderHookWithProviders(() => useOnboarding());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.isComplete).toBe(false);
+      expect(result.current.shouldShow).toBe(true);
+
+      // First step should be welcome
+      expect(result.current.currentStep?.id).toBe("welcome");
+
+      // Should have all 6 pending steps (turmas not shown until cursando is done)
+      const stepIds = result.current.steps.map(s => s.id);
+      expect(stepIds).toContain("welcome");
+      expect(stepIds).toContain("periodo");
+      expect(stepIds).toContain("concluidas");
+      expect(stepIds).toContain("cursando");
+      expect(stepIds).toContain("entidades");
+      expect(stepIds).toContain("done");
+      // turmas NOT shown because cursando is not yet completed
+      expect(stepIds).not.toContain("turmas");
+    });
+
+    it("shows turmas step when cursando is completed and PAAS is available", async () => {
+      const meta = freshMetadata({
+        welcome: { completedAt: "2025-01-01" },
+        periodo: { completedAt: "2025-01-01" },
+        concluidas: { completedAt: "2025-01-01" },
+        semesters: {
+          "2025.1": { cursando: { completedAt: "2025-01-01" } },
+        },
+      });
+      mockGetMetadata.mockResolvedValue(meta);
+
+      const { result } = renderHookWithProviders(() => useOnboarding());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      const stepIds = result.current.steps.map(s => s.id);
+      expect(stepIds).toContain("turmas");
+    });
+
+    it("hides turmas step when PAAS is not available", async () => {
+      mockUsePaasCalendar.mockReturnValue({
+        data: { description: "2024.2" }, // different from semester
+      } as ReturnType<typeof usePaasCalendar>);
+
+      const meta = freshMetadata({
+        welcome: { completedAt: "2025-01-01" },
+        semesters: {
+          "2025.1": { cursando: { completedAt: "2025-01-01" } },
+        },
+      });
+      mockGetMetadata.mockResolvedValue(meta);
+
+      const { result } = renderHookWithProviders(() => useOnboarding());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      const stepIds = result.current.steps.map(s => s.id);
+      expect(stepIds).not.toContain("turmas");
+    });
+
+    it("hides cursando step when no active semester", async () => {
+      mockUseSemestreAtivo.mockReturnValue({
+        data: undefined,
+      } as ReturnType<typeof useSemestreAtivo>);
+
+      const meta = freshMetadata();
+      mockGetMetadata.mockResolvedValue(meta);
+
+      const { result } = renderHookWithProviders(() => useOnboarding());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      const stepIds = result.current.steps.map(s => s.id);
+      expect(stepIds).not.toContain("cursando");
+      expect(stepIds).not.toContain("turmas");
+    });
+  });
+
+  describe("periodo step auto-detection", () => {
+    it("skips periodo step when user already has periodoAtual set", async () => {
+      mockUseCurrentUser.mockReturnValue({
+        data: {
+          id: "user-1",
+          nome: "Test User",
+          periodoAtual: "5",
+          centro: { sigla: "CI" },
+        },
+      } as ReturnType<typeof useCurrentUser>);
+
+      const meta = freshMetadata();
+      mockGetMetadata.mockResolvedValue(meta);
+
+      const { result } = renderHookWithProviders(() => useOnboarding());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // periodo should not appear in pending steps
+      const stepIds = result.current.steps.map(s => s.id);
+      expect(stepIds).not.toContain("periodo");
+    });
+
+    it("shows periodo step when user has no periodoAtual", async () => {
+      const meta = freshMetadata();
+      mockGetMetadata.mockResolvedValue(meta);
+
+      const { result } = renderHookWithProviders(() => useOnboarding());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      const stepIds = result.current.steps.map(s => s.id);
+      expect(stepIds).toContain("periodo");
+    });
+  });
+
+  describe("completion tracking", () => {
+    it("reports isComplete when all steps are done", async () => {
+      const meta = freshMetadata({
+        welcome: { completedAt: "2025-01-01" },
+        periodo: { completedAt: "2025-01-01" },
+        concluidas: { completedAt: "2025-01-01" },
+        entidades: { completedAt: "2025-01-01" },
+        done: { completedAt: "2025-01-01" },
+        semesters: {
+          "2025.1": {
+            cursando: { completedAt: "2025-01-01" },
+            turmas: { completedAt: "2025-01-01" },
+          },
+        },
+      });
+      mockGetMetadata.mockResolvedValue(meta);
+
+      const { result } = renderHookWithProviders(() => useOnboarding());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.isComplete).toBe(true);
+      expect(result.current.shouldShow).toBe(false);
+      expect(result.current.currentStep).toBeNull();
+      expect(result.current.steps).toHaveLength(0);
+    });
+
+    it("tracks completedCount and totalCount correctly", async () => {
+      const meta = freshMetadata({
+        welcome: { completedAt: "2025-01-01" },
+        periodo: { completedAt: "2025-01-01" },
+      });
+      mockGetMetadata.mockResolvedValue(meta);
+
+      const { result } = renderHookWithProviders(() => useOnboarding());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.completedCount).toBe(2);
+      // Total includes: welcome, periodo, concluidas, cursando, entidades, done = 6
+      // (turmas excluded since cursando not done)
+      expect(result.current.totalCount).toBe(6);
+    });
+
+    it("counts skipped steps as completed", async () => {
+      const meta = freshMetadata({
+        welcome: { completedAt: "2025-01-01" },
+        periodo: { skippedAt: "2025-01-01" },
+        concluidas: { skippedAt: "2025-01-01" },
+      });
+      mockGetMetadata.mockResolvedValue(meta);
+
+      const { result } = renderHookWithProviders(() => useOnboarding());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.completedCount).toBe(3);
+    });
+  });
+
+  describe("step completion mutations", () => {
+    it("completes a one-time step", async () => {
+      const meta = freshMetadata();
+      mockGetMetadata.mockResolvedValue(meta);
+      mockUpdateMetadata.mockResolvedValue({
+        ...meta,
+        welcome: { completedAt: "2025-01-01" },
+      });
+
+      const { result } = renderHookWithProviders(() => useOnboarding());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      await result.current.completeStep("welcome");
+
+      expect(mockUpdateMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({
+          welcome: { completedAt: expect.any(String) },
+        }),
+        "test-token"
+      );
+    });
+
+    it("completes a per-semester step with semester name", async () => {
+      const meta = freshMetadata({
+        welcome: { completedAt: "2025-01-01" },
+        periodo: { completedAt: "2025-01-01" },
+        concluidas: { completedAt: "2025-01-01" },
+      });
+      mockGetMetadata.mockResolvedValue(meta);
+      mockUpdateMetadata.mockResolvedValue({
+        ...meta,
+        semesters: { "2025.1": { cursando: { completedAt: "2025-01-01" } } },
+      });
+
+      const { result } = renderHookWithProviders(() => useOnboarding());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      await result.current.completeStep("cursando");
+
+      expect(mockUpdateMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({
+          semesters: {
+            "2025.1": { cursando: { completedAt: expect.any(String) } },
+          },
+        }),
+        "test-token"
+      );
+    });
+  });
+
+  describe("step skipping", () => {
+    it("skips a skippable step", async () => {
+      const meta = freshMetadata({ welcome: { completedAt: "2025-01-01" } });
+      mockGetMetadata.mockResolvedValue(meta);
+      mockUpdateMetadata.mockResolvedValue({
+        ...meta,
+        periodo: { skippedAt: "2025-01-01" },
+      });
+
+      const { result } = renderHookWithProviders(() => useOnboarding());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      await result.current.skipStep("periodo");
+
+      expect(mockUpdateMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({
+          periodo: { skippedAt: expect.any(String) },
+        }),
+        "test-token"
+      );
+    });
+
+    it("skips a per-semester step", async () => {
+      const meta = freshMetadata({
+        welcome: { completedAt: "2025-01-01" },
+        periodo: { completedAt: "2025-01-01" },
+        concluidas: { completedAt: "2025-01-01" },
+      });
+      mockGetMetadata.mockResolvedValue(meta);
+      mockUpdateMetadata.mockResolvedValue({
+        ...meta,
+        semesters: { "2025.1": { cursando: { skippedAt: "2025-01-01" } } },
+      });
+
+      const { result } = renderHookWithProviders(() => useOnboarding());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      await result.current.skipStep("cursando");
+
+      expect(mockUpdateMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({
+          semesters: {
+            "2025.1": { cursando: { skippedAt: expect.any(String) } },
+          },
+        }),
+        "test-token"
+      );
+    });
+  });
+
+  describe("PAAS availability", () => {
+    it("paasAvailable is true when PAAS semester matches DB semester", async () => {
+      const meta = freshMetadata();
+      mockGetMetadata.mockResolvedValue(meta);
+
+      const { result } = renderHookWithProviders(() => useOnboarding());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.paasAvailable).toBe(true);
+    });
+
+    it("paasAvailable is false when PAAS semester differs from DB semester", async () => {
+      mockUsePaasCalendar.mockReturnValue({
+        data: { description: "2024.2" },
+      } as ReturnType<typeof usePaasCalendar>);
+
+      const meta = freshMetadata();
+      mockGetMetadata.mockResolvedValue(meta);
+
+      const { result } = renderHookWithProviders(() => useOnboarding());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.paasAvailable).toBe(false);
+    });
+
+    it("paasAvailable is false when PAAS data is not loaded", async () => {
+      mockUsePaasCalendar.mockReturnValue({
+        data: undefined,
+      } as ReturnType<typeof usePaasCalendar>);
+
+      const meta = freshMetadata();
+      mockGetMetadata.mockResolvedValue(meta);
+
+      const { result } = renderHookWithProviders(() => useOnboarding());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.paasAvailable).toBe(false);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns isComplete true when no metadata exists", async () => {
+      mockGetMetadata.mockResolvedValue(null as unknown as OnboardingMetadata);
+
+      const { result } = renderHookWithProviders(() => useOnboarding());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // When metadata is null, hook treats onboarding as complete
+      expect(result.current.isComplete).toBe(true);
+      expect(result.current.shouldShow).toBe(false);
+    });
+
+    it("step definitions have correct skippable flags", async () => {
+      const meta = freshMetadata();
+      mockGetMetadata.mockResolvedValue(meta);
+
+      const { result } = renderHookWithProviders(() => useOnboarding());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      const welcomeStep = result.current.steps.find(s => s.id === "welcome");
+      const periodoStep = result.current.steps.find(s => s.id === "periodo");
+      const doneStep = result.current.steps.find(s => s.id === "done");
+
+      expect(welcomeStep?.isSkippable).toBe(false);
+      expect(periodoStep?.isSkippable).toBe(true);
+      expect(doneStep?.isSkippable).toBe(false);
+    });
+  });
+});

--- a/src/lib/server/services/admin/__tests__/merge-facade-user.test.ts
+++ b/src/lib/server/services/admin/__tests__/merge-facade-user.test.ts
@@ -1,8 +1,10 @@
 import { mergeFacadeUser } from "../merge-facade-user";
 import type { IUsuariosRepository } from "@/lib/server/db/interfaces/usuarios-repository.interface";
-import type { IMembrosRepository } from "@/lib/server/db/interfaces/membros-repository.interface";
+import type {
+  IMembrosRepository,
+  MembroRaw,
+} from "@/lib/server/db/interfaces/membros-repository.interface";
 import type { UsuarioWithRelations } from "@/lib/server/db/interfaces/types";
-import type { MembroRaw } from "@/lib/server/db/interfaces/membros-repository.interface";
 
 function makeUsuario(overrides: Partial<UsuarioWithRelations> = {}): UsuarioWithRelations {
   return {
@@ -37,8 +39,12 @@ function makeDeps(
   realMemberships: MembroRaw[] = []
 ) {
   const findById = jest.fn().mockImplementation((id: string) => {
-    if (id === "facade-1") return Promise.resolve(facadeUser);
-    if (id === "real-1") return Promise.resolve(realUser);
+    if (id === "facade-1") {
+      return Promise.resolve(facadeUser);
+    }
+    if (id === "real-1") {
+      return Promise.resolve(realUser);
+    }
     return Promise.resolve(null);
   });
 
@@ -49,8 +55,12 @@ function makeDeps(
     } as unknown as IUsuariosRepository,
     membrosRepository: {
       findRawByUsuarioId: jest.fn().mockImplementation((userId: string) => {
-        if (userId === "facade-1") return Promise.resolve(facadeMemberships);
-        if (userId === "real-1") return Promise.resolve(realMemberships);
+        if (userId === "facade-1") {
+          return Promise.resolve(facadeMemberships);
+        }
+        if (userId === "real-1") {
+          return Promise.resolve(realMemberships);
+        }
         return Promise.resolve([]);
       }),
       create: jest.fn().mockResolvedValue({ id: "new-membro" }),

--- a/src/lib/server/services/admin/__tests__/merge-facade-user.test.ts
+++ b/src/lib/server/services/admin/__tests__/merge-facade-user.test.ts
@@ -1,0 +1,245 @@
+import { mergeFacadeUser } from "../merge-facade-user";
+import type { IUsuariosRepository } from "@/lib/server/db/interfaces/usuarios-repository.interface";
+import type { IMembrosRepository } from "@/lib/server/db/interfaces/membros-repository.interface";
+import type { UsuarioWithRelations } from "@/lib/server/db/interfaces/types";
+import type { MembroRaw } from "@/lib/server/db/interfaces/membros-repository.interface";
+
+function makeUsuario(overrides: Partial<UsuarioWithRelations> = {}): UsuarioWithRelations {
+  return {
+    id: "user-1",
+    nome: "Test User",
+    email: "test@academico.ufpb.br",
+    eFacade: false,
+    papelPlataforma: "USER",
+    centro: { id: "c1", nome: "CI", sigla: "CI", descricao: null, campusId: "campus-1" },
+    curso: { id: "k1", nome: "CC", centroId: "c1", criadoEm: new Date(), atualizadoEm: new Date() },
+    ...overrides,
+  } as unknown as UsuarioWithRelations;
+}
+
+function makeMembership(overrides: Partial<MembroRaw> = {}): MembroRaw {
+  return {
+    id: "membro-1",
+    usuarioId: "facade-1",
+    entidadeId: "entidade-1",
+    papel: "MEMBRO",
+    cargoId: null,
+    startedAt: new Date("2024-01-01"),
+    endedAt: null,
+    ...overrides,
+  };
+}
+
+function makeDeps(
+  facadeUser: UsuarioWithRelations | null = makeUsuario({ id: "facade-1", eFacade: true }),
+  realUser: UsuarioWithRelations | null = makeUsuario({ id: "real-1", eFacade: false }),
+  facadeMemberships: MembroRaw[] = [],
+  realMemberships: MembroRaw[] = []
+) {
+  const findById = jest.fn().mockImplementation((id: string) => {
+    if (id === "facade-1") return Promise.resolve(facadeUser);
+    if (id === "real-1") return Promise.resolve(realUser);
+    return Promise.resolve(null);
+  });
+
+  return {
+    usuariosRepository: {
+      findById,
+      delete: jest.fn().mockResolvedValue(undefined),
+    } as unknown as IUsuariosRepository,
+    membrosRepository: {
+      findRawByUsuarioId: jest.fn().mockImplementation((userId: string) => {
+        if (userId === "facade-1") return Promise.resolve(facadeMemberships);
+        if (userId === "real-1") return Promise.resolve(realMemberships);
+        return Promise.resolve([]);
+      }),
+      create: jest.fn().mockResolvedValue({ id: "new-membro" }),
+      deleteByUsuarioId: jest.fn().mockResolvedValue(1),
+    } as unknown as IMembrosRepository,
+  };
+}
+
+describe("mergeFacadeUser", () => {
+  it("copies memberships from facade to real user and deletes facade", async () => {
+    const facadeMemberships = [
+      makeMembership({ id: "m1", entidadeId: "ent-1", papel: "ADMIN", cargoId: "cargo-1" }),
+      makeMembership({ id: "m2", entidadeId: "ent-2", papel: "MEMBRO" }),
+    ];
+    const deps = makeDeps(undefined, undefined, facadeMemberships, []);
+
+    const result = await mergeFacadeUser("facade-1", "real-1", true, deps);
+
+    expect(result.success).toBe(true);
+    expect(result.membershipsCopied).toBe(2);
+    expect(result.conflicts).toBe(0);
+    expect(result.facadeUserDeleted).toBe(true);
+
+    // Verify memberships were created for real user
+    expect(deps.membrosRepository.create).toHaveBeenCalledTimes(2);
+    expect(deps.membrosRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        usuarioId: "real-1",
+        entidadeId: "ent-1",
+        papel: "ADMIN",
+        cargoId: "cargo-1",
+      })
+    );
+    expect(deps.membrosRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        usuarioId: "real-1",
+        entidadeId: "ent-2",
+        papel: "MEMBRO",
+      })
+    );
+
+    // Verify facade cleanup
+    expect(deps.membrosRepository.deleteByUsuarioId).toHaveBeenCalledWith("facade-1");
+    expect(deps.usuariosRepository.delete).toHaveBeenCalledWith("facade-1");
+  });
+
+  it("detects conflicts when real user already has membership in same entity", async () => {
+    const facadeMemberships = [
+      makeMembership({ id: "m1", entidadeId: "ent-1" }),
+      makeMembership({ id: "m2", entidadeId: "ent-2" }),
+    ];
+    const realMemberships = [
+      makeMembership({ id: "m3", usuarioId: "real-1", entidadeId: "ent-1" }),
+    ];
+    const deps = makeDeps(undefined, undefined, facadeMemberships, realMemberships);
+
+    const result = await mergeFacadeUser("facade-1", "real-1", true, deps);
+
+    expect(result.success).toBe(true);
+    expect(result.membershipsCopied).toBe(1); // only ent-2 copied
+    expect(result.conflicts).toBe(1); // ent-1 was a conflict
+    expect(deps.membrosRepository.create).toHaveBeenCalledTimes(1);
+    expect(deps.membrosRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ entidadeId: "ent-2" })
+    );
+  });
+
+  it("skips facade deletion when deleteFacade is false", async () => {
+    const facadeMemberships = [makeMembership({ id: "m1", entidadeId: "ent-1" })];
+    const deps = makeDeps(undefined, undefined, facadeMemberships, []);
+
+    const result = await mergeFacadeUser("facade-1", "real-1", false, deps);
+
+    expect(result.success).toBe(true);
+    expect(result.facadeUserDeleted).toBe(false);
+    expect(deps.membrosRepository.deleteByUsuarioId).not.toHaveBeenCalled();
+    expect(deps.usuariosRepository.delete).not.toHaveBeenCalled();
+  });
+
+  it("returns error when facade user is not found", async () => {
+    const deps = makeDeps(null);
+
+    const result = await mergeFacadeUser("facade-1", "real-1", true, deps);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Facade user not found");
+  });
+
+  it("returns error when user is not a facade", async () => {
+    const nonFacade = makeUsuario({ id: "facade-1", eFacade: false });
+    const deps = makeDeps(nonFacade);
+
+    const result = await mergeFacadeUser("facade-1", "real-1", true, deps);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("User is not a facade user");
+  });
+
+  it("returns error when real user is not found", async () => {
+    const deps = makeDeps(undefined, null);
+
+    const result = await mergeFacadeUser("facade-1", "real-1", true, deps);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Real user not found");
+  });
+
+  it("returns error when target user is also a facade", async () => {
+    const alsoFacade = makeUsuario({ id: "real-1", eFacade: true });
+    const deps = makeDeps(undefined, alsoFacade);
+
+    const result = await mergeFacadeUser("facade-1", "real-1", true, deps);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Target user is a facade user");
+  });
+
+  it("handles merge with no memberships to copy", async () => {
+    const deps = makeDeps(undefined, undefined, [], []);
+
+    const result = await mergeFacadeUser("facade-1", "real-1", true, deps);
+
+    expect(result.success).toBe(true);
+    expect(result.membershipsCopied).toBe(0);
+    expect(result.conflicts).toBe(0);
+    expect(result.facadeUserDeleted).toBe(true);
+    expect(deps.membrosRepository.create).not.toHaveBeenCalled();
+  });
+
+  it("preserves startedAt and endedAt when copying memberships", async () => {
+    const startDate = new Date("2023-06-15");
+    const endDate = new Date("2024-01-15");
+    const facadeMemberships = [
+      makeMembership({ entidadeId: "ent-1", startedAt: startDate, endedAt: endDate }),
+    ];
+    const deps = makeDeps(undefined, undefined, facadeMemberships, []);
+
+    await mergeFacadeUser("facade-1", "real-1", true, deps);
+
+    expect(deps.membrosRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        startedAt: startDate,
+        endedAt: endDate,
+      })
+    );
+  });
+
+  it("handles all memberships being conflicts", async () => {
+    const facadeMemberships = [
+      makeMembership({ entidadeId: "ent-1" }),
+      makeMembership({ entidadeId: "ent-2" }),
+    ];
+    const realMemberships = [
+      makeMembership({ usuarioId: "real-1", entidadeId: "ent-1" }),
+      makeMembership({ usuarioId: "real-1", entidadeId: "ent-2" }),
+    ];
+    const deps = makeDeps(undefined, undefined, facadeMemberships, realMemberships);
+
+    const result = await mergeFacadeUser("facade-1", "real-1", true, deps);
+
+    expect(result.success).toBe(true);
+    expect(result.membershipsCopied).toBe(0);
+    expect(result.conflicts).toBe(2);
+    expect(deps.membrosRepository.create).not.toHaveBeenCalled();
+  });
+
+  it("catches unexpected errors and returns them gracefully", async () => {
+    const deps = makeDeps();
+    (deps.membrosRepository.findRawByUsuarioId as jest.Mock).mockRejectedValue(
+      new Error("DB connection lost")
+    );
+
+    const result = await mergeFacadeUser("facade-1", "real-1", true, deps);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("DB connection lost");
+  });
+
+  it("deletes facade memberships before deleting user (FK constraint)", async () => {
+    const facadeMemberships = [makeMembership({ entidadeId: "ent-1" })];
+    const deps = makeDeps(undefined, undefined, facadeMemberships, []);
+
+    await mergeFacadeUser("facade-1", "real-1", true, deps);
+
+    // deleteByUsuarioId must be called before delete
+    const deleteByUserCall = (deps.membrosRepository.deleteByUsuarioId as jest.Mock).mock
+      .invocationCallOrder[0];
+    const deleteUserCall = (deps.usuariosRepository.delete as jest.Mock).mock
+      .invocationCallOrder[0];
+    expect(deleteByUserCall).toBeLessThan(deleteUserCall);
+  });
+});

--- a/src/lib/server/services/auth/__tests__/authenticate.test.ts
+++ b/src/lib/server/services/auth/__tests__/authenticate.test.ts
@@ -1,0 +1,128 @@
+import { authenticate } from "../authenticate";
+import type { IUsuariosRepository } from "@/lib/server/db/interfaces/usuarios-repository.interface";
+import type { UsuarioWithRelations } from "@/lib/server/db/interfaces/types";
+import { hash } from "bcryptjs";
+
+// Mock jwt module
+jest.mock("@/lib/server/services/jwt/jwt", () => ({
+  signToken: jest.fn().mockReturnValue("mock-jwt-token"),
+}));
+
+function makeUsuario(overrides: Partial<UsuarioWithRelations> = {}): UsuarioWithRelations {
+  return {
+    id: "user-1",
+    nome: "Test User",
+    email: "test@academico.ufpb.br",
+    senhaHash: "hashed-password",
+    eVerificado: true,
+    eFacade: false,
+    slug: "test-user",
+    urlFotoPerfil: null,
+    matricula: null,
+    permissoes: [],
+    papelPlataforma: "USER",
+    periodoAtual: null,
+    onboardingMetadata: null,
+    centroId: "centro-1",
+    cursoId: "curso-1",
+    criadoEm: new Date(),
+    atualizadoEm: new Date(),
+    centro: { id: "centro-1", nome: "CI", sigla: "CI", descricao: null, campusId: "campus-1" },
+    curso: {
+      id: "curso-1",
+      nome: "CC",
+      centroId: "centro-1",
+      criadoEm: new Date(),
+      atualizadoEm: new Date(),
+    },
+    ...overrides,
+  } as UsuarioWithRelations;
+}
+
+function makeMockRepo(usuario: UsuarioWithRelations | null = null): IUsuariosRepository {
+  return {
+    findByEmail: jest.fn().mockResolvedValue(usuario),
+    findById: jest.fn(),
+    findBySlug: jest.fn(),
+    findMany: jest.fn(),
+    findManyPaginated: jest.fn(),
+    search: jest.fn(),
+    create: jest.fn(),
+    markAsVerified: jest.fn(),
+    updatePassword: jest.fn(),
+    updatePapelPlataforma: jest.fn(),
+    updateFotoPerfil: jest.fn(),
+    updateCentro: jest.fn(),
+    updateCurso: jest.fn(),
+    updateSlug: jest.fn(),
+    updatePeriodoAtual: jest.fn(),
+    getOnboardingMetadata: jest.fn(),
+    updateOnboardingMetadata: jest.fn(),
+    clearOnboardingMetadata: jest.fn(),
+    delete: jest.fn(),
+  };
+}
+
+describe("authenticate", () => {
+  it("returns token and user on valid credentials", async () => {
+    const senhaHash = await hash("password123", 10);
+    const usuario = makeUsuario({ senhaHash });
+    const repo = makeMockRepo(usuario);
+
+    const result = await authenticate(
+      { email: "Test@academico.ufpb.br", senha: "password123" },
+      repo
+    );
+
+    expect(result.token).toBe("mock-jwt-token");
+    expect(result.usuario).toBe(usuario);
+    expect(repo.findByEmail).toHaveBeenCalledWith("test@academico.ufpb.br");
+  });
+
+  it("normalizes email to lowercase and trims whitespace", async () => {
+    const senhaHash = await hash("password123", 10);
+    const usuario = makeUsuario({ senhaHash });
+    const repo = makeMockRepo(usuario);
+
+    await authenticate({ email: "  TEST@ACADEMICO.UFPB.BR  ", senha: "password123" }, repo);
+
+    expect(repo.findByEmail).toHaveBeenCalledWith("test@academico.ufpb.br");
+  });
+
+  it("throws EMAIL_NAO_ENCONTRADO when user does not exist", async () => {
+    const repo = makeMockRepo(null);
+
+    await expect(
+      authenticate({ email: "missing@academico.ufpb.br", senha: "password" }, repo)
+    ).rejects.toThrow("EMAIL_NAO_ENCONTRADO");
+  });
+
+  it("throws EMAIL_NAO_ENCONTRADO when user has no password hash (facade user)", async () => {
+    const usuario = makeUsuario({ senhaHash: null });
+    const repo = makeMockRepo(usuario);
+
+    await expect(
+      authenticate({ email: "test@academico.ufpb.br", senha: "password" }, repo)
+    ).rejects.toThrow("EMAIL_NAO_ENCONTRADO");
+  });
+
+  it("throws SENHA_INVALIDA when password does not match", async () => {
+    const senhaHash = await hash("correct-password", 10);
+    const usuario = makeUsuario({ senhaHash });
+    const repo = makeMockRepo(usuario);
+
+    await expect(
+      authenticate({ email: "test@academico.ufpb.br", senha: "wrong-password" }, repo)
+    ).rejects.toThrow("SENHA_INVALIDA");
+  });
+
+  it("throws when user email is not verified", async () => {
+    const senhaHash = await hash("password123", 10);
+    const usuario = makeUsuario({ senhaHash, eVerificado: false });
+    const repo = makeMockRepo(usuario);
+
+    await expect(
+      authenticate({ email: "test@academico.ufpb.br", senha: "password123" }, repo)
+    ).rejects.toThrow("Email não verificado");
+  });
+});

--- a/src/lib/server/services/auth/__tests__/forgot-password.test.ts
+++ b/src/lib/server/services/auth/__tests__/forgot-password.test.ts
@@ -1,0 +1,135 @@
+import { forgotPassword } from "../forgot-password";
+import type { IUsuariosRepository } from "@/lib/server/db/interfaces/usuarios-repository.interface";
+import type { ITokenVerificacaoRepository } from "@/lib/server/db/interfaces/token-verificacao-repository.interface";
+import type { IEmailService } from "@/lib/server/services/email/email-service.interface";
+import type { TokenVerificacao, UsuarioWithRelations } from "@/lib/server/db/interfaces/types";
+
+function makeUsuario(overrides: Partial<UsuarioWithRelations> = {}): UsuarioWithRelations {
+  return {
+    id: "user-1",
+    nome: "Test User",
+    email: "test@academico.ufpb.br",
+    centro: { id: "c1", nome: "CI", sigla: "CI", descricao: null, campusId: "campus-1" },
+    curso: { id: "k1", nome: "CC", centroId: "c1", criadoEm: new Date(), atualizadoEm: new Date() },
+    ...overrides,
+  } as UsuarioWithRelations;
+}
+
+function makeDeps(
+  usuario: UsuarioWithRelations | null = makeUsuario(),
+  lastToken: TokenVerificacao | null = null
+) {
+  return {
+    usuariosRepository: {
+      findByEmail: jest.fn().mockResolvedValue(usuario),
+    } as unknown as IUsuariosRepository,
+    tokenVerificacaoRepository: {
+      findLatestByUsuarioIdAndTipo: jest.fn().mockResolvedValue(lastToken),
+      deleteByUsuarioIdAndTipo: jest.fn().mockResolvedValue(undefined),
+      create: jest.fn().mockResolvedValue({ id: "new-token-id" }),
+      findByToken: jest.fn(),
+      markAsUsed: jest.fn(),
+      deleteExpiredTokens: jest.fn(),
+    } as unknown as ITokenVerificacaoRepository,
+    emailService: {
+      sendPasswordResetEmail: jest.fn().mockResolvedValue(undefined),
+      sendVerificationEmail: jest.fn(),
+    } as IEmailService,
+  };
+}
+
+describe("forgotPassword", () => {
+  it("always returns success message (enumeration prevention)", async () => {
+    const deps = makeDeps();
+    const result = await forgotPassword({ email: "test@academico.ufpb.br" }, deps);
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("Se o email estiver cadastrado");
+  });
+
+  it("returns success even when user does not exist", async () => {
+    const deps = makeDeps(null);
+    const result = await forgotPassword({ email: "nonexistent@academico.ufpb.br" }, deps);
+
+    expect(result.success).toBe(true);
+    expect(deps.tokenVerificacaoRepository.create).not.toHaveBeenCalled();
+    expect(deps.emailService.sendPasswordResetEmail).not.toHaveBeenCalled();
+  });
+
+  it("normalizes email to lowercase and trims", async () => {
+    const deps = makeDeps();
+    await forgotPassword({ email: "  TEST@ACADEMICO.UFPB.BR  " }, deps);
+
+    expect(deps.usuariosRepository.findByEmail).toHaveBeenCalledWith("test@academico.ufpb.br");
+  });
+
+  it("creates token and sends email for valid user", async () => {
+    const deps = makeDeps();
+    await forgotPassword({ email: "test@academico.ufpb.br" }, deps);
+
+    expect(deps.tokenVerificacaoRepository.deleteByUsuarioIdAndTipo).toHaveBeenCalledWith(
+      "user-1",
+      "RESET_SENHA"
+    );
+    expect(deps.tokenVerificacaoRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        usuarioId: "user-1",
+        tipo: "RESET_SENHA",
+        token: expect.any(String),
+        expiraEm: expect.any(Date),
+      })
+    );
+    expect(deps.emailService.sendPasswordResetEmail).toHaveBeenCalledWith(
+      "test@academico.ufpb.br",
+      expect.any(String),
+      "Test User"
+    );
+  });
+
+  it("rate limits - skips if last token was created less than 1 minute ago", async () => {
+    const recentToken = {
+      id: "recent-token",
+      criadoEm: new Date(), // just now
+    } as TokenVerificacao;
+    const deps = makeDeps(makeUsuario(), recentToken);
+
+    const result = await forgotPassword({ email: "test@academico.ufpb.br" }, deps);
+
+    expect(result.success).toBe(true);
+    expect(deps.tokenVerificacaoRepository.create).not.toHaveBeenCalled();
+    expect(deps.emailService.sendPasswordResetEmail).not.toHaveBeenCalled();
+  });
+
+  it("allows request if last token was created more than 1 minute ago", async () => {
+    const oldToken = {
+      id: "old-token",
+      criadoEm: new Date(Date.now() - 2 * 60 * 1000), // 2 min ago
+    } as TokenVerificacao;
+    const deps = makeDeps(makeUsuario(), oldToken);
+
+    await forgotPassword({ email: "test@academico.ufpb.br" }, deps);
+
+    expect(deps.tokenVerificacaoRepository.create).toHaveBeenCalled();
+  });
+
+  it("returns success even when email sending fails", async () => {
+    const deps = makeDeps();
+    (deps.emailService.sendPasswordResetEmail as jest.Mock).mockRejectedValue(
+      new Error("SMTP error")
+    );
+
+    const result = await forgotPassword({ email: "test@academico.ufpb.br" }, deps);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("returns success when user has no email", async () => {
+    const noEmailUser = makeUsuario({ email: null });
+    const deps = makeDeps(noEmailUser);
+
+    const result = await forgotPassword({ email: "test@academico.ufpb.br" }, deps);
+
+    expect(result.success).toBe(true);
+    expect(deps.tokenVerificacaoRepository.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/server/services/auth/__tests__/middleware.test.ts
+++ b/src/lib/server/services/auth/__tests__/middleware.test.ts
@@ -1,0 +1,188 @@
+/**
+ * @jest-environment node
+ */
+import { withAuth, withAdmin, getOptionalUser, canManageVagaForEntidade } from "../middleware";
+import type { UsuarioWithRelations } from "@/lib/server/db/interfaces/types";
+
+// Mock dependencies
+const mockFindById = jest.fn();
+const mockFindActiveByUsuarioAndEntidade = jest.fn();
+
+jest.mock("@/lib/server/services/jwt/jwt", () => ({
+  verifyToken: jest.fn(),
+}));
+
+jest.mock("@/lib/server/container", () => ({
+  getContainer: () => ({
+    usuariosRepository: { findById: mockFindById },
+    membrosRepository: { findActiveByUsuarioAndEntidade: mockFindActiveByUsuarioAndEntidade },
+  }),
+}));
+
+// Import after mocks
+import { verifyToken } from "@/lib/server/services/jwt/jwt";
+
+function makeUsuario(overrides: Partial<UsuarioWithRelations> = {}): UsuarioWithRelations {
+  return {
+    id: "user-1",
+    nome: "Test User",
+    email: "test@academico.ufpb.br",
+    papelPlataforma: "USER",
+    centro: { id: "c1", nome: "CI", sigla: "CI", descricao: null, campusId: "campus-1" },
+    curso: { id: "k1", nome: "CC", centroId: "c1", criadoEm: new Date(), atualizadoEm: new Date() },
+    ...overrides,
+  } as UsuarioWithRelations;
+}
+
+function makeRequest(token?: string): Request {
+  const headers = new Headers();
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+  return new Request("http://localhost/api/test", { headers });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("withAuth", () => {
+  it("calls handler with user when token is valid", async () => {
+    const usuario = makeUsuario();
+    (verifyToken as jest.Mock).mockReturnValue({ sub: "user-1" });
+    mockFindById.mockResolvedValue(usuario);
+
+    const handler = jest.fn().mockResolvedValue(new Response("ok"));
+    const response = await withAuth(makeRequest("valid-token"), handler);
+
+    expect(handler).toHaveBeenCalledWith(expect.any(Request), usuario);
+    expect(response.status).toBe(200);
+  });
+
+  it("returns 401 when no Authorization header", async () => {
+    const handler = jest.fn();
+    const response = await withAuth(makeRequest(), handler);
+
+    expect(response.status).toBe(401);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when token is invalid", async () => {
+    (verifyToken as jest.Mock).mockReturnValue(null);
+
+    const handler = jest.fn();
+    const response = await withAuth(makeRequest("bad-token"), handler);
+
+    expect(response.status).toBe(401);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when user is not found in database", async () => {
+    (verifyToken as jest.Mock).mockReturnValue({ sub: "deleted-user" });
+    mockFindById.mockResolvedValue(null);
+
+    const handler = jest.fn();
+    const response = await withAuth(makeRequest("valid-token"), handler);
+
+    expect(response.status).toBe(404);
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+describe("withAdmin", () => {
+  it("calls handler when user is MASTER_ADMIN", async () => {
+    const admin = makeUsuario({ papelPlataforma: "MASTER_ADMIN" });
+    (verifyToken as jest.Mock).mockReturnValue({ sub: "user-1" });
+    mockFindById.mockResolvedValue(admin);
+
+    const handler = jest.fn().mockResolvedValue(new Response("ok"));
+    const response = await withAdmin(makeRequest("valid-token"), handler);
+
+    expect(handler).toHaveBeenCalledWith(expect.any(Request), admin);
+    expect(response.status).toBe(200);
+  });
+
+  it("returns 403 when user is not MASTER_ADMIN", async () => {
+    const regularUser = makeUsuario({ papelPlataforma: "USER" });
+    (verifyToken as jest.Mock).mockReturnValue({ sub: "user-1" });
+    mockFindById.mockResolvedValue(regularUser);
+
+    const handler = jest.fn();
+    const response = await withAdmin(makeRequest("valid-token"), handler);
+
+    expect(response.status).toBe(403);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when no token (inherits from withAuth)", async () => {
+    const handler = jest.fn();
+    const response = await withAdmin(makeRequest(), handler);
+
+    expect(response.status).toBe(401);
+  });
+});
+
+describe("getOptionalUser", () => {
+  it("returns user when valid token is provided", async () => {
+    const usuario = makeUsuario();
+    (verifyToken as jest.Mock).mockReturnValue({ sub: "user-1" });
+    mockFindById.mockResolvedValue(usuario);
+
+    const result = await getOptionalUser(makeRequest("valid-token"));
+
+    expect(result).toBe(usuario);
+  });
+
+  it("returns null when no token is provided", async () => {
+    const result = await getOptionalUser(makeRequest());
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when token is invalid", async () => {
+    (verifyToken as jest.Mock).mockReturnValue(null);
+
+    const result = await getOptionalUser(makeRequest("bad-token"));
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("canManageVagaForEntidade", () => {
+  it("returns true for MASTER_ADMIN regardless of membership", async () => {
+    const admin = makeUsuario({ papelPlataforma: "MASTER_ADMIN" });
+
+    const result = await canManageVagaForEntidade(admin, "entidade-1");
+
+    expect(result).toBe(true);
+    expect(mockFindActiveByUsuarioAndEntidade).not.toHaveBeenCalled();
+  });
+
+  it("returns true when user is ADMIN of the entity", async () => {
+    const user = makeUsuario();
+    mockFindActiveByUsuarioAndEntidade.mockResolvedValue({ papel: "ADMIN" });
+
+    const result = await canManageVagaForEntidade(user, "entidade-1");
+
+    expect(result).toBe(true);
+    expect(mockFindActiveByUsuarioAndEntidade).toHaveBeenCalledWith("user-1", "entidade-1");
+  });
+
+  it("returns false when user is MEMBRO (not ADMIN) of the entity", async () => {
+    const user = makeUsuario();
+    mockFindActiveByUsuarioAndEntidade.mockResolvedValue({ papel: "MEMBRO" });
+
+    const result = await canManageVagaForEntidade(user, "entidade-1");
+
+    expect(result).toBe(false);
+  });
+
+  it("returns false when user has no membership in entity", async () => {
+    const user = makeUsuario();
+    mockFindActiveByUsuarioAndEntidade.mockResolvedValue(null);
+
+    const result = await canManageVagaForEntidade(user, "entidade-1");
+
+    expect(result).toBe(false);
+  });
+});

--- a/src/lib/server/services/auth/__tests__/register.test.ts
+++ b/src/lib/server/services/auth/__tests__/register.test.ts
@@ -1,5 +1,4 @@
-import { register } from "../register";
-import type { RegisterDependencies } from "../register";
+import { register, type RegisterDependencies } from "../register";
 import type { UsuarioWithRelations, Centro, Curso } from "@/lib/server/db/interfaces/types";
 
 // Mock bcryptjs

--- a/src/lib/server/services/auth/__tests__/register.test.ts
+++ b/src/lib/server/services/auth/__tests__/register.test.ts
@@ -105,7 +105,7 @@ describe("register", () => {
     const deps = makeDeps();
 
     await expect(register({ ...validInput, email: "test@gmail.com" }, deps)).rejects.toThrow(
-      "Apenas emails acadêmicos"
+      "Apenas e-mails institucionais"
     );
   });
 

--- a/src/lib/server/services/auth/__tests__/register.test.ts
+++ b/src/lib/server/services/auth/__tests__/register.test.ts
@@ -1,0 +1,169 @@
+import { register } from "../register";
+import type { RegisterDependencies } from "../register";
+import type { UsuarioWithRelations, Centro, Curso } from "@/lib/server/db/interfaces/types";
+
+// Mock bcryptjs
+jest.mock("bcryptjs", () => ({
+  hash: jest.fn().mockResolvedValue("hashed-password"),
+}));
+
+// Mock env - email disabled by default (auto-verify)
+jest.mock("@/lib/server/config/env", () => ({
+  MASTER_ADMIN_EMAILS: ["admin@gmail.com"],
+  EMAIL_ENABLED: false,
+}));
+
+// Mock logger
+jest.mock("@/lib/server/utils/logger", () => ({
+  createLogger: () => ({ error: jest.fn(), info: jest.fn(), warn: jest.fn(), debug: jest.fn() }),
+}));
+
+const mockCentro: Centro = {
+  id: "centro-1",
+  nome: "CI",
+  sigla: "CI",
+  descricao: null,
+  campusId: "campus-1",
+};
+
+const mockCurso = {
+  id: "curso-1",
+  nome: "Ciência da Computação",
+  centroId: "centro-1",
+  criadoEm: new Date(),
+  atualizadoEm: new Date(),
+} as Curso;
+
+const mockCreatedUser = {
+  id: "new-user-id",
+  nome: "Test User",
+  email: "test@academico.ufpb.br",
+  centro: mockCentro,
+  curso: mockCurso,
+} as UsuarioWithRelations;
+
+function makeDeps(overrides: Partial<RegisterDependencies> = {}): RegisterDependencies {
+  return {
+    usuariosRepository: {
+      findByEmail: jest.fn().mockResolvedValue(null),
+      create: jest.fn().mockResolvedValue(mockCreatedUser),
+    } as any,
+    centrosRepository: {
+      findById: jest.fn().mockResolvedValue(mockCentro),
+    } as any,
+    cursosRepository: {
+      findById: jest.fn().mockResolvedValue(mockCurso),
+    } as any,
+    tokenVerificacaoRepository: {
+      create: jest.fn().mockResolvedValue({ id: "token-1" }),
+    } as any,
+    emailService: {
+      sendVerificationEmail: jest.fn().mockResolvedValue(undefined),
+      sendPasswordResetEmail: jest.fn(),
+    },
+    ...overrides,
+  };
+}
+
+const validInput = {
+  nome: "Test User",
+  email: "test@academico.ufpb.br",
+  senha: "password123",
+  centroId: "centro-1",
+  cursoId: "curso-1",
+};
+
+describe("register", () => {
+  it("creates user with auto-verification when email is disabled", async () => {
+    const deps = makeDeps();
+
+    const result = await register(validInput, deps);
+
+    expect(result.usuarioId).toBe("new-user-id");
+    expect(result.autoVerificado).toBe(true);
+    expect(deps.usuariosRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nome: "Test User",
+        email: "test@academico.ufpb.br",
+        senhaHash: "hashed-password",
+        eVerificado: true,
+        papelPlataforma: "USER",
+      })
+    );
+    // No token created when auto-verified
+    expect(deps.tokenVerificacaoRepository.create).not.toHaveBeenCalled();
+  });
+
+  it("normalizes email to lowercase", async () => {
+    const deps = makeDeps();
+
+    await register({ ...validInput, email: "TEST@ACADEMICO.UFPB.BR" }, deps);
+
+    expect(deps.usuariosRepository.findByEmail).toHaveBeenCalledWith("test@academico.ufpb.br");
+  });
+
+  it("rejects non-UFPB email domains", async () => {
+    const deps = makeDeps();
+
+    await expect(register({ ...validInput, email: "test@gmail.com" }, deps)).rejects.toThrow(
+      "Apenas emails acadêmicos"
+    );
+  });
+
+  it("allows master admin emails regardless of domain", async () => {
+    const deps = makeDeps();
+
+    const result = await register({ ...validInput, email: "admin@gmail.com" }, deps);
+
+    expect(result.usuarioId).toBe("new-user-id");
+    expect(deps.usuariosRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ papelPlataforma: "MASTER_ADMIN" })
+    );
+  });
+
+  it("throws when email is already registered", async () => {
+    const deps = makeDeps({
+      usuariosRepository: {
+        findByEmail: jest.fn().mockResolvedValue(mockCreatedUser),
+        create: jest.fn(),
+      } as any,
+    });
+
+    await expect(register(validInput, deps)).rejects.toThrow("já está em uso");
+  });
+
+  it("throws when centro is not found", async () => {
+    const deps = makeDeps({
+      centrosRepository: { findById: jest.fn().mockResolvedValue(null) } as any,
+    });
+
+    await expect(register(validInput, deps)).rejects.toThrow("Centro não encontrado");
+  });
+
+  it("throws when curso is not found", async () => {
+    const deps = makeDeps({
+      cursosRepository: { findById: jest.fn().mockResolvedValue(null) } as any,
+    });
+
+    await expect(register(validInput, deps)).rejects.toThrow("Curso não encontrado");
+  });
+
+  it("throws when curso does not belong to selected centro", async () => {
+    const wrongCentoCurso = { ...mockCurso, centroId: "different-centro" } as Curso;
+    const deps = makeDeps({
+      cursosRepository: { findById: jest.fn().mockResolvedValue(wrongCentoCurso) } as any,
+    });
+
+    await expect(register(validInput, deps)).rejects.toThrow("não pertence ao centro");
+  });
+
+  it("assigns USER role for regular UFPB emails", async () => {
+    const deps = makeDeps();
+
+    await register(validInput, deps);
+
+    expect(deps.usuariosRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ papelPlataforma: "USER" })
+    );
+  });
+});

--- a/src/lib/server/services/auth/__tests__/resend-verification.test.ts
+++ b/src/lib/server/services/auth/__tests__/resend-verification.test.ts
@@ -1,0 +1,196 @@
+import { resendVerificationByUser, resendVerificationByEmail } from "../resend-verification";
+import type { IUsuariosRepository } from "@/lib/server/db/interfaces/usuarios-repository.interface";
+import type { ITokenVerificacaoRepository } from "@/lib/server/db/interfaces/token-verificacao-repository.interface";
+import type { IEmailService } from "@/lib/server/services/email/email-service.interface";
+import type { TokenVerificacao, UsuarioWithRelations } from "@/lib/server/db/interfaces/types";
+
+// Mock logger
+jest.mock("@/lib/server/utils/logger", () => ({
+  createLogger: () => ({ error: jest.fn(), info: jest.fn(), warn: jest.fn(), debug: jest.fn() }),
+}));
+
+function makeUsuario(overrides: Partial<UsuarioWithRelations> = {}): UsuarioWithRelations {
+  return {
+    id: "user-1",
+    nome: "Test User",
+    email: "test@academico.ufpb.br",
+    eVerificado: false,
+    centro: { id: "c1", nome: "CI", sigla: "CI", descricao: null, campusId: "campus-1" },
+    curso: { id: "k1", nome: "CC", centroId: "c1", criadoEm: new Date(), atualizadoEm: new Date() },
+    ...overrides,
+  } as UsuarioWithRelations;
+}
+
+function makeDeps(
+  usuario: UsuarioWithRelations | null = makeUsuario(),
+  lastToken: TokenVerificacao | null = null
+) {
+  return {
+    usuariosRepository: {
+      findById: jest.fn().mockResolvedValue(usuario),
+      findByEmail: jest.fn().mockResolvedValue(usuario),
+    } as unknown as IUsuariosRepository,
+    tokenVerificacaoRepository: {
+      findLatestByUsuarioIdAndTipo: jest.fn().mockResolvedValue(lastToken),
+      deleteByUsuarioIdAndTipo: jest.fn().mockResolvedValue(undefined),
+      create: jest.fn().mockResolvedValue({ id: "new-token-id" }),
+      findByToken: jest.fn(),
+      markAsUsed: jest.fn(),
+      deleteExpiredTokens: jest.fn(),
+    } as unknown as ITokenVerificacaoRepository,
+    emailService: {
+      sendVerificationEmail: jest.fn().mockResolvedValue(undefined),
+      sendPasswordResetEmail: jest.fn(),
+    } as IEmailService,
+  };
+}
+
+describe("resendVerificationByUser", () => {
+  it("sends verification email for unverified user", async () => {
+    const deps = makeDeps();
+
+    const result = await resendVerificationByUser({ usuarioId: "user-1" }, deps);
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("Email de verificação enviado");
+    expect(deps.tokenVerificacaoRepository.deleteByUsuarioIdAndTipo).toHaveBeenCalledWith(
+      "user-1",
+      "VERIFICACAO_EMAIL"
+    );
+    expect(deps.tokenVerificacaoRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        usuarioId: "user-1",
+        tipo: "VERIFICACAO_EMAIL",
+        token: expect.any(String),
+        expiraEm: expect.any(Date),
+      })
+    );
+    expect(deps.emailService.sendVerificationEmail).toHaveBeenCalled();
+  });
+
+  it("throws when user is not found", async () => {
+    const deps = makeDeps(null);
+
+    await expect(resendVerificationByUser({ usuarioId: "missing" }, deps)).rejects.toThrow(
+      "Usuário não encontrado"
+    );
+  });
+
+  it("throws when user has no email", async () => {
+    const noEmailUser = makeUsuario({ email: null });
+    const deps = makeDeps(noEmailUser);
+
+    await expect(resendVerificationByUser({ usuarioId: "user-1" }, deps)).rejects.toThrow(
+      "não possui email"
+    );
+  });
+
+  it("returns early if already verified", async () => {
+    const verifiedUser = makeUsuario({ eVerificado: true });
+    const deps = makeDeps(verifiedUser);
+
+    const result = await resendVerificationByUser({ usuarioId: "user-1" }, deps);
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("já está verificado");
+    expect(deps.emailService.sendVerificationEmail).not.toHaveBeenCalled();
+  });
+
+  it("rate limits - throws if last token was created less than 1 minute ago", async () => {
+    const recentToken = { id: "t1", criadoEm: new Date() } as TokenVerificacao;
+    const deps = makeDeps(makeUsuario(), recentToken);
+
+    await expect(resendVerificationByUser({ usuarioId: "user-1" }, deps)).rejects.toThrow(
+      "Aguarde pelo menos 1 minuto"
+    );
+  });
+
+  it("allows resend if last token is older than 1 minute", async () => {
+    const oldToken = {
+      id: "t1",
+      criadoEm: new Date(Date.now() - 2 * 60 * 1000),
+    } as TokenVerificacao;
+    const deps = makeDeps(makeUsuario(), oldToken);
+
+    const result = await resendVerificationByUser({ usuarioId: "user-1" }, deps);
+
+    expect(result.success).toBe(true);
+    expect(deps.emailService.sendVerificationEmail).toHaveBeenCalled();
+  });
+
+  it("throws when email sending fails", async () => {
+    const deps = makeDeps();
+    (deps.emailService.sendVerificationEmail as jest.Mock).mockRejectedValue(
+      new Error("SMTP error")
+    );
+
+    await expect(resendVerificationByUser({ usuarioId: "user-1" }, deps)).rejects.toThrow(
+      "Falha ao enviar email"
+    );
+  });
+});
+
+describe("resendVerificationByEmail", () => {
+  it("always returns success message (enumeration prevention)", async () => {
+    const deps = makeDeps();
+    const result = await resendVerificationByEmail({ email: "test@academico.ufpb.br" }, deps);
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("Se o email estiver cadastrado");
+  });
+
+  it("returns success when user does not exist", async () => {
+    const deps = makeDeps(null);
+    const result = await resendVerificationByEmail({ email: "missing@academico.ufpb.br" }, deps);
+
+    expect(result.success).toBe(true);
+    expect(deps.tokenVerificacaoRepository.create).not.toHaveBeenCalled();
+  });
+
+  it("returns success when user is already verified (no email sent)", async () => {
+    const verifiedUser = makeUsuario({ eVerificado: true });
+    const deps = makeDeps(verifiedUser);
+
+    const result = await resendVerificationByEmail({ email: "test@academico.ufpb.br" }, deps);
+
+    expect(result.success).toBe(true);
+    expect(deps.emailService.sendVerificationEmail).not.toHaveBeenCalled();
+  });
+
+  it("normalizes email to lowercase and trims", async () => {
+    const deps = makeDeps();
+    await resendVerificationByEmail({ email: "  TEST@ACADEMICO.UFPB.BR  " }, deps);
+
+    expect(deps.usuariosRepository.findByEmail).toHaveBeenCalledWith("test@academico.ufpb.br");
+  });
+
+  it("rate limits silently - returns success without creating token", async () => {
+    const recentToken = { id: "t1", criadoEm: new Date() } as TokenVerificacao;
+    const deps = makeDeps(makeUsuario(), recentToken);
+
+    const result = await resendVerificationByEmail({ email: "test@academico.ufpb.br" }, deps);
+
+    expect(result.success).toBe(true);
+    expect(deps.tokenVerificacaoRepository.create).not.toHaveBeenCalled();
+  });
+
+  it("sends email for valid unverified user", async () => {
+    const deps = makeDeps();
+
+    await resendVerificationByEmail({ email: "test@academico.ufpb.br" }, deps);
+
+    expect(deps.tokenVerificacaoRepository.create).toHaveBeenCalled();
+    expect(deps.emailService.sendVerificationEmail).toHaveBeenCalled();
+  });
+
+  it("returns success even when email sending fails", async () => {
+    const deps = makeDeps();
+    (deps.emailService.sendVerificationEmail as jest.Mock).mockRejectedValue(
+      new Error("SMTP error")
+    );
+
+    const result = await resendVerificationByEmail({ email: "test@academico.ufpb.br" }, deps);
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/lib/server/services/auth/__tests__/reset-password.test.ts
+++ b/src/lib/server/services/auth/__tests__/reset-password.test.ts
@@ -1,0 +1,131 @@
+import { resetPassword } from "../reset-password";
+import type { IUsuariosRepository } from "@/lib/server/db/interfaces/usuarios-repository.interface";
+import type { ITokenVerificacaoRepository } from "@/lib/server/db/interfaces/token-verificacao-repository.interface";
+import type { TokenVerificacao, UsuarioWithRelations } from "@/lib/server/db/interfaces/types";
+
+// Mock bcryptjs to avoid slow hashing in tests
+jest.mock("bcryptjs", () => ({
+  hash: jest.fn().mockResolvedValue("new-hashed-password"),
+}));
+
+function makeToken(overrides: Partial<TokenVerificacao> = {}): TokenVerificacao {
+  return {
+    id: "token-1",
+    usuarioId: "user-1",
+    token: "reset-token",
+    tipo: "RESET_SENHA",
+    expiraEm: new Date(Date.now() + 60 * 60 * 1000), // 1h from now
+    usadoEm: null,
+    criadoEm: new Date(),
+    ...overrides,
+  } as TokenVerificacao;
+}
+
+function makeUsuario(): UsuarioWithRelations {
+  return {
+    id: "user-1",
+    nome: "Test User",
+    email: "test@academico.ufpb.br",
+    centro: { id: "c1", nome: "CI", sigla: "CI", descricao: null, campusId: "campus-1" },
+    curso: { id: "k1", nome: "CC", centroId: "c1", criadoEm: new Date(), atualizadoEm: new Date() },
+  } as UsuarioWithRelations;
+}
+
+function makeDeps(
+  tokenData: TokenVerificacao | null = makeToken(),
+  usuario: UsuarioWithRelations | null = makeUsuario()
+) {
+  return {
+    tokenVerificacaoRepository: {
+      findByToken: jest.fn().mockResolvedValue(tokenData),
+      markAsUsed: jest.fn().mockResolvedValue(undefined),
+      create: jest.fn(),
+      findLatestByUsuarioIdAndTipo: jest.fn(),
+      deleteExpiredTokens: jest.fn(),
+      deleteByUsuarioIdAndTipo: jest.fn(),
+    } as unknown as ITokenVerificacaoRepository,
+    usuariosRepository: {
+      findById: jest.fn().mockResolvedValue(usuario),
+      updatePassword: jest.fn().mockResolvedValue(undefined),
+    } as unknown as IUsuariosRepository,
+  };
+}
+
+describe("resetPassword", () => {
+  it("resets password successfully with valid token", async () => {
+    const deps = makeDeps();
+
+    const result = await resetPassword(
+      { token: "reset-token", novaSenha: "new-strong-password" },
+      deps
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("Senha redefinida com sucesso");
+    expect(deps.usuariosRepository.updatePassword).toHaveBeenCalledWith(
+      "user-1",
+      "new-hashed-password"
+    );
+    expect(deps.tokenVerificacaoRepository.markAsUsed).toHaveBeenCalledWith("token-1");
+  });
+
+  it("throws when password is too short", async () => {
+    const deps = makeDeps();
+
+    await expect(resetPassword({ token: "reset-token", novaSenha: "short" }, deps)).rejects.toThrow(
+      "pelo menos 8 caracteres"
+    );
+  });
+
+  it("throws when password is too long", async () => {
+    const deps = makeDeps();
+    const longPassword = "a".repeat(129);
+
+    await expect(
+      resetPassword({ token: "reset-token", novaSenha: longPassword }, deps)
+    ).rejects.toThrow("no máximo 128 caracteres");
+  });
+
+  it("throws when token is not found", async () => {
+    const deps = makeDeps(null);
+
+    await expect(
+      resetPassword({ token: "bad-token", novaSenha: "valid-password-123" }, deps)
+    ).rejects.toThrow("Token inválido ou expirado");
+  });
+
+  it("throws when token is expired", async () => {
+    const expiredToken = makeToken({ expiraEm: new Date(Date.now() - 1000) });
+    const deps = makeDeps(expiredToken);
+
+    await expect(
+      resetPassword({ token: "reset-token", novaSenha: "valid-password-123" }, deps)
+    ).rejects.toThrow("Token expirado");
+  });
+
+  it("throws when token was already used", async () => {
+    const usedToken = makeToken({ usadoEm: new Date() });
+    const deps = makeDeps(usedToken);
+
+    await expect(
+      resetPassword({ token: "reset-token", novaSenha: "valid-password-123" }, deps)
+    ).rejects.toThrow("Este link já foi utilizado");
+  });
+
+  it("throws when token type is not RESET_SENHA", async () => {
+    const wrongToken = makeToken({ tipo: "VERIFICACAO_EMAIL" as TokenVerificacao["tipo"] });
+    const deps = makeDeps(wrongToken);
+
+    await expect(
+      resetPassword({ token: "reset-token", novaSenha: "valid-password-123" }, deps)
+    ).rejects.toThrow("Token inválido");
+  });
+
+  it("throws when user is not found", async () => {
+    const deps = makeDeps(makeToken(), null);
+
+    await expect(
+      resetPassword({ token: "reset-token", novaSenha: "valid-password-123" }, deps)
+    ).rejects.toThrow("Usuário não encontrado");
+  });
+});

--- a/src/lib/server/services/auth/__tests__/reset-password.test.ts
+++ b/src/lib/server/services/auth/__tests__/reset-password.test.ts
@@ -28,7 +28,7 @@ function makeUsuario(): UsuarioWithRelations {
     email: "test@academico.ufpb.br",
     centro: { id: "c1", nome: "CI", sigla: "CI", descricao: null, campusId: "campus-1" },
     curso: { id: "k1", nome: "CC", centroId: "c1", criadoEm: new Date(), atualizadoEm: new Date() },
-  } as UsuarioWithRelations;
+  } as unknown as UsuarioWithRelations;
 }
 
 function makeDeps(

--- a/src/lib/server/services/auth/__tests__/verify-email.test.ts
+++ b/src/lib/server/services/auth/__tests__/verify-email.test.ts
@@ -1,0 +1,112 @@
+import { verifyEmail } from "../verify-email";
+import type { IUsuariosRepository } from "@/lib/server/db/interfaces/usuarios-repository.interface";
+import type { ITokenVerificacaoRepository } from "@/lib/server/db/interfaces/token-verificacao-repository.interface";
+import type { TokenVerificacao, UsuarioWithRelations } from "@/lib/server/db/interfaces/types";
+
+function makeToken(overrides: Partial<TokenVerificacao> = {}): TokenVerificacao {
+  return {
+    id: "token-1",
+    usuarioId: "user-1",
+    token: "valid-token",
+    tipo: "VERIFICACAO_EMAIL",
+    expiraEm: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24h from now
+    usadoEm: null,
+    criadoEm: new Date(),
+    ...overrides,
+  } as TokenVerificacao;
+}
+
+function makeUsuario(overrides: Partial<UsuarioWithRelations> = {}): UsuarioWithRelations {
+  return {
+    id: "user-1",
+    nome: "Test User",
+    email: "test@academico.ufpb.br",
+    eVerificado: false,
+    centro: { id: "c1", nome: "CI", sigla: "CI", descricao: null, campusId: "campus-1" },
+    curso: { id: "k1", nome: "CC", centroId: "c1", criadoEm: new Date(), atualizadoEm: new Date() },
+    ...overrides,
+  } as UsuarioWithRelations;
+}
+
+function makeDeps(
+  tokenData: TokenVerificacao | null = makeToken(),
+  usuario: UsuarioWithRelations | null = makeUsuario()
+) {
+  return {
+    tokenVerificacaoRepository: {
+      findByToken: jest.fn().mockResolvedValue(tokenData),
+      markAsUsed: jest.fn().mockResolvedValue(undefined),
+      create: jest.fn(),
+      findLatestByUsuarioIdAndTipo: jest.fn(),
+      deleteExpiredTokens: jest.fn(),
+      deleteByUsuarioIdAndTipo: jest.fn(),
+    } as unknown as ITokenVerificacaoRepository,
+    usuariosRepository: {
+      findById: jest.fn().mockResolvedValue(usuario),
+      markAsVerified: jest.fn().mockResolvedValue(undefined),
+    } as unknown as IUsuariosRepository,
+  };
+}
+
+describe("verifyEmail", () => {
+  it("verifies email successfully with valid token", async () => {
+    const deps = makeDeps();
+
+    const result = await verifyEmail({ token: "valid-token" }, deps);
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("verificado com sucesso");
+    expect(deps.usuariosRepository.markAsVerified).toHaveBeenCalledWith("user-1");
+    expect(deps.tokenVerificacaoRepository.markAsUsed).toHaveBeenCalledWith("token-1");
+  });
+
+  it("throws when token is not found", async () => {
+    const deps = makeDeps(null);
+
+    await expect(verifyEmail({ token: "bad-token" }, deps)).rejects.toThrow(
+      "Token inválido ou expirado"
+    );
+  });
+
+  it("throws when token is expired", async () => {
+    const expiredToken = makeToken({ expiraEm: new Date(Date.now() - 1000) });
+    const deps = makeDeps(expiredToken);
+
+    await expect(verifyEmail({ token: "valid-token" }, deps)).rejects.toThrow("Token expirado");
+  });
+
+  it("throws when token was already used", async () => {
+    const usedToken = makeToken({ usadoEm: new Date() });
+    const deps = makeDeps(usedToken);
+
+    await expect(verifyEmail({ token: "valid-token" }, deps)).rejects.toThrow(
+      "Este link já foi utilizado"
+    );
+  });
+
+  it("throws when token type is not VERIFICACAO_EMAIL", async () => {
+    const wrongTypeToken = makeToken({ tipo: "RESET_SENHA" as TokenVerificacao["tipo"] });
+    const deps = makeDeps(wrongTypeToken);
+
+    await expect(verifyEmail({ token: "valid-token" }, deps)).rejects.toThrow("Token inválido");
+  });
+
+  it("throws when user is not found", async () => {
+    const deps = makeDeps(makeToken(), null);
+
+    await expect(verifyEmail({ token: "valid-token" }, deps)).rejects.toThrow(
+      "Usuário não encontrado"
+    );
+  });
+
+  it("returns success without re-verifying if already verified", async () => {
+    const verifiedUser = makeUsuario({ eVerificado: true });
+    const deps = makeDeps(makeToken(), verifiedUser);
+
+    const result = await verifyEmail({ token: "valid-token" }, deps);
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("já verificado");
+    expect(deps.usuariosRepository.markAsVerified).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- **Auth services** (66 tests): authenticate, register, verify-email, reset-password, forgot-password, resend-verification, and middleware — covers password handling, token lifecycle, email enumeration prevention, rate limiting, and permission checks
- **Admin mutations** (45 tests): merge-facade-user service (conflict detection, cascade delete, membership transfer), user deletion route, role update route, and entity member add/update/delete routes with permission guards
- **Onboarding state machine** (18 tests): step ordering, conditional visibility (turmas requires cursando + PAAS), periodo auto-detection, semester-based steps, PAAS availability matching, and completion/skip mutations

First server-side test coverage in the project. Total test count goes from 153 to 312.

## Test plan

- [x] All 129 new tests pass locally
- [x] Existing 183 tests unaffected (264 Jest + 48 Vitest = 312 total)
- [x] Lint, format, and type-check pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)