### PR TITLE
fix(onboarding): hide onboarding when between semesters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Submodule**: Remove `aquario-vagas` git submodule and all references (repo was deleted). Vagas now fully served via backend API
 
 ### Changed
+- **Onboarding**: Hide onboarding entirely when between semesters — only show it when today falls within an active semester's date range
 - **UI**: Replace native date inputs with DatePicker across all forms — entities, memberships, vagas, and calendar management (#167)
 - **Users**:  Otimiza verificação de unicidade de slug em `prisma-usuarios-repository.ts`, limitando a consulta de existência a `select: { id: true }` para reduzir payload por iteração.
 

--- a/src/lib/client/hooks/__tests__/use-onboarding.integration.test.tsx
+++ b/src/lib/client/hooks/__tests__/use-onboarding.integration.test.tsx
@@ -32,7 +32,12 @@ vi.mock("@/lib/client/hooks/use-usuarios", () => ({
 
 vi.mock("@/lib/client/hooks/use-calendario-academico", () => ({
   useSemestreAtivo: vi.fn(() => ({
-    data: { id: "sem-1", nome: "2025.1" },
+    data: {
+      id: "sem-1",
+      nome: "2025.1",
+      dataInicio: "2025-01-01T00:00:00.000Z",
+      dataFim: "2099-12-31T23:59:59.999Z",
+    },
   })),
 }));
 
@@ -82,7 +87,12 @@ describe("useOnboarding", () => {
     } as ReturnType<typeof useCurrentUser>);
 
     mockUseSemestreAtivo.mockReturnValue({
-      data: { id: "sem-1", nome: "2025.1" },
+      data: {
+        id: "sem-1",
+        nome: "2025.1",
+        dataInicio: "2025-01-01T00:00:00.000Z",
+        dataFim: "2099-12-31T23:59:59.999Z",
+      },
     } as ReturnType<typeof useSemestreAtivo>);
 
     mockUsePaasCalendar.mockReturnValue({
@@ -161,6 +171,28 @@ describe("useOnboarding", () => {
 
       const stepIds = result.current.steps.map(s => s.id);
       expect(stepIds).not.toContain("turmas");
+    });
+
+    it("hides entire onboarding when in gray zone between semesters", async () => {
+      mockUseSemestreAtivo.mockReturnValue({
+        data: {
+          id: "sem-2",
+          nome: "2099.1",
+          dataInicio: "2099-01-01T00:00:00.000Z",
+          dataFim: "2099-06-30T23:59:59.999Z",
+        },
+      } as ReturnType<typeof useSemestreAtivo>);
+
+      const meta = freshMetadata();
+      mockGetMetadata.mockResolvedValue(meta);
+
+      const { result } = renderHookWithProviders(() => useOnboarding());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.shouldShow).toBe(false);
     });
 
     it("hides cursando step when no active semester", async () => {

--- a/src/lib/client/hooks/use-onboarding.ts
+++ b/src/lib/client/hooks/use-onboarding.ts
@@ -246,7 +246,8 @@ export const useOnboarding = () => {
   );
 
   const isLoading = isAuthLoading || isMetadataLoading;
-  const shouldShow = isAuthenticated && !isLoading && isMetadataFetched && !status.isComplete && isInsideSemester;
+  const shouldShow =
+    isAuthenticated && !isLoading && isMetadataFetched && !status.isComplete && isInsideSemester;
 
   return {
     ...status,

--- a/src/lib/client/hooks/use-onboarding.ts
+++ b/src/lib/client/hooks/use-onboarding.ts
@@ -101,6 +101,12 @@ export const useOnboarding = () => {
     paasSemestreNome === dbSemestreNome
   );
 
+  const isInsideSemester = !!(
+    semestreAtivo &&
+    new Date(semestreAtivo.dataInicio) <= new Date() &&
+    new Date(semestreAtivo.dataFim) >= new Date()
+  );
+
   const status: OnboardingStatus = useMemo(() => {
     if (!metadata || !isMetadataFetched) {
       return {
@@ -113,7 +119,7 @@ export const useOnboarding = () => {
     }
 
     const m = metadata as OnboardingMetadata;
-    const semNome = semestreAtivo?.nome;
+    const semNome = isInsideSemester ? semestreAtivo?.nome : undefined;
     const semesterMeta = semNome ? m.semesters?.[semNome] : undefined;
 
     // Build the full list of relevant steps (both completed and pending)
@@ -185,7 +191,7 @@ export const useOnboarding = () => {
       completedCount,
       totalCount: allSteps.length,
     };
-  }, [metadata, isMetadataFetched, semestreAtivo?.nome, user?.periodoAtual, paasAvailable]);
+  }, [metadata, isMetadataFetched, semestreAtivo, user?.periodoAtual, paasAvailable]);
 
   const completeStep = useCallback(
     async (stepId: OnboardingStepId) => {
@@ -240,7 +246,7 @@ export const useOnboarding = () => {
   );
 
   const isLoading = isAuthLoading || isMetadataLoading;
-  const shouldShow = isAuthenticated && !isLoading && isMetadataFetched && !status.isComplete;
+  const shouldShow = isAuthenticated && !isLoading && isMetadataFetched && !status.isComplete && isInsideSemester;
 
   return {
     ...status,


### PR DESCRIPTION
## Summary
- Hide the entire onboarding modal when the current date falls outside any semester's `dataInicio`–`dataFim` range (gray zone between semesters)
- Per-semester steps (`cursando`, `turmas`) also exclude the upcoming semester's name so no steps are built for a semester that hasn't started
- Added test for gray zone scenario; updated existing test mocks to include semester date fields

## Test plan
- [x] All 19 onboarding integration tests pass
- [ ] Verify onboarding does not appear when logged in between semesters
- [ ] Verify onboarding appears normally when logged in during an active semester

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Onboarding now appears only during an active semester; it is hidden when the current date falls outside the semester date range.
* **Tests**
  * Added an integration test to verify onboarding is hidden in the gap between semesters.
* **Documentation**
  * Changelog updated to record this onboarding visibility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->