### PR TITLE
feat(openapi): add interactive API documentation with Scalar UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **API Docs**: Interactive OpenAPI 3.1 documentation rendered with Scalar UI at `/api-docs`, covering all 56 API endpoints with request/response schemas, examples, and error codes (#149)
+- **API Docs**: JSON spec endpoint at `GET /api/openapi` for tooling integration (Postman, Insomnia, SDK generators)
 - **Grades Curriculares**: Botão para exportar grade curricular como imagem PNG — "Com meu progresso" (barra de progresso e stats) e "Grade limpa" (#169)
 - **UI**: DatePicker component with Calendar popover, pt-BR locale, and date range constraints
 - **Search**: Global search command palette (Ctrl+K) with unified search across pages, guides, entities, jobs, disciplines, courses, and user profiles
@@ -18,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Submodule**: Remove `aquario-vagas` git submodule and all references (repo was deleted). Vagas now fully served via backend API
 
 ### Changed
+- **API**: Extract Zod validation schemas from route handlers into `src/lib/server/api-schemas/` for Next.js 15 App Router compatibility
 - **UI**: Replace native date inputs with DatePicker across all forms — entities, memberships, vagas, and calendar management (#167)
 - **Users**:  Otimiza verificação de unicidade de slug em `prisma-usuarios-repository.ts`, limitando a consulta de existência a `select: { id: true }` para reduzir payload por iteração.
 

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -273,7 +273,7 @@ Interactive API docs are available at [`/api-docs`](http://localhost:3000/api-do
 
 ### How it works
 
-```
+```text
 Zod schemas (api-schemas/)           →  zod-to-openapi  →  OpenAPI 3.1 JSON  →  Scalar UI
 Route handler error codes (route.ts) →  paths/*.ts       →  (same spec)       →  (same page)
 ```
@@ -294,7 +294,7 @@ All 56 API endpoints are documented with request/response schemas, examples, and
 
 ### File structure
 
-```
+```text
 src/lib/server/
 ├── api-schemas/          # Zod schemas (shared between routes and OpenAPI)
 │   ├── auth.ts

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -267,6 +267,55 @@ describe("useData", () => {
 
 ---
 
+## API Documentation
+
+Interactive API docs are available at [`/api-docs`](http://localhost:3000/api-docs) (Scalar UI) and the raw OpenAPI 3.1 spec at [`GET /api/openapi`](http://localhost:3000/api/openapi).
+
+### How it works
+
+```
+Zod schemas (api-schemas/)           →  zod-to-openapi  →  OpenAPI 3.1 JSON  →  Scalar UI
+Route handler error codes (route.ts) →  paths/*.ts       →  (same spec)       →  (same page)
+```
+
+All 56 API endpoints are documented with request/response schemas, examples, and error codes — generated from the same Zod schemas used for runtime validation.
+
+### Adding docs for a new endpoint
+
+1. **Create the path file** in `src/lib/server/openapi/paths/` (or add to an existing one)
+2. **Register it** in `src/lib/server/openapi/paths/index.ts`
+3. **Use `errorResponses()`** with examples matching the actual `ApiError.xxx()` calls in the route handler:
+   ```typescript
+   ...errorResponses([400, 404], {
+     404: { message: "Recurso não encontrado", code: "NOT_FOUND" },
+   })
+   ```
+4. **Run tests**: `npm run test` — the generator test validates spec structure and endpoint count
+
+### File structure
+
+```
+src/lib/server/
+├── api-schemas/          # Zod schemas (shared between routes and OpenAPI)
+│   ├── auth.ts
+│   ├── usuarios.ts
+│   ├── entidades.ts
+│   ├── vagas.ts
+│   └── calendario.ts
+└── openapi/
+    ├── registry.ts       # Tags and security scheme
+    ├── generator.ts      # Spec generation with lazy cache
+    ├── common-schemas.ts # Shared error/pagination schemas + errorResponses()
+    └── paths/            # One file per resource group
+        ├── index.ts      # Registers all path groups
+        ├── auth.ts
+        ├── usuarios.ts
+        ├── entidades.ts
+        └── ...
+```
+
+---
+
 ## Code Style
 
 ### Tools

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.3.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@asteasolutions/zod-to-openapi": "^7.3.4",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
@@ -35,6 +36,7 @@
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-toast": "^1.2.15",
         "@radix-ui/react-tooltip": "^1.2.8",
+        "@scalar/api-reference-react": "^0.9.20",
         "@tanstack/react-query": "^5.90.5",
         "@tanstack/react-query-devtools": "^5.90.2",
         "@tiptap/extension-blockquote": "^2.10.0",
@@ -126,6 +128,69 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.13.tgz",
+      "integrity": "sha512-g7nE4PFtngOZNZSy1lOPpkC+FAiHxqBJXqyRMEG7NUrEVZlz5goBdtHg1YgWRJIX776JTXAmbOI5JreAKVAsVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.2",
+        "@ai-sdk/provider-utils": "4.0.5",
+        "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.2.tgz",
+      "integrity": "sha512-HrEmNt/BH/hkQ7zpi2o6N3k1ZR1QTb7z85WYhYygiTxOQuaml4CMtHCWRbric5WPU+RNsYI7r1EpyVQMKO1pYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.5.tgz",
+      "integrity": "sha512-Ow/X/SEkeExTTc1x+nYLB9ZHK2WUId8+9TlkamAx7Tl9vxU+cKzWx2dwjgMHeCN6twrgwkLrrtqckQeO4mxgVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.2",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/vue": {
+      "version": "3.0.33",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/vue/-/vue-3.0.33.tgz",
+      "integrity": "sha512-czM9Js3a7f+Eo35gjEYEeJYUoPvMg5Dfi4bOLyDBghLqn0gaVg8yTmTaSuHCg+3K/+1xPjyXd4+2XcQIohWWiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "4.0.5",
+        "ai": "6.0.33",
+        "swrv": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "vue": "^3.3.4"
+      }
+    },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
@@ -193,6 +258,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@asteasolutions/zod-to-openapi": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@asteasolutions/zod-to-openapi/-/zod-to-openapi-7.3.4.tgz",
+      "integrity": "sha512-/2rThQ5zPi9OzVwes6U7lK1+Yvug0iXu25olp7S0XsYmOqnyMfxH7gdSQjn/+DSOHRg7wnotwGJSyL+fBKdnEA==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi3-ts": "^4.1.2"
+      },
+      "peerDependencies": {
+        "zod": "^3.20.2"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
@@ -223,7 +300,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -402,12 +478,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -729,9 +805,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -747,6 +823,160 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
+      "integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
+      "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.11.tgz",
+      "integrity": "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.12"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
+      "integrity": "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-json": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
+      "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/json": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-xml": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-xml/-/lang-xml-6.1.0.tgz",
+      "integrity": "sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/xml": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-yaml": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-yaml/-/lang-yaml-6.1.3.tgz",
+      "integrity": "sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.2.0",
+        "@lezer/lr": "^1.0.0",
+        "@lezer/yaml": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
+      "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.41.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.41.0.tgz",
+      "integrity": "sha512-6H/qadXsVuDY219Yljhohglve8xf4B8xJkVOEWfA5uiYKiTFppjqsvsfR5iPA0RbvRBoOyTZpbLIxe9+0UR8xA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.6.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
@@ -836,7 +1066,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -880,7 +1109,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -909,7 +1137,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1037,7 +1264,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1081,7 +1307,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1134,7 +1359,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1151,7 +1375,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1168,7 +1391,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1185,7 +1407,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1202,7 +1423,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1219,7 +1439,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1236,7 +1455,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1253,7 +1471,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1270,7 +1487,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1287,7 +1503,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1304,7 +1519,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1321,7 +1535,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1338,7 +1551,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1355,7 +1567,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1372,7 +1583,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1389,7 +1599,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1406,7 +1615,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1423,7 +1631,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1440,7 +1647,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1457,7 +1663,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1474,7 +1679,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1491,7 +1695,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1508,7 +1711,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1525,7 +1727,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1542,7 +1743,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1559,7 +1759,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1795,6 +1994,70 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@floating-ui/vue": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/vue/-/vue-1.1.9.tgz",
+      "integrity": "sha512-BfNqNW6KA83Nexspgb9DZuz578R7HT8MZw1CfK9I6Ah4QReNWEJsXWHN+SdmOVLNGmTPDi+fDT535Df5PzMLbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.4",
+        "@floating-ui/utils": "^0.2.10",
+        "vue-demi": ">=0.13.0"
+      }
+    },
+    "node_modules/@floating-ui/vue/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@headlessui/tailwindcss": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@headlessui/tailwindcss/-/tailwindcss-0.2.2.tgz",
+      "integrity": "sha512-xNe42KjdyA4kfUKLLPGzME9zkH7Q3rOZ5huFihWNWOQFxnItxPB3/67yBI8/qBfY8nwBRx5GHn4VprsoluVMGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "tailwindcss": "^3.0 || ^4.0"
+      }
+    },
+    "node_modules/@headlessui/vue": {
+      "version": "1.7.23",
+      "resolved": "https://registry.npmjs.org/@headlessui/vue/-/vue-1.7.23.tgz",
+      "integrity": "sha512-JzdCNqurrtuu0YW6QaDtR2PIYCKPUWq28csDyMvN4zmGccmE7lz40Is6hc3LA4HFeCI7sekZ/PQMTNmn9I/4Wg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/vue-virtual": "^3.0.0-beta.60"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -2312,6 +2575,24 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@internationalized/date": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.0.tgz",
+      "integrity": "sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.5.tgz",
+      "integrity": "sha512-6hY4Kl4HPBvtfS62asS/R22JzNNy8vi/Ssev7x6EobfCp+9QIB2hKvI2EtbdJ0VSQacxVNtqhE/NmF/NZ0gm6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -2936,6 +3217,102 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/css": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.3.tgz",
+      "integrity": "sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
+      "integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
+      "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
+      "integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/xml": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@lezer/xml/-/xml-1.0.6.tgz",
+      "integrity": "sha512-CdDwirL0OEaStFue/66ZmFSeppuL6Dwjlk8qk153mSQwiSH/Dlri4GNymrNWnUmPl2Um7QfV1FO9KFUyX3Twww==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/yaml": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@lezer/yaml/-/yaml-1.0.4.tgz",
+      "integrity": "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.4.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
+    },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-6.5.0.tgz",
@@ -2977,7 +3354,6 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.5.0.tgz",
       "integrity": "sha512-yjvtXoFcrPLGtgKRxFaH6OQPtcLPhkloC0BML6rBG5UeldR0nPULR/2E2BfXdo5JNV7j7lOzrrLX2Qf/iSidow==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@mui/core-downloads-tracker": "^6.5.0",
@@ -3399,6 +3775,252 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
+      "integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.208.0.tgz",
+      "integrity": "sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-exporter-base": "0.208.0",
+        "@opentelemetry/otlp-transformer": "0.208.0",
+        "@opentelemetry/sdk-logs": "0.208.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.208.0.tgz",
+      "integrity": "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-transformer": "0.208.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.208.0.tgz",
+      "integrity": "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/sdk-logs": "0.208.0",
+        "@opentelemetry/sdk-metrics": "2.2.0",
+        "@opentelemetry/sdk-trace-base": "2.2.0",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.1.tgz",
+      "integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.208.0.tgz",
+      "integrity": "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.2.0.tgz",
+      "integrity": "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
+      "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@parcel/watcher": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
@@ -3695,6 +4317,12 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@phosphor-icons/core": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@phosphor-icons/core/-/core-2.1.1.tgz",
+      "integrity": "sha512-v4ARvrip4qBCImOE5rmPUylOEK4iiED9ZyKjcvzuezqMaiRASCHKcRIuvvxL/twvLpkfnEODCOJp5dM4eZilxQ==",
+      "license": "MIT"
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -3744,6 +4372,12 @@
       "dependencies": {
         "cross-spawn": "^7.0.6"
       }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.363.2",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.363.2.tgz",
+      "integrity": "sha512-UcUwHEd2LXxWq4bW/I4TbwYcA+BHO/cSuHcNpGXjRCp76eJk1eOuQnm/a3MrfHtbt2X11CQu+eWpqiSgcv+X6A==",
+      "license": "MIT"
     },
     "node_modules/@prisma/client": {
       "version": "6.19.1",
@@ -3829,6 +4463,70 @@
       "dependencies": {
         "@prisma/debug": "6.19.3"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -6169,6 +6867,17 @@
       "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
       "license": "MIT"
     },
+    "node_modules/@replit/codemirror-css-color-picker": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@replit/codemirror-css-color-picker/-/codemirror-css-color-picker-6.3.0.tgz",
+      "integrity": "sha512-19biDANghUm7Fz7L1SNMIhK48tagaWuCOHj4oPPxc7hxPGkTVY2lU/jVZ8tsbTKQPVG7BO2CBDzs7CBwb20t4A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.53",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.53.tgz",
@@ -6540,6 +7249,805 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@scalar/agent-chat": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@scalar/agent-chat/-/agent-chat-0.10.1.tgz",
+      "integrity": "sha512-VjGMuuqtxgdxL59eOjaTEKTc8YYiBdegwuc4wiaFMdo6LLowkUDrx4PgwfO2DBZ032uBqZyjaWQemE0DA2CsSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ai-sdk/vue": "3.0.33",
+        "@scalar/api-client": "2.41.0",
+        "@scalar/components": "0.21.3",
+        "@scalar/helpers": "0.4.3",
+        "@scalar/icons": "0.7.2",
+        "@scalar/json-magic": "0.12.5",
+        "@scalar/openapi-types": "0.7.0",
+        "@scalar/themes": "0.15.2",
+        "@scalar/types": "0.7.6",
+        "@scalar/use-toasts": "0.10.1",
+        "@scalar/workspace-store": "0.43.1",
+        "@vueuse/core": "13.9.0",
+        "ai": "6.0.33",
+        "js-base64": "^3.7.8",
+        "neverpanic": "0.0.7",
+        "truncate-json": "3.0.1",
+        "vue": "^3.5.30",
+        "whatwg-mimetype": "4.0.0",
+        "zod": "^4.3.5"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/agent-chat/node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@scalar/agent-chat/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@scalar/api-client": {
+      "version": "2.41.0",
+      "resolved": "https://registry.npmjs.org/@scalar/api-client/-/api-client-2.41.0.tgz",
+      "integrity": "sha512-7olL0H8zESePpKSmJwalP0u2RK00qEUHL8gHDEukIyjVF0oDZK/JCCXPSCtg94A+kWTG+e6BMtjhp0WWIqf2dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@headlessui/tailwindcss": "^0.2.2",
+        "@headlessui/vue": "1.7.23",
+        "@scalar/components": "0.21.3",
+        "@scalar/draggable": "0.4.1",
+        "@scalar/helpers": "0.4.3",
+        "@scalar/icons": "0.7.2",
+        "@scalar/import": "0.5.4",
+        "@scalar/json-magic": "0.12.5",
+        "@scalar/oas-utils": "0.10.16",
+        "@scalar/object-utils": "1.3.4",
+        "@scalar/openapi-types": "0.7.0",
+        "@scalar/postman-to-openapi": "0.6.1",
+        "@scalar/sidebar": "0.8.18",
+        "@scalar/snippetz": "0.7.8",
+        "@scalar/themes": "0.15.2",
+        "@scalar/typebox": "^0.1.3",
+        "@scalar/types": "0.7.6",
+        "@scalar/use-codemirror": "0.14.11",
+        "@scalar/use-hooks": "0.4.2",
+        "@scalar/use-toasts": "0.10.1",
+        "@scalar/workspace-store": "0.43.1",
+        "@types/har-format": "^1.2.16",
+        "@vueuse/core": "13.9.0",
+        "@vueuse/integrations": "13.9.0",
+        "focus-trap": "^7.8.0",
+        "fuse.js": "^7.1.0",
+        "js-base64": "^3.7.8",
+        "microdiff": "^1.5.0",
+        "monaco-editor": "0.54.0",
+        "monaco-yaml": "5.2.3",
+        "nanoid": "^5.1.6",
+        "posthog-js": "1.363.2",
+        "pretty-ms": "^9.3.0",
+        "radix-vue": "^1.9.17",
+        "shell-quote": "^1.8.3",
+        "type-fest": "^5.3.1",
+        "vite-plugin-monaco-editor": "^1.1.0",
+        "vue": "^3.5.30",
+        "vue-router": "4.6.2",
+        "whatwg-mimetype": "4.0.0",
+        "yaml": "^2.8.0",
+        "zod": "^4.3.5"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/api-client/node_modules/nanoid": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
+      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/@scalar/api-client/node_modules/type-fest": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
+      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@scalar/api-client/node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@scalar/api-client/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@scalar/api-reference": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/@scalar/api-reference/-/api-reference-1.51.0.tgz",
+      "integrity": "sha512-CmyvtSM9YNTPit1ZxfYhfAp7MtE+KXUxOID4sIf8+Flfr5zFOHVAu1ww1WySszugWG/8xV4BCZuJZtHGwtQyHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@headlessui/vue": "1.7.23",
+        "@scalar/agent-chat": "0.10.1",
+        "@scalar/api-client": "2.41.0",
+        "@scalar/code-highlight": "0.3.2",
+        "@scalar/components": "0.21.3",
+        "@scalar/helpers": "0.4.3",
+        "@scalar/icons": "0.7.2",
+        "@scalar/oas-utils": "0.10.16",
+        "@scalar/sidebar": "0.8.18",
+        "@scalar/snippetz": "0.7.8",
+        "@scalar/themes": "0.15.2",
+        "@scalar/types": "0.7.6",
+        "@scalar/use-hooks": "0.4.2",
+        "@scalar/use-toasts": "0.10.1",
+        "@scalar/workspace-store": "0.43.1",
+        "@unhead/vue": "^2.1.4",
+        "@vueuse/core": "13.9.0",
+        "fuse.js": "^7.1.0",
+        "github-slugger": "2.0.0",
+        "microdiff": "^1.5.0",
+        "nanoid": "^5.1.6",
+        "vue": "^3.5.30",
+        "yaml": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/api-reference-react": {
+      "version": "0.9.20",
+      "resolved": "https://registry.npmjs.org/@scalar/api-reference-react/-/api-reference-react-0.9.20.tgz",
+      "integrity": "sha512-syiRHB1XRdKWM2a0fbzUCPNb5nQa/WHl/SLYu7pF/GBT5MBO27fYjPx8BSGvXA5Vdt218cWgZofiu/T1mVKFiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/api-reference": "1.51.0",
+        "@scalar/types": "0.7.6"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@scalar/api-reference/node_modules/nanoid": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
+      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/@scalar/code-highlight": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@scalar/code-highlight/-/code-highlight-0.3.2.tgz",
+      "integrity": "sha512-K9Cr3uQ0Rga4MEwAd3Jd4qvWy/pL7LPzL+xjdrpKEfdPj3C96W9oFE9Ok9wnNxuvuGqlN6JEqTw8Kjy3LYo45w==",
+      "license": "MIT",
+      "dependencies": {
+        "hast-util-to-text": "^4.0.2",
+        "highlight.js": "^11.11.1",
+        "highlightjs-curl": "^1.3.0",
+        "lowlight": "^3.3.0",
+        "rehype-external-links": "^3.0.0",
+        "rehype-format": "^5.0.1",
+        "rehype-parse": "^9.0.1",
+        "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "^6.0.0",
+        "rehype-stringify": "^10.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/components": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@scalar/components/-/components-0.21.3.tgz",
+      "integrity": "sha512-vOQyxImr6nbMDGUkIM4vs+DF0A26l33J+zYHAV4cm1X8FQ0huPW464EPDiD7csPkg79yF9vqblhFhyqq4u2dqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "0.2.10",
+        "@floating-ui/vue": "1.1.9",
+        "@headlessui/vue": "1.7.23",
+        "@scalar/code-highlight": "0.3.2",
+        "@scalar/helpers": "0.4.3",
+        "@scalar/icons": "0.7.2",
+        "@scalar/themes": "0.15.2",
+        "@scalar/use-hooks": "0.4.2",
+        "@vueuse/core": "13.9.0",
+        "cva": "1.0.0-beta.4",
+        "nanoid": "^5.1.6",
+        "radix-vue": "^1.9.17",
+        "vue": "^3.5.30",
+        "vue-component-type-helpers": "^3.2.2"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/components/node_modules/nanoid": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
+      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/@scalar/draggable": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@scalar/draggable/-/draggable-0.4.1.tgz",
+      "integrity": "sha512-TvTiy0tB2ulfBL7jwrpnsf7Geqlq/tWaIopkyZLii9bZPxPX5y1o6fVJXMyjtsUo0FSzvB382kN4uPi1TK/Hww==",
+      "license": "MIT",
+      "dependencies": {
+        "vue": "^3.5.26"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/helpers": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.4.3.tgz",
+      "integrity": "sha512-Gv2V7SFreLx3DltzF2lKXdaJSH5cP1LOyt9PxON1cSWGxkrs3sg93c1taEJsW24E9ckfYXkL5hjCAVLfAN3wQw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/icons": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@scalar/icons/-/icons-0.7.2.tgz",
+      "integrity": "sha512-21L2y/D6oU7wZHHa9i6FK98cZ+XH4HX9+e69uNpvlp4awRUpz6ifNHOLlxI607bq+Yz4G313gnV0uyUHwZ/pig==",
+      "license": "MIT",
+      "dependencies": {
+        "@phosphor-icons/core": "^2.1.1",
+        "@types/node": "^24.1.0",
+        "chalk": "^5.6.2",
+        "vue": "^3.5.30"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/icons/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@scalar/import": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@scalar/import/-/import-0.5.4.tgz",
+      "integrity": "sha512-EwqIC+cRzbGVg6w0P1tN0K/46hfb0rbHOTNwL4n7FmKxOH6zdbO5dCvlyh41rjOoc19keVGeq7oPg6o/6D6rBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/helpers": "0.4.3",
+        "yaml": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/json-magic": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@scalar/json-magic/-/json-magic-0.12.5.tgz",
+      "integrity": "sha512-MkGOjodEeQ7V7M78W6Oq+t3q1LaUR+SRLZLqFbU6s26Gc+12T+v89JXcHvd+3ug0xFVMg/kdczZ3O6miBhyNsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/helpers": "0.4.3",
+        "pathe": "^2.0.3",
+        "yaml": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/oas-utils": {
+      "version": "0.10.16",
+      "resolved": "https://registry.npmjs.org/@scalar/oas-utils/-/oas-utils-0.10.16.tgz",
+      "integrity": "sha512-xez3QrGYjn4Dhl6blvcUUzbVR1IOQVQhDO54UuZJwKWbOT3brEyAeZBwzttWmWDe3uGazPF160mj7qBXlT6sDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/helpers": "0.4.3",
+        "@scalar/json-magic": "0.12.5",
+        "@scalar/object-utils": "1.3.4",
+        "@scalar/openapi-parser": "0.25.8",
+        "@scalar/openapi-types": "0.7.0",
+        "@scalar/themes": "0.15.2",
+        "@scalar/types": "0.7.6",
+        "@scalar/workspace-store": "0.43.1",
+        "flatted": "^3.3.3",
+        "github-slugger": "2.0.0",
+        "type-fest": "^5.3.1",
+        "vue": "^3.5.30",
+        "yaml": "^2.8.0",
+        "zod": "^4.3.5"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/oas-utils/node_modules/type-fest": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
+      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@scalar/oas-utils/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@scalar/object-utils": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@scalar/object-utils/-/object-utils-1.3.4.tgz",
+      "integrity": "sha512-M3S6QgsMfSTgWgTQTS+m3+/pkpTlZmyWMFFUy/qWbQaD00qbR/OcftA7QIEPe6ToJgsNPHHS4+bOXzeLoJJBfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/helpers": "0.4.3",
+        "flatted": "^3.3.3",
+        "just-clone": "^6.2.0",
+        "ts-deepmerge": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/openapi-parser": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@scalar/openapi-parser/-/openapi-parser-0.25.8.tgz",
+      "integrity": "sha512-09yGXQSMYVlxJkLIn9Nz2q7Du7/olHKhR4oU0/JgkOdcKBiixSeLmhcAm7Hmj2Z82xOYpF+ZJUTCzsh8DQv5Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/helpers": "0.4.3",
+        "@scalar/json-magic": "0.12.5",
+        "@scalar/openapi-types": "0.7.0",
+        "@scalar/openapi-upgrader": "0.2.4",
+        "ajv": "^8.17.1",
+        "ajv-draft-04": "^1.0.0",
+        "ajv-formats": "^3.0.1",
+        "jsonpointer": "^5.0.1",
+        "leven": "^4.0.0",
+        "yaml": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/openapi-parser/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@scalar/openapi-parser/node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@scalar/openapi-parser/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@scalar/openapi-parser/node_modules/leven": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-4.1.0.tgz",
+      "integrity": "sha512-KZ9W9nWDT7rF7Dazg8xyLHGLrmpgq2nVNFUckhqdW3szVP6YhCpp/RAnpmVExA9JvrMynjwSLVrEj3AepHR6ew==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@scalar/openapi-types": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@scalar/openapi-types/-/openapi-types-0.7.0.tgz",
+      "integrity": "sha512-kN0PwlJW0de4bwQ4ib+mBHzKJUvBCyR/gwU4zLEq6SCbj+GfgYUh+2a0/yl1WYVUiSkkwFsHjfmQ8KjhR3HK0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/openapi-upgrader": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@scalar/openapi-upgrader/-/openapi-upgrader-0.2.4.tgz",
+      "integrity": "sha512-AcrF7BMxKCTHnT82SHbHun6dJO4XC9tS5gD7EJsr/7YwFkx9JtbtZCryJXtqWJ5c7i1v1KH4PRRjDga/hCULTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/openapi-types": "0.7.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/postman-to-openapi": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@scalar/postman-to-openapi/-/postman-to-openapi-0.6.1.tgz",
+      "integrity": "sha512-YUEH33s1HCAkApSdIFNB5XUGxzp7D5U9X2kgMKlZSyN2fW+yAePonaq5S9E4wU/2swSm+PvL9B2gw02yPjecUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/helpers": "0.4.3",
+        "@scalar/openapi-types": "0.7.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/sidebar": {
+      "version": "0.8.18",
+      "resolved": "https://registry.npmjs.org/@scalar/sidebar/-/sidebar-0.8.18.tgz",
+      "integrity": "sha512-FtHXmSyXYXtM5Y3TPbBrVfhJgaGC3fFkJugZN/y5BzXZXQoKZyTmBMJk8jMkgaMp+0cvpEtKJfYuBJvoAxtFmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/components": "0.21.3",
+        "@scalar/helpers": "0.4.3",
+        "@scalar/icons": "0.7.2",
+        "@scalar/themes": "0.15.2",
+        "@scalar/use-hooks": "0.4.2",
+        "@scalar/workspace-store": "0.43.1",
+        "vue": "^3.5.30"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/snippetz": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@scalar/snippetz/-/snippetz-0.7.8.tgz",
+      "integrity": "sha512-1g037ajdeGepBKj6+At+6BGSW4OqwONq2NoonGDcpDkW01dInTJx9q8AatXT1qdVUwV1gAVOYjCHsmSxkZictw==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/types": "0.7.6",
+        "js-base64": "^3.7.8",
+        "stringify-object": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/themes": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@scalar/themes/-/themes-0.15.2.tgz",
+      "integrity": "sha512-GA+cM2Lojv2sqwfB6yTerBAnBTfVzIzUZ3C8T4PP9snaLyy7b0CMoHtnDEqERX/NZiRfnrIWeEYGy09cDi0w4g==",
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^5.1.6"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/themes/node_modules/nanoid": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
+      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/@scalar/typebox": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@scalar/typebox/-/typebox-0.1.3.tgz",
+      "integrity": "sha512-lU055AUccECZMIfGA0z/C1StYmboAYIPJLDFBzOO81yXBi35Pxdq+I4fWX6iUZ8qcoHneiLGk9jAUM1rA93iEg==",
+      "license": "MIT"
+    },
+    "node_modules/@scalar/types": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.7.6.tgz",
+      "integrity": "sha512-n5d7neeGTY/yS36AwAv3FAyCnJbbLjMPwyuEXBLgxHcb5i8DXnNfwy1nzz8jx/EJ88i1zmQ8BuMs+207saHgNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/helpers": "0.4.3",
+        "nanoid": "^5.1.6",
+        "type-fest": "^5.3.1",
+        "zod": "^4.3.5"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/types/node_modules/nanoid": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
+      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/@scalar/types/node_modules/type-fest": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
+      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@scalar/types/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@scalar/use-codemirror": {
+      "version": "0.14.11",
+      "resolved": "https://registry.npmjs.org/@scalar/use-codemirror/-/use-codemirror-0.14.11.tgz",
+      "integrity": "sha512-5wtC4pUjzhy72j3aAueJg+fh9KflevJvXMn0YscsxiDTvqwIzeZcHe1N9VNtvzDXgLblEeBT6D0+Vs+boyExxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.18.3",
+        "@codemirror/commands": "^6.7.1",
+        "@codemirror/lang-css": "^6.3.1",
+        "@codemirror/lang-html": "^6.4.8",
+        "@codemirror/lang-json": "^6.0.0",
+        "@codemirror/lang-xml": "^6.0.0",
+        "@codemirror/lang-yaml": "^6.1.2",
+        "@codemirror/language": "^6.10.7",
+        "@codemirror/lint": "^6.8.4",
+        "@codemirror/state": "^6.5.0",
+        "@codemirror/view": "^6.35.3",
+        "@lezer/common": "^1.2.3",
+        "@lezer/highlight": "^1.2.1",
+        "@replit/codemirror-css-color-picker": "^6.3.0",
+        "vue": "^3.5.30"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/use-hooks": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@scalar/use-hooks/-/use-hooks-0.4.2.tgz",
+      "integrity": "sha512-c12RFw75aqRFc2iXQDdm9cHk0E/bT8LTelgNQDR8Bhp7950Swssr10lWC61CWdOigjRth+ES61Jo8yGi5yUBwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/use-toasts": "0.10.1",
+        "@vueuse/core": "13.9.0",
+        "cva": "1.0.0-beta.2",
+        "tailwind-merge": "3.4.0",
+        "vue": "^3.5.30",
+        "zod": "^4.3.5"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/use-hooks/node_modules/cva": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/cva/-/cva-1.0.0-beta.2.tgz",
+      "integrity": "sha512-dqcOFe247I5pKxfuzqfq3seLL5iMYsTgo40Uw7+pKZAntPgFtR7Tmy59P5IVIq/XgB0NQWoIvYDt9TwHkuK8Cg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.5.5 < 6"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@scalar/use-hooks/node_modules/tailwind-merge": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
+      "integrity": "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/@scalar/use-hooks/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@scalar/use-toasts": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@scalar/use-toasts/-/use-toasts-0.10.1.tgz",
+      "integrity": "sha512-8fsDd4efEDF+EydA+1+np/ac2KsAXPR1LdTYtTUxpv8Uj1l7lUMT/T5A7xnR+wNKmyVREihb9KnGp3pSjO2kYg==",
+      "license": "MIT",
+      "dependencies": {
+        "vue": "^3.5.26",
+        "vue-sonner": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/validation": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@scalar/validation/-/validation-0.3.0.tgz",
+      "integrity": "sha512-4X/AP3JO23DuYxs1MMjn6IlT9gyrKPCuZj8ybTB9QIjC+3tSJLpQOwZg7HEyyz2HoVwOt9jdef2jO3RXW7DqTw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@scalar/workspace-store": {
+      "version": "0.43.1",
+      "resolved": "https://registry.npmjs.org/@scalar/workspace-store/-/workspace-store-0.43.1.tgz",
+      "integrity": "sha512-R0V2PXMhjbfELRtiRfn6vNaLPJalo1AKUs1AkCvJZyMaCNHrGUH14rdhwAz790ahVjebY66VKdn19Q4x1t60uA==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/helpers": "0.4.3",
+        "@scalar/json-magic": "0.12.5",
+        "@scalar/openapi-upgrader": "0.2.4",
+        "@scalar/snippetz": "0.7.8",
+        "@scalar/typebox": "0.1.3",
+        "@scalar/types": "0.7.6",
+        "@scalar/validation": "0.3.0",
+        "github-slugger": "2.0.0",
+        "js-base64": "^3.7.8",
+        "type-fest": "^5.3.1",
+        "vue": "^3.5.30",
+        "yaml": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/workspace-store/node_modules/type-fest": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
+      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@selderee/plugin-htmlparser2": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
@@ -6584,7 +8092,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -6634,7 +8141,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.12.tgz",
       "integrity": "sha512-graRZspg7EoEaw0a8faiUASCyJrqjKPdqJ9EwuDRUF9mEYJ1YPczI9H+/agJ0mOJkPCJDk0lsz5QTrLZ/jQ2rg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.12"
       },
@@ -6661,6 +8167,32 @@
       "peerDependencies": {
         "@tanstack/react-query": "^5.90.10",
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.23",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.23.tgz",
+      "integrity": "sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/vue-virtual": {
+      "version": "3.13.23",
+      "resolved": "https://registry.npmjs.org/@tanstack/vue-virtual/-/vue-virtual-3.13.23.tgz",
+      "integrity": "sha512-b5jPluAR6U3eOq6GWAYSpj3ugnAIZgGR0e6aGAgyRse0Yu6MVQQ0ZWm9SArSXWtageogn6bkVD8D//c4IjW3xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.23"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "vue": "^2.7.0 || ^3.0.0"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -6758,7 +8290,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.27.1.tgz",
       "integrity": "sha512-nkerkl8syHj44ZzAB7oA2GPmmZINKBKCa79FuNvmGJrJ4qyZwlkDzszud23YteFZEytbc87kVd/fP76ROS6sLg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -7085,7 +8616,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.27.1.tgz",
       "integrity": "sha512-ijKo3+kIjALthYsnBmkRXAuw2Tswd9gd7BUR5OMfIcjGp8v576vKxOxrRfuYiUM78GPt//P0sVc1WV82H5N0PQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -7190,7 +8720,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -7296,6 +8827,12 @@
       "dependencies": {
         "@types/estree": "*"
       }
+    },
+    "node_modules/@types/har-format": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.16.tgz",
+      "integrity": "sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==",
+      "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
@@ -7457,7 +8994,6 @@
       "version": "24.10.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.4.tgz",
       "integrity": "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -7487,7 +9023,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.5.tgz",
       "integrity": "sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -7499,7 +9034,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -7567,6 +9101,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
       "license": "MIT"
     },
     "node_modules/@types/webxr": {
@@ -7645,7 +9185,6 @@
       "integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.1",
         "@typescript-eslint/types": "8.50.1",
@@ -7849,6 +9388,22 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
+    },
+    "node_modules/@unhead/vue": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.1.13.tgz",
+      "integrity": "sha512-HYy0shaHRnLNW9r85gppO8IiGz0ONWVV3zGdlT8CQ0tbTwixznJCIiyqV4BSV1aIF1jJIye0pd1p/k6Eab8Z/A==",
+      "license": "MIT",
+      "dependencies": {
+        "hookable": "^6.0.1",
+        "unhead": "2.1.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      },
+      "peerDependencies": {
+        "vue": ">=3.5.18"
+      }
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
       "version": "1.11.1",
@@ -8135,6 +9690,15 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
+      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.2.tgz",
@@ -8262,7 +9826,6 @@
       "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "fflate": "^0.8.2",
@@ -8294,6 +9857,240 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.32.tgz",
+      "integrity": "sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.2",
+        "@vue/shared": "3.5.32",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.32.tgz",
+      "integrity": "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.32",
+        "@vue/shared": "3.5.32"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.32.tgz",
+      "integrity": "sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.2",
+        "@vue/compiler-core": "3.5.32",
+        "@vue/compiler-dom": "3.5.32",
+        "@vue/compiler-ssr": "3.5.32",
+        "@vue/shared": "3.5.32",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.8",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.32.tgz",
+      "integrity": "sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.32",
+        "@vue/shared": "3.5.32"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.32.tgz",
+      "integrity": "sha512-/ORasxSGvZ6MN5gc+uE364SxFdJ0+WqVG0CENXaGW58TOCdrAW76WWaplDtECeS1qphvtBZtR+3/o1g1zL4xPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.32"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.32.tgz",
+      "integrity": "sha512-pDrXCejn4UpFDFmMd27AcJEbHaLemaE5o4pbb7sLk79SRIhc6/t34BQA7SGNgYtbMnvbF/HHOftYBgFJtUoJUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.32",
+        "@vue/shared": "3.5.32"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.32.tgz",
+      "integrity": "sha512-1CDVv7tv/IV13V8Nip1k/aaObVbWqRlVCVezTwx3K07p7Vxossp5JU1dcPNhJk3w347gonIUT9jQOGutyJrSVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.32",
+        "@vue/runtime-core": "3.5.32",
+        "@vue/shared": "3.5.32",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.32.tgz",
+      "integrity": "sha512-IOjm2+JQwRFS7W28HNuJeXQle9KdZbODFY7hFGVtnnghF51ta20EWAZJHX+zLGtsHhaU6uC9BGPV52KVpYryMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.32",
+        "@vue/shared": "3.5.32"
+      },
+      "peerDependencies": {
+        "vue": "3.5.32"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.32.tgz",
+      "integrity": "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==",
+      "license": "MIT"
+    },
+    "node_modules/@vueuse/core": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-13.9.0.tgz",
+      "integrity": "sha512-ts3regBQyURfCE2BcytLqzm8+MmLlo5Ln/KLoxDVcsZ2gzIwVNnQpQOL/UKV8alUqjSZOlpFZcRNsLRqj+OzyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "13.9.0",
+        "@vueuse/shared": "13.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@vueuse/integrations": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-13.9.0.tgz",
+      "integrity": "sha512-SDobKBbPIOe0cVL7QxMzGkuUGHvWTdihi9zOrrWaWUgFKe15cwEcwfWmgrcNzjT6kHnNmWuTajPHoIzUjYNYYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "13.9.0",
+        "@vueuse/shared": "13.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "^4",
+        "axios": "^1",
+        "change-case": "^5",
+        "drauu": "^0.4",
+        "focus-trap": "^7",
+        "fuse.js": "^7",
+        "idb-keyval": "^6",
+        "jwt-decode": "^4",
+        "nprogress": "^0.2",
+        "qrcode": "^1.5",
+        "sortablejs": "^1",
+        "universal-cookie": "^7 || ^8",
+        "vue": "^3.5.0"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-13.9.0.tgz",
+      "integrity": "sha512-1AFRvuiGphfF7yWixZa0KwjYH8ulyjDCC0aFgrGRz8+P4kvDFSdXLVfTk5xAN9wEuD1J6z4/myMoYbnHoX07zg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-13.9.0.tgz",
+      "integrity": "sha512-e89uuTLMh0U5cZ9iDpEI2senqPGfbPRTHM/0AaQkcxnpqjkZqDYP8rpfm7edOz8s+pOCOROEy1PIveSW8+fL5g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
     "node_modules/@webgpu/types": {
       "version": "0.1.68",
       "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.68.tgz",
@@ -8307,7 +10104,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8335,6 +10131,24 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ai": {
+      "version": "6.0.33",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.33.tgz",
+      "integrity": "sha512-bVokbmy2E2QF6Efl+5hOJx5MRWoacZ/CZY/y1E+VcewknvGlgaiCzMu8Xgddz6ArFJjiMFNUPHKxAhIePE4rmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.13",
+        "@ai-sdk/provider": "3.0.2",
+        "@ai-sdk/provider-utils": "4.0.5",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -8351,6 +10165,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -8903,7 +10756,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9545,6 +11397,18 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/convert-hrtime": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
+      "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
@@ -9675,6 +11539,26 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/cva": {
+      "version": "1.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/cva/-/cva-1.0.0-beta.4.tgz",
+      "integrity": "sha512-F/JS9hScapq4DBVQXcK85l9U91M6ePeXoBMSp7vypzShoefUBxjQTo3g3935PUHgQd+IW77DjbPRIxugy4/GCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.5.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -9765,7 +11649,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -9899,7 +11782,6 @@
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
       "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/dequal": {
@@ -9977,7 +11859,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -10206,7 +12089,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -10491,7 +12373,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10580,7 +12461,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -10682,7 +12562,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -11245,6 +13124,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -11422,6 +13310,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -11514,8 +13418,16 @@
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/focus-trap": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
+      "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.4.0"
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -11607,6 +13519,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/function-timeout": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-1.0.2.tgz",
+      "integrity": "sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/function.prototype.name": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
@@ -11636,6 +13560,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.3.0.tgz",
+      "integrity": "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
       }
     },
     "node_modules/generator-function": {
@@ -11713,6 +13650,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/get-own-enumerable-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-keys/-/get-own-enumerable-keys-1.0.0.tgz",
+      "integrity": "sha512-PKsK2FSrQCyxcGHsGrLDcK0lx+0Ke+6e8KFFozA9/fIQLhQzPaRvJFdcz7+Axg3jUH/Mq+NI4xa5u/UT2tQskA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-package-type": {
@@ -11801,6 +13750,12 @@
         "giget": "dist/cli.mjs"
       }
     },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "license": "ISC"
+    },
     "node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -11886,6 +13841,15 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/guess-json-indent": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/guess-json-indent/-/guess-json-indent-3.0.1.tgz",
+      "integrity": "sha512-LWZ3Vr8BG7DHE3TzPYFqkhjNRw4vYgFSsv2nfMuHklAlOfiy54/EwiDQuQfFVLxENCVv20wpbjfTayooQHrEhQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.18.0"
+      }
     },
     "node_modules/happy-dom": {
       "version": "20.8.9",
@@ -12011,6 +13975,226 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-embedded": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-3.0.0.tgz",
+      "integrity": "sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-is-element": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-format": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-format/-/hast-util-format-1.1.0.tgz",
+      "integrity": "sha512-yY1UDz6bC9rDvCWHpx12aIBGRG7krurX0p0Fm6pT547LwDIZZiNr8a+IHDogorAdreULSEzP82Nlv5SZkHZcjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-minify-whitespace": "^1.0.0",
+        "hast-util-phrasing": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-whitespace-sensitive-tag-names": "^3.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-has-property": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz",
+      "integrity": "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-body-ok-link": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-3.0.1.tgz",
+      "integrity": "sha512-0qpnzOBLztXHbHQenVB8uNuxTnm/QBFUOmdOSsEn7GnBtyY07+ENTWVFBAnXd/zEgd9/SUG3lRY7hSIBWRgGpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-minify-whitespace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-minify-whitespace/-/hast-util-minify-whitespace-1.0.1.tgz",
+      "integrity": "sha512-L96fPOVpnclQE0xzdWb/D12VT5FabA7SnZOUMtL1DbXmYiHJMXZvFkIZfiMmTCNJHUeO2K9UYNXoVyfz+QHuOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-phrasing": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-phrasing/-/hast-util-phrasing-3.0.1.tgz",
+      "integrity": "sha512-6h60VfI3uBQUxHqTyMymMZnEbNl1XmEGtOxxKYL7stY2o601COo62AWAYBQR9lZbYXYSBoxag8UpPRXK+9fqSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-has-property": "^3.0.0",
+        "hast-util-is-body-ok-link": "^3.0.0",
+        "hast-util-is-element": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-raw": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "hast-util-to-parse5": "^8.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "parse5": "^7.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -12038,6 +14222,41 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -12050,6 +14269,38 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/highlightjs-curl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/highlightjs-curl/-/highlightjs-curl-1.3.0.tgz",
+      "integrity": "sha512-50UEfZq1KR0Lfk2Tr6xb/MUIZH3h10oNC0OTy9g7WELcs5Fgy/mKN1vEhuKTkKbdo8vr5F9GXstu2eLhApfQ3A==",
+      "license": "Apache-2.0"
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
@@ -12064,6 +14315,12 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/hookable": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.0.tgz",
+      "integrity": "sha512-ZoKZSJgu8voGK2geJS+6YtYjvIzu9AOM/KZXsBxr83uhLL++e9pEv/dlgwgy3dvHg06kTz6JOh1hk3C8Ceiymw==",
       "license": "MIT"
     },
     "node_modules/hosted-git-info": {
@@ -12119,6 +14376,26 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
       "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/html-whitespace-sensitive-tag-names": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-whitespace-sensitive-tag-names/-/html-whitespace-sensitive-tag-names-3.0.1.tgz",
+      "integrity": "sha512-q+310vW8zmymYHALr1da4HyXUQ0zgiIwIicEfotYPWGN0OJVEN/58IJ3A4GBYcEq3LGAZqKb+ugvP0GNB9CEAA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -12234,6 +14511,21 @@
         "yup": "^1.2.0"
       }
     },
+    "node_modules/identifier-regex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/identifier-regex/-/identifier-regex-1.0.1.tgz",
+      "integrity": "sha512-ZrYyM0sozNPZlvBvE7Oq9Bn44n0qKGrYu5sQ0JzMUnjIhpgWYE2JB6aBoFwEYdPjqj7jPyxXTMJiHDOxDfd8yw==",
+      "license": "MIT",
+      "dependencies": {
+        "reserved-identifiers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -12344,6 +14636,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-absolute-url": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
+      "integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-alphabetical": {
@@ -12668,6 +14972,22 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-identifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-identifier/-/is-identifier-1.0.1.tgz",
+      "integrity": "sha512-HQ5v4rEJ7REUV54bCd2l5FaD299SGDEn2UPoVXaTHAyGviLq2menVUD2udi3trQ32uvB6LdAh/0ck2EuizrtpA==",
+      "license": "MIT",
+      "dependencies": {
+        "identifier-regex": "^1.0.0",
+        "super-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -12726,6 +15046,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-3.0.0.tgz",
+      "integrity": "sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
@@ -12762,6 +15094,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regexp": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-3.1.0.tgz",
+      "integrity": "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-set": {
@@ -14122,10 +16466,15 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/js-base64": {
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
+      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -14152,7 +16501,6 @@
       "integrity": "sha512-GtldT42B8+jefDUC4yUKAvsaOrH7PDHmZxZXNgF2xMmymjUbRYJvpAybZAKEmXDGTM0mCsz8duOa4vTm5AY2Kg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -14235,6 +16583,12 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -14260,6 +16614,21 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -14299,6 +16668,12 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/just-clone": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-clone/-/just-clone-6.2.0.tgz",
+      "integrity": "sha512-1IynUYEc/HAwxhi3WDpIpxJbZpMCvvrrmZVqvj9EhpvbH8lls7HhdhiByjL7DkAaWlLIzpC0Xc/VPvy/UxLNjA==",
+      "license": "MIT"
     },
     "node_modules/jwa": {
       "version": "2.0.1",
@@ -14757,6 +17132,12 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/longest-streak": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
@@ -14786,6 +17167,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lowlight": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
+      "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.0.0",
+        "highlight.js": "~11.11.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -14811,6 +17207,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -14819,10 +17216,38 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/make-asynchronous": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/make-asynchronous/-/make-asynchronous-1.1.0.tgz",
+      "integrity": "sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-event": "^6.0.0",
+        "type-fest": "^4.6.0",
+        "web-worker": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-asynchronous/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-dir": {
@@ -14880,6 +17305,28 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -14888,6 +17335,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mdast-util-from-markdown": {
@@ -14908,6 +17383,107 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -15079,6 +17655,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/microdiff": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/microdiff/-/microdiff-1.5.0.tgz",
+      "integrity": "sha512-Drq+/THMvDdzRYrK0oxJmOKiC24ayUV8ahrt8l3oRK51PWt6gdtrIGrlIH3pT/lFh1z93FbAcidtsHcWbnRz8Q==",
+      "license": "MIT"
+    },
     "node_modules/micromark": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
@@ -15146,6 +17728,127 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -15603,6 +18306,103 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/monaco-editor": {
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.54.0.tgz",
+      "integrity": "sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "3.1.7",
+        "marked": "14.0.0"
+      }
+    },
+    "node_modules/monaco-languageserver-types": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/monaco-languageserver-types/-/monaco-languageserver-types-0.4.0.tgz",
+      "integrity": "sha512-QQ3BZiU5LYkJElGncSNb5AKoJ/LCs6YBMCJMAz9EA7v+JaOdn3kx2cXpPTcZfKA5AEsR0vc97sAw+5mdNhVBmw==",
+      "license": "MIT",
+      "dependencies": {
+        "monaco-types": "^0.1.0",
+        "vscode-languageserver-protocol": "^3.0.0",
+        "vscode-uri": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
+    },
+    "node_modules/monaco-marker-data-provider": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/monaco-marker-data-provider/-/monaco-marker-data-provider-1.2.5.tgz",
+      "integrity": "sha512-5ZdcYukhPwgYMCvlZ9H5uWs5jc23BQ8fFF5AhSIdrz5mvYLsqGZ58ZLxTv8rCX6+AxdJ8+vxg1HVSk+F2bLosg==",
+      "license": "MIT",
+      "dependencies": {
+        "monaco-types": "^0.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
+    },
+    "node_modules/monaco-types": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/monaco-types/-/monaco-types-0.1.2.tgz",
+      "integrity": "sha512-8LwfrlWXsedHwAL41xhXyqzPibS8IqPuIXr9NdORhonS495c2/wky+sI1PRLvMCuiI0nqC2NH1six9hdiRY4Xg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
+    },
+    "node_modules/monaco-worker-manager": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/monaco-worker-manager/-/monaco-worker-manager-2.0.1.tgz",
+      "integrity": "sha512-kdPL0yvg5qjhKPNVjJoym331PY/5JC11aPJXtCZNwWRvBr6jhkIamvYAyiY5P1AWFmNOy0aRDRoMdZfa71h8kg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "monaco-editor": ">=0.30.0"
+      }
+    },
+    "node_modules/monaco-yaml": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/monaco-yaml/-/monaco-yaml-5.2.3.tgz",
+      "integrity": "sha512-GEplKC+YYmS0TOlJdv0FzbqkDN/IG2FSwEw+95myECVxTlhty2amwERYjzvorvJXmIagP1grd3Lleq7aQEJpPg==",
+      "license": "MIT",
+      "workspaces": [
+        "examples/*"
+      ],
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "monaco-languageserver-types": "^0.4.0",
+        "monaco-marker-data-provider": "^1.0.0",
+        "monaco-types": "^0.1.0",
+        "monaco-worker-manager": "^2.0.0",
+        "path-browserify": "^1.0.0",
+        "prettier": "^2.0.0",
+        "vscode-languageserver-textdocument": "^1.0.0",
+        "vscode-languageserver-types": "^3.0.0",
+        "vscode-uri": "^3.0.0",
+        "yaml": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">=0.36"
+      }
+    },
+    "node_modules/monaco-yaml/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/motion": {
       "version": "12.23.26",
       "resolved": "https://registry.npmjs.org/motion/-/motion-12.23.26.tgz",
@@ -15711,6 +18511,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/neverpanic": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/neverpanic/-/neverpanic-0.0.7.tgz",
+      "integrity": "sha512-GFRTSX2JAEATOCQYlyFkR+9FJPl0pD24toE1foqYAsL6aPLlRKn6L0UFOtJhZCxEbDv+SUsiW4AcPs9cIFwkFw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "5"
+      }
     },
     "node_modules/next": {
       "version": "15.5.14",
@@ -16077,6 +18886,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi3-ts": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.5.0.tgz",
+      "integrity": "sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.8.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -16119,6 +18937,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/p-event": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.1.tgz",
+      "integrity": "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-timeout": "^6.1.2"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -16146,6 +18979,18 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+      "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -16223,11 +19068,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -16248,6 +19104,12 @@
       "funding": {
         "url": "https://ko-fi.com/killymxi"
       }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -16321,7 +19183,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/pathval": {
@@ -16488,9 +19349,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
       "funding": [
         {
           "type": "opencollective",
@@ -16506,7 +19367,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -16617,16 +19477,33 @@
       "license": "MIT"
     },
     "node_modules/posthog-js": {
-      "version": "1.310.1",
-      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.310.1.tgz",
-      "integrity": "sha512-UkR6zzlWNtqHDXHJl2Yk062DOmZyVKTPL5mX4j4V+u3RiYbMHJe47+PpMMUsvK1R2e1r/m9uSlHaJMJRzyUjGg==",
+      "version": "1.363.2",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.363.2.tgz",
+      "integrity": "sha512-4ZEWMrymlFzjgDSmh25VeJQT//2XUFbfKqEPDNUW4dxcqWiVMo1+gJFy5YhJgVYS46OAXLbMcJgmuZBCnDIgVg==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@posthog/core": "1.9.0",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/api-logs": "^0.208.0",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
+        "@opentelemetry/resources": "^2.2.0",
+        "@opentelemetry/sdk-logs": "^0.208.0",
+        "@posthog/core": "1.24.1",
+        "@posthog/types": "1.363.2",
         "core-js": "^3.38.1",
+        "dompurify": "^3.3.2",
         "fflate": "^0.4.8",
-        "preact": "^10.19.3",
-        "web-vitals": "^4.2.4"
+        "preact": "^10.28.2",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.1.0"
+      }
+    },
+    "node_modules/posthog-js/node_modules/@posthog/core": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.24.1.tgz",
+      "integrity": "sha512-e8AciAnc6MRFws89ux8lJKFAaI03yEon0ASDoUO7yS91FVqbUGXYekObUUR3LHplcg+pmyiJBI0jolY0SFbGRA==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6"
       }
     },
     "node_modules/posthog-js/node_modules/fflate": {
@@ -16672,7 +19549,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -16702,6 +19578,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -16717,6 +19594,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -16729,7 +19607,23 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/prisma": {
       "version": "6.19.3",
@@ -16738,7 +19632,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.3",
         "@prisma/engines": "6.19.3"
@@ -16903,7 +19796,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
       "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -16933,7 +19825,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -16982,11 +19873,34 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.4.tgz",
       "integrity": "sha512-WkKgnyjNncri03Gjaz3IFWvCAE94XoiEgvtr0/r2Xw7R8/IjK3sKLSiDoCHWcsXSAinVaKlGRZDvMCsF1kbzjA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.1.0"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/punycode": {
@@ -17025,6 +19939,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -17045,6 +19965,140 @@
       ],
       "license": "MIT"
     },
+    "node_modules/radix-vue": {
+      "version": "1.9.17",
+      "resolved": "https://registry.npmjs.org/radix-vue/-/radix-vue-1.9.17.tgz",
+      "integrity": "sha512-mVCu7I2vXt1L2IUYHTt0sZMz7s1K2ZtqKeTIxG3yC5mMFfLBG4FtE1FDeRMpDd+Hhg/ybi9+iXmAP1ISREndoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.7",
+        "@floating-ui/vue": "^1.1.0",
+        "@internationalized/date": "^3.5.4",
+        "@internationalized/number": "^3.5.3",
+        "@tanstack/vue-virtual": "^3.8.1",
+        "@vueuse/core": "^10.11.0",
+        "@vueuse/shared": "^10.11.0",
+        "aria-hidden": "^1.2.4",
+        "defu": "^6.1.4",
+        "fast-deep-equal": "^3.1.3",
+        "nanoid": "^5.0.7"
+      },
+      "peerDependencies": {
+        "vue": ">= 3.2.0"
+      }
+    },
+    "node_modules/radix-vue/node_modules/@types/web-bluetooth": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
+      "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==",
+      "license": "MIT"
+    },
+    "node_modules/radix-vue/node_modules/@vueuse/core": {
+      "version": "10.11.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.11.1.tgz",
+      "integrity": "sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.20",
+        "@vueuse/metadata": "10.11.1",
+        "@vueuse/shared": "10.11.1",
+        "vue-demi": ">=0.14.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/radix-vue/node_modules/@vueuse/core/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/radix-vue/node_modules/@vueuse/metadata": {
+      "version": "10.11.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.11.1.tgz",
+      "integrity": "sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/radix-vue/node_modules/@vueuse/shared": {
+      "version": "10.11.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.11.1.tgz",
+      "integrity": "sha512-LHpC8711VFZlDaYUXEBbFBCQ7GS3dVU9mjOhhMhXP6txTV4EhYQg/KGnQuvt/sPAtoUKq7VVUnL6mVtFoL42sA==",
+      "license": "MIT",
+      "dependencies": {
+        "vue-demi": ">=0.14.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/radix-vue/node_modules/@vueuse/shared/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/radix-vue/node_modules/nanoid": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
+      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
     "node_modules/rc9": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
@@ -17061,7 +20115,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -17088,7 +20141,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -17476,6 +20528,115 @@
         "jsesc": "bin/jsesc"
       }
     },
+    "node_modules/rehype-external-links": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-3.0.0.tgz",
+      "integrity": "sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "is-absolute-url": "^4.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-format": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-format/-/rehype-format-5.0.1.tgz",
+      "integrity": "sha512-zvmVru9uB0josBVpr946OR8ui7nJEdzZobwLOOqHb/OOD88W0Vk2SqLwoVOj0fM6IPCCO6TaV9CvQvJMWwukFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-format": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-parse": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
+      "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-raw": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-raw": "^9.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-stringify": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+      "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -17509,6 +20670,21 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -17523,7 +20699,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -17539,6 +20714,18 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/reserved-identifiers": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
+      "integrity": "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/resolve": {
@@ -17850,7 +21037,6 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.1.tgz",
       "integrity": "sha512-uf6HoO8fy6ClsrShvMgaKUn14f2EHQLQRtpsZZLeU/Mv0Q1K5P0+x2uvH6Cub39TVVbWNSrraUhDAoFph6vh0A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -18035,6 +21221,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {
@@ -18374,6 +21572,24 @@
         "node": ">=0.6.19"
       }
     },
+    "node_modules/string-byte-length": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/string-byte-length/-/string-byte-length-3.0.1.tgz",
+      "integrity": "sha512-yJ8vP0HMwZ54CcA8S8mKoXbkezpZHANFtmafFo8lGxZThCQcAwRHjdFabuSLgOzxj9OFJcmssmiAvmcOK4O2Hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/string-byte-slice": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/string-byte-slice/-/string-byte-slice-3.0.1.tgz",
+      "integrity": "sha512-GWv2K4lYyd2+AhmKH3BV+OVx62xDX+99rSLfKpaqFiQU7uOMaUY1tDjdrRD4gsrCr9lTyjMgjna7tZcCOw+Smg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -18585,6 +21801,24 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stringify-object": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-6.0.0.tgz",
+      "integrity": "sha512-6f94vIED6vmJJfh3lyVsVWxCYSfI5uM+16ntED/Ql37XIyV6kj0mRAAiTeMMc/QLYIaizC3bUprQ8pQnDDrKfA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "get-own-enumerable-keys": "^1.0.0",
+        "is-identifier": "^1.0.1",
+        "is-obj": "^3.0.0",
+        "is-regexp": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -18678,6 +21912,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -18756,6 +21996,23 @@
         "node": ">= 6"
       }
     },
+    "node_modules/super-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-1.1.0.tgz",
+      "integrity": "sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-timeout": "^1.0.1",
+        "make-asynchronous": "^1.0.1",
+        "time-span": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -18781,6 +22038,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swrv": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/swrv/-/swrv-1.2.0.tgz",
+      "integrity": "sha512-lH/g4UcNyj+7lzK4eRGT4C68Q4EhQ6JtM9otPRIASfhhzfLWtbZPHcMuhuba7S9YVYuxkMUGImwMyGpfbkH07A==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "vue": ">=3.2.26 < 4"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -18804,6 +22070,24 @@
         "url": "https://opencollective.com/synckit"
       }
     },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "license": "MIT"
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tailwind-merge": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.0.tgz",
@@ -18819,7 +22103,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -18902,7 +22185,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -19080,6 +22362,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/time-span": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
+      "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
+      "license": "MIT",
+      "dependencies": {
+        "convert-hrtime": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tiny-case": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
@@ -19141,7 +22438,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -19289,6 +22585,20 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/truncate-json": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/truncate-json/-/truncate-json-3.0.1.tgz",
+      "integrity": "sha512-QVsbr1WhGLq2F0oDyYbqtOXcf3gcnL8C9H5EX8bBwAr8ZWvWGJzukpPrDrWgJMrNtgDbo74BIjI4kJu3q2xQWw==",
+      "license": "MIT",
+      "dependencies": {
+        "guess-json-indent": "^3.0.1",
+        "string-byte-length": "^3.0.1",
+        "string-byte-slice": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -19300,6 +22610,15 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-deepmerge": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-7.0.3.tgz",
+      "integrity": "sha512-Du/ZW2RfwV/D4cmA5rXafYjBQVuvu4qGiEEla4EmEHVHgRdx68Gftx7i66jn2bzHPwSVZY36Ae6OuDn9el4ZKA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14.13.1"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -19356,7 +22675,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -19489,9 +22807,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -19538,8 +22854,19 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unhead": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.1.13.tgz",
+      "integrity": "sha512-jO9M1sI6b2h/1KpIu4Jeu+ptumLmUKboRRLxys5pYHFeT+lqTzfNHbYUX9bxVDhC1FBszAGuWcUVlmvIPsah8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "hookable": "^6.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      }
     },
     "node_modules/unified": {
       "version": "11.0.5",
@@ -19554,6 +22881,20 @@
         "is-plain-obj": "^4.0.0",
         "trough": "^2.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -19600,9 +22941,9 @@
       }
     },
     "node_modules/unist-util-visit": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
-      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -19809,6 +23150,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/vfile-message": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
@@ -19829,7 +23184,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -19922,6 +23276,15 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/vite-plugin-monaco-editor": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-monaco-editor/-/vite-plugin-monaco-editor-1.1.0.tgz",
+      "integrity": "sha512-IvtUqZotrRoVqwT0PBBDIZPNraya3BxN/bfcNfnxZ5rkJiGcNtO5eAOWWSgT7zullIAEqQwxMU83yL9J5k7gww==",
+      "license": "MIT",
+      "peerDependencies": {
+        "monaco-editor": ">=0.33.0"
+      }
+    },
     "node_modules/vite/node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -19946,7 +23309,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -19960,7 +23322,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -20048,6 +23409,91 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "license": "MIT"
+    },
+    "node_modules/vue": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.32.tgz",
+      "integrity": "sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.32",
+        "@vue/compiler-sfc": "3.5.32",
+        "@vue/runtime-dom": "3.5.32",
+        "@vue/server-renderer": "3.5.32",
+        "@vue/shared": "3.5.32"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-component-type-helpers": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.2.6.tgz",
+      "integrity": "sha512-O02tnvIfOQVmnvoWwuSydwRoHjZVt8UEBR+2p4rT35p8GAy5VTlWP8o5qXfJR/GWCN0nVZoYWsVUvx2jwgdBmQ==",
+      "license": "MIT"
+    },
+    "node_modules/vue-router": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.2.tgz",
+      "integrity": "sha512-my83mxQKXyCms9EegBXZldehOihxBjgSjZqrZwgg4vBacNGl0oBCO+xT//wgOYpLV1RW93ZfqxrjTozd+82nbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/vue-sonner": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/vue-sonner/-/vue-sonner-1.3.2.tgz",
+      "integrity": "sha512-UbZ48E9VIya3ToiRHAZUbodKute/z/M1iT8/3fU8zEbwBRE11AKuHikssv18LMk2gTTr6eMQT4qf6JoLHWuj/A==",
+      "license": "MIT"
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -20077,10 +23523,26 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/web-vitals": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
-      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.2.0.tgz",
+      "integrity": "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/web-worker": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+      "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
       "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
@@ -20450,7 +23912,6 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "devOptional": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@asteasolutions/zod-to-openapi": "^7.3.4",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
@@ -64,6 +65,7 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-toast": "^1.2.15",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@scalar/api-reference-react": "^0.9.20",
     "@tanstack/react-query": "^5.90.5",
     "@tanstack/react-query-devtools": "^5.90.2",
     "@tiptap/extension-blockquote": "^2.10.0",
@@ -145,5 +147,10 @@
   },
   "resolutions": {
     "yjs": "latest"
+  },
+  "overrides": {
+    "monaco-editor": {
+      "dompurify": "$dompurify"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-toast": "^1.2.15",
     "@radix-ui/react-tooltip": "^1.2.8",
-    "@scalar/api-reference-react": "^0.9.20",
+    "@scalar/api-reference-react": "0.9.20",
     "@tanstack/react-query": "^5.90.5",
     "@tanstack/react-query-devtools": "^5.90.2",
     "@tiptap/extension-blockquote": "^2.10.0",

--- a/src/app/api-docs/api-docs.css
+++ b/src/app/api-docs/api-docs.css
@@ -1,0 +1,54 @@
+/*
+ * Scoped overrides for the /api-docs page.
+ *
+ * This file is only imported by src/app/api-docs/page.tsx, so Next.js only
+ * loads it when the docs page is active. Every rule is additionally scoped
+ * via `body:has(.scalar-app)` or by targeting stable Scalar-specific class
+ * names, so nothing bleeds into other routes of the project even if the
+ * stylesheet happened to leak into the global cascade.
+ *
+ * All overrides use `!important` because Scalar ships its own inline styles
+ * with high specificity from Vue scoped CSS.
+ */
+
+/* ---------------------------------------------------------------------------
+ * Hide the global aquario NavWrapper on /api-docs.
+ *
+ * The Scalar reference is a full-screen documentation surface — it owns its
+ * own sidebar, search and theme controls. Stacking the site's global navbar
+ * on top of it halves the visible viewport and overlaps the Scalar sidebar.
+ *
+ * `:has(.scalar-app)` is a conditional selector that only matches when the
+ * Scalar root component is present in the DOM, which only happens on this
+ * page. In every other route of the site the selector does not match and
+ * the NavWrapper renders normally.
+ * ------------------------------------------------------------------------- */
+body:has(.scalar-app) > div > nav {
+  display: none !important;
+}
+
+/* ---------------------------------------------------------------------------
+ * Hide Scalar's upstream "Developer Tools / Configure / Share / Deploy"
+ * toolbar that renders above the main content area.
+ *
+ * These buttons belong to Scalar Cloud / workspace features that are not
+ * part of the aquario's documentation workflow. The `.api-reference-toolbar`
+ * class is a stable, semantically-named Scalar class (verified live on the
+ * rendered DOM) specifically applied to the `<header>` containing those
+ * four buttons.
+ * ------------------------------------------------------------------------- */
+.api-reference-toolbar {
+  display: none !important;
+}
+
+/* ---------------------------------------------------------------------------
+ * Hide Scalar's "Generate MCP / VS Code / Cursor" integration block in the
+ * sidebar footer. This is an upstream Scalar feature for wiring the spec
+ * into IDEs via the Model Context Protocol, which the aquario does not use.
+ *
+ * The `.scalar-mcp-layer` class is a namespaced Scalar class (part of the
+ * official `scalar-*` namespace) with a single, well-defined purpose.
+ * ------------------------------------------------------------------------- */
+.scalar-mcp-layer {
+  display: none !important;
+}

--- a/src/app/api-docs/page.tsx
+++ b/src/app/api-docs/page.tsx
@@ -5,31 +5,7 @@ import "@scalar/api-reference-react/style.css";
 
 import "./api-docs.css";
 
-/**
- * Interactive API documentation page powered by Scalar.
- *
- * The Scalar component fetches the OpenAPI spec from `/api/openapi` on mount
- * and renders an interactive reference with a sidebar, code samples, and
- * "Try it out" functionality. The spec itself is generated from Zod schemas
- * registered in `src/lib/server/openapi/paths/`.
- *
- * This is a client component because the underlying Scalar renderer uses
- * browser-only APIs (the package is a Vue app wrapped in a React adapter).
- *
- * Layout notes:
- * - `layout: "modern"` — the default Scalar layout with the sidebar on the
- *   left and the content on the right. Visually the most polished option.
- * - `defaultOpenFirstTag: false` + `defaultOpenAllTags: false` — every tag
- *   group starts collapsed so the user can navigate intentionally instead
- *   of landing on a 19,000px-tall page with 56 endpoints already stacked.
- * - `hideModels: true` collapses the "Models" appendix at the end of the
- *   sidebar. Every component schema (ApiErrorBody, ErrorCode, PaginationMeta,
- *   UserProfile, etc) is already referenced inline on the endpoints that use
- *   it, so the dedicated models section only adds redundant navigation noise.
- * - Visual tweaks that Scalar's configuration API does not expose are
- *   handled in ./api-docs.css using CSS `:has()` and stable Scalar class
- *   names (verified live against the rendered DOM).
- */
+// "use client" is required — Scalar is a Vue app wrapped in a React adapter and uses browser-only APIs.
 export default function ApiDocsPage() {
   return (
     <ApiReferenceReact

--- a/src/app/api-docs/page.tsx
+++ b/src/app/api-docs/page.tsx
@@ -3,6 +3,8 @@
 import { ApiReferenceReact } from "@scalar/api-reference-react";
 import "@scalar/api-reference-react/style.css";
 
+import "./api-docs.css";
+
 /**
  * Interactive API documentation page powered by Scalar.
  *
@@ -13,15 +15,31 @@ import "@scalar/api-reference-react/style.css";
  *
  * This is a client component because the underlying Scalar renderer uses
  * browser-only APIs (the package is a Vue app wrapped in a React adapter).
+ *
+ * Layout notes:
+ * - `layout: "modern"` — the default Scalar layout with the sidebar on the
+ *   left and the content on the right. Visually the most polished option.
+ * - `defaultOpenFirstTag: false` + `defaultOpenAllTags: false` — every tag
+ *   group starts collapsed so the user can navigate intentionally instead
+ *   of landing on a 19,000px-tall page with 56 endpoints already stacked.
+ * - `hideModels: true` collapses the "Models" appendix at the end of the
+ *   sidebar. Every component schema (ApiErrorBody, ErrorCode, PaginationMeta,
+ *   UserProfile, etc) is already referenced inline on the endpoints that use
+ *   it, so the dedicated models section only adds redundant navigation noise.
+ * - Visual tweaks that Scalar's configuration API does not expose are
+ *   handled in ./api-docs.css using CSS `:has()` and stable Scalar class
+ *   names (verified live against the rendered DOM).
  */
 export default function ApiDocsPage() {
   return (
     <ApiReferenceReact
       configuration={{
         url: "/api/openapi",
-        theme: "default",
-        hideClientButton: false,
+        layout: "modern",
+        hideModels: true,
         defaultOpenAllTags: false,
+        defaultOpenFirstTag: false,
+        theme: "default",
         metaData: {
           title: "Aquário UFPB API — Documentation",
           description:

--- a/src/app/api-docs/page.tsx
+++ b/src/app/api-docs/page.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { ApiReferenceReact } from "@scalar/api-reference-react";
+import "@scalar/api-reference-react/style.css";
+
+/**
+ * Interactive API documentation page powered by Scalar.
+ *
+ * The Scalar component fetches the OpenAPI spec from `/api/openapi` on mount
+ * and renders an interactive reference with a sidebar, code samples, and
+ * "Try it out" functionality. The spec itself is generated from Zod schemas
+ * registered in `src/lib/server/openapi/paths/`.
+ *
+ * This is a client component because the underlying Scalar renderer uses
+ * browser-only APIs (the package is a Vue app wrapped in a React adapter).
+ */
+export default function ApiDocsPage() {
+  return (
+    <ApiReferenceReact
+      configuration={{
+        url: "/api/openapi",
+        theme: "default",
+        hideClientButton: false,
+        defaultOpenAllTags: false,
+        metaData: {
+          title: "Aquário UFPB API — Documentation",
+          description:
+            "Interactive reference for the Aquário UFPB API. Test endpoints directly from your browser.",
+        },
+      }}
+    />
+  );
+}

--- a/src/app/api/auth/esqueci-senha/route.ts
+++ b/src/app/api/auth/esqueci-senha/route.ts
@@ -5,7 +5,7 @@ import { getContainer } from "@/lib/server/container";
 import { forgotPassword } from "@/lib/server/services/auth/forgot-password";
 import { fromZodError } from "@/lib/server/errors";
 
-const forgotPasswordSchema = z.object({
+export const forgotPasswordSchema = z.object({
   email: z.string().email("Email inválido"),
 });
 

--- a/src/app/api/auth/esqueci-senha/route.ts
+++ b/src/app/api/auth/esqueci-senha/route.ts
@@ -4,10 +4,7 @@ import { z } from "zod";
 import { getContainer } from "@/lib/server/container";
 import { forgotPassword } from "@/lib/server/services/auth/forgot-password";
 import { fromZodError } from "@/lib/server/errors";
-
-export const forgotPasswordSchema = z.object({
-  email: z.string().email("Email inválido"),
-});
+import { forgotPasswordSchema } from "@/lib/server/api-schemas/auth";
 
 export async function POST(request: Request) {
   try {

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -12,7 +12,7 @@ const LOGIN_RATE_LIMIT = {
   windowMs: 60 * 1000, // 1 minute
 };
 
-const loginSchema = z.object({
+export const loginSchema = z.object({
   email: z.string().email("Email inválido"),
   senha: z.string().min(1, "Senha é obrigatória"),
 });

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -5,17 +5,13 @@ import { getContainer } from "@/lib/server/container";
 import { authenticate } from "@/lib/server/services/auth/authenticate";
 import { checkRateLimit, getClientIP } from "@/lib/server/services/rate-limit/rate-limiter";
 import { ApiError, fromZodError, ErrorCode } from "@/lib/server/errors";
+import { loginSchema } from "@/lib/server/api-schemas/auth";
 
 // Rate limit: 5 login attempts per minute per IP
 const LOGIN_RATE_LIMIT = {
   limit: 5,
   windowMs: 60 * 1000, // 1 minute
 };
-
-export const loginSchema = z.object({
-  email: z.string().email("Email inválido"),
-  senha: z.string().min(1, "Senha é obrigatória"),
-});
 
 export async function POST(request: Request) {
   // Check rate limit

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -4,18 +4,7 @@ import { z } from "zod";
 import { getContainer } from "@/lib/server/container";
 import { register } from "@/lib/server/services/auth/register";
 import { ApiError, fromZodError } from "@/lib/server/errors";
-
-export const registerSchema = z.object({
-  nome: z.string().min(2, "Nome deve ter pelo menos 2 caracteres"),
-  email: z.string().email("Email inválido"),
-  senha: z
-    .string()
-    .min(8, "Senha deve ter pelo menos 8 caracteres")
-    .max(128, "Senha deve ter no máximo 128 caracteres"),
-  centroId: z.string().uuid("Centro inválido"),
-  cursoId: z.string().uuid("Curso inválido"),
-  urlFotoPerfil: z.string().url().optional(),
-});
+import { registerSchema } from "@/lib/server/api-schemas/auth";
 
 export async function POST(request: Request) {
   try {

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -34,7 +34,7 @@ export async function POST(request: Request) {
 
     const message = error instanceof Error ? error.message : "Erro no cadastro";
 
-    if (message === "EMAIL_JA_CADASTRADO") {
+    if (message === "Este e-mail já está em uso.") {
       return ApiError.emailExists();
     }
 

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -5,7 +5,7 @@ import { getContainer } from "@/lib/server/container";
 import { register } from "@/lib/server/services/auth/register";
 import { ApiError, fromZodError } from "@/lib/server/errors";
 
-const registerSchema = z.object({
+export const registerSchema = z.object({
   nome: z.string().min(2, "Nome deve ter pelo menos 2 caracteres"),
   email: z.string().email("Email inválido"),
   senha: z

--- a/src/app/api/auth/resetar-senha/route.ts
+++ b/src/app/api/auth/resetar-senha/route.ts
@@ -5,7 +5,7 @@ import { getContainer } from "@/lib/server/container";
 import { resetPassword } from "@/lib/server/services/auth/reset-password";
 import { ApiError, fromZodError } from "@/lib/server/errors";
 
-const resetPasswordSchema = z.object({
+export const resetPasswordSchema = z.object({
   token: z.string().min(1, "Token é obrigatório"),
   novaSenha: z.string().min(8, "Senha deve ter pelo menos 8 caracteres"),
 });

--- a/src/app/api/auth/resetar-senha/route.ts
+++ b/src/app/api/auth/resetar-senha/route.ts
@@ -4,11 +4,7 @@ import { z } from "zod";
 import { getContainer } from "@/lib/server/container";
 import { resetPassword } from "@/lib/server/services/auth/reset-password";
 import { ApiError, fromZodError } from "@/lib/server/errors";
-
-export const resetPasswordSchema = z.object({
-  token: z.string().min(1, "Token é obrigatório"),
-  novaSenha: z.string().min(8, "Senha deve ter pelo menos 8 caracteres"),
-});
+import { resetPasswordSchema } from "@/lib/server/api-schemas/auth";
 
 export async function POST(request: Request) {
   try {

--- a/src/app/api/auth/solicitar-reenvio-verificacao/route.ts
+++ b/src/app/api/auth/solicitar-reenvio-verificacao/route.ts
@@ -5,14 +5,14 @@ import { getContainer } from "@/lib/server/container";
 import { resendVerificationByEmail } from "@/lib/server/services/auth/resend-verification";
 import { fromZodError } from "@/lib/server/errors";
 
-const requestSchema = z.object({
+export const resendVerificationRequestSchema = z.object({
   email: z.string().email("Email inválido"),
 });
 
 export async function POST(request: Request) {
   try {
     const body = await request.json();
-    const { email } = requestSchema.parse(body);
+    const { email } = resendVerificationRequestSchema.parse(body);
 
     const container = getContainer();
     const result = await resendVerificationByEmail(

--- a/src/app/api/auth/solicitar-reenvio-verificacao/route.ts
+++ b/src/app/api/auth/solicitar-reenvio-verificacao/route.ts
@@ -4,10 +4,7 @@ import { z } from "zod";
 import { getContainer } from "@/lib/server/container";
 import { resendVerificationByEmail } from "@/lib/server/services/auth/resend-verification";
 import { fromZodError } from "@/lib/server/errors";
-
-export const resendVerificationRequestSchema = z.object({
-  email: z.string().email("Email inválido"),
-});
+import { resendVerificationRequestSchema } from "@/lib/server/api-schemas/auth";
 
 export async function POST(request: Request) {
   try {

--- a/src/app/api/auth/verificar-email/route.ts
+++ b/src/app/api/auth/verificar-email/route.ts
@@ -4,10 +4,7 @@ import { z } from "zod";
 import { getContainer } from "@/lib/server/container";
 import { verifyEmail } from "@/lib/server/services/auth/verify-email";
 import { ApiError, fromZodError } from "@/lib/server/errors";
-
-export const verifySchema = z.object({
-  token: z.string().min(1, "Token é obrigatório"),
-});
+import { verifySchema } from "@/lib/server/api-schemas/auth";
 
 export async function POST(request: Request) {
   try {

--- a/src/app/api/auth/verificar-email/route.ts
+++ b/src/app/api/auth/verificar-email/route.ts
@@ -5,7 +5,7 @@ import { getContainer } from "@/lib/server/container";
 import { verifyEmail } from "@/lib/server/services/auth/verify-email";
 import { ApiError, fromZodError } from "@/lib/server/errors";
 
-const verifySchema = z.object({
+export const verifySchema = z.object({
   token: z.string().min(1, "Token é obrigatório"),
 });
 

--- a/src/app/api/calendario-academico/[id]/eventos/[eventoId]/route.ts
+++ b/src/app/api/calendario-academico/[id]/eventos/[eventoId]/route.ts
@@ -12,7 +12,7 @@ const dateString = z
   .string()
   .refine(s => !isNaN(new Date(s).getTime()), { message: "Data inválida" });
 
-const updateEventoSchema = z.object({
+export const updateEventoSchema = z.object({
   descricao: z.string().min(1).optional(),
   dataInicio: dateString.optional(),
   dataFim: dateString.optional(),

--- a/src/app/api/calendario-academico/[id]/eventos/[eventoId]/route.ts
+++ b/src/app/api/calendario-academico/[id]/eventos/[eventoId]/route.ts
@@ -3,21 +3,10 @@ import { z } from "zod";
 import { getContainer } from "@/lib/server/container";
 import { ApiError, fromZodError } from "@/lib/server/errors";
 import { withAdmin } from "@/lib/server/services/auth/middleware";
-import { ALL_CATEGORIAS } from "@/lib/shared/config/calendario-academico";
+import { updateEventoSchema } from "@/lib/server/api-schemas/calendario";
 import type { UpdateEventoInput } from "@/lib/server/db/interfaces/calendario-repository.interface";
 
 type RouteContext = { params: Promise<{ id: string; eventoId: string }> };
-
-const dateString = z
-  .string()
-  .refine(s => !isNaN(new Date(s).getTime()), { message: "Data inválida" });
-
-export const updateEventoSchema = z.object({
-  descricao: z.string().min(1).optional(),
-  dataInicio: dateString.optional(),
-  dataFim: dateString.optional(),
-  categoria: z.enum(ALL_CATEGORIAS).optional(),
-});
 
 export function PUT(request: Request, context: RouteContext) {
   return withAdmin(request, async req => {

--- a/src/app/api/calendario-academico/[id]/eventos/batch/route.ts
+++ b/src/app/api/calendario-academico/[id]/eventos/batch/route.ts
@@ -3,26 +3,9 @@ import { z } from "zod";
 import { getContainer } from "@/lib/server/container";
 import { ApiError, fromZodError } from "@/lib/server/errors";
 import { withAdmin } from "@/lib/server/services/auth/middleware";
-import { ALL_CATEGORIAS } from "@/lib/shared/config/calendario-academico";
+import { batchCreateSchema } from "@/lib/server/api-schemas/calendario";
 
 type RouteContext = { params: Promise<{ id: string }> };
-
-const dateString = z
-  .string()
-  .min(1, "Data é obrigatória")
-  .refine(s => !isNaN(new Date(s).getTime()), { message: "Data inválida" });
-
-export const batchCreateSchema = z.object({
-  eventos: z.array(
-    z.object({
-      descricao: z.string().min(1),
-      dataInicio: dateString,
-      dataFim: dateString,
-      categoria: z.enum(ALL_CATEGORIAS).default("OUTRA"),
-    })
-  ),
-  replace: z.boolean().default(false),
-});
 
 export function POST(request: Request, context: RouteContext) {
   return withAdmin(request, async req => {

--- a/src/app/api/calendario-academico/[id]/eventos/batch/route.ts
+++ b/src/app/api/calendario-academico/[id]/eventos/batch/route.ts
@@ -12,7 +12,7 @@ const dateString = z
   .min(1, "Data é obrigatória")
   .refine(s => !isNaN(new Date(s).getTime()), { message: "Data inválida" });
 
-const batchCreateSchema = z.object({
+export const batchCreateSchema = z.object({
   eventos: z.array(
     z.object({
       descricao: z.string().min(1),

--- a/src/app/api/calendario-academico/[id]/eventos/route.ts
+++ b/src/app/api/calendario-academico/[id]/eventos/route.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { getContainer } from "@/lib/server/container";
 import { ApiError, fromZodError } from "@/lib/server/errors";
 import { withAdmin } from "@/lib/server/services/auth/middleware";
-import { ALL_CATEGORIAS } from "@/lib/shared/config/calendario-academico";
+import { createEventoSchema } from "@/lib/server/api-schemas/calendario";
 
 type RouteContext = { params: Promise<{ id: string }> };
 
@@ -23,18 +23,6 @@ export async function GET(_request: Request, context: RouteContext) {
     return ApiError.internal("Erro ao buscar eventos");
   }
 }
-
-const dateString = z
-  .string()
-  .min(1, "Data é obrigatória")
-  .refine(s => !isNaN(new Date(s).getTime()), { message: "Data inválida" });
-
-export const createEventoSchema = z.object({
-  descricao: z.string().min(1, "Descrição é obrigatória"),
-  dataInicio: dateString,
-  dataFim: dateString,
-  categoria: z.enum(ALL_CATEGORIAS).default("OUTRA"),
-});
 
 export function POST(request: Request, context: RouteContext) {
   return withAdmin(request, async req => {

--- a/src/app/api/calendario-academico/[id]/eventos/route.ts
+++ b/src/app/api/calendario-academico/[id]/eventos/route.ts
@@ -29,7 +29,7 @@ const dateString = z
   .min(1, "Data é obrigatória")
   .refine(s => !isNaN(new Date(s).getTime()), { message: "Data inválida" });
 
-const createEventoSchema = z.object({
+export const createEventoSchema = z.object({
   descricao: z.string().min(1, "Descrição é obrigatória"),
   dataInicio: dateString,
   dataFim: dateString,

--- a/src/app/api/calendario-academico/[id]/route.ts
+++ b/src/app/api/calendario-academico/[id]/route.ts
@@ -26,7 +26,7 @@ const dateString = z
   .string()
   .refine(s => !isNaN(new Date(s).getTime()), { message: "Data inválida" });
 
-const updateSemestreSchema = z.object({
+export const updateSemestreSchema = z.object({
   nome: z.string().min(1).optional(),
   dataInicio: dateString.optional(),
   dataFim: dateString.optional(),

--- a/src/app/api/calendario-academico/[id]/route.ts
+++ b/src/app/api/calendario-academico/[id]/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { getContainer } from "@/lib/server/container";
 import { ApiError, fromZodError } from "@/lib/server/errors";
 import { withAdmin } from "@/lib/server/services/auth/middleware";
+import { updateSemestreSchema } from "@/lib/server/api-schemas/calendario";
 
 type RouteContext = { params: Promise<{ id: string }> };
 
@@ -21,16 +22,6 @@ export async function GET(_request: Request, context: RouteContext) {
     return ApiError.internal("Erro ao buscar semestre");
   }
 }
-
-const dateString = z
-  .string()
-  .refine(s => !isNaN(new Date(s).getTime()), { message: "Data inválida" });
-
-export const updateSemestreSchema = z.object({
-  nome: z.string().min(1).optional(),
-  dataInicio: dateString.optional(),
-  dataFim: dateString.optional(),
-});
 
 export function PUT(request: Request, context: RouteContext) {
   return withAdmin(request, async req => {

--- a/src/app/api/calendario-academico/route.ts
+++ b/src/app/api/calendario-academico/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { getContainer } from "@/lib/server/container";
 import { ApiError, fromZodError } from "@/lib/server/errors";
 import { withAdmin } from "@/lib/server/services/auth/middleware";
+import { createSemestreSchema } from "@/lib/server/api-schemas/calendario";
 
 export const dynamic = "force-dynamic";
 
@@ -23,17 +24,6 @@ export async function GET(request: Request) {
     return ApiError.internal("Erro ao buscar semestres");
   }
 }
-
-const dateString = z
-  .string()
-  .min(1, "Data é obrigatória")
-  .refine(s => !isNaN(new Date(s).getTime()), { message: "Data inválida" });
-
-export const createSemestreSchema = z.object({
-  nome: z.string().min(1, "Nome é obrigatório"),
-  dataInicio: dateString,
-  dataFim: dateString,
-});
 
 export function POST(request: Request) {
   return withAdmin(request, async req => {

--- a/src/app/api/calendario-academico/route.ts
+++ b/src/app/api/calendario-academico/route.ts
@@ -29,7 +29,7 @@ const dateString = z
   .min(1, "Data é obrigatória")
   .refine(s => !isNaN(new Date(s).getTime()), { message: "Data inválida" });
 
-const createSemestreSchema = z.object({
+export const createSemestreSchema = z.object({
   nome: z.string().min(1, "Nome é obrigatório"),
   dataInicio: dateString,
   dataFim: dateString,

--- a/src/app/api/entidades/[id]/cargos/route.ts
+++ b/src/app/api/entidades/[id]/cargos/route.ts
@@ -9,13 +9,13 @@ type RouteContext = {
   params: Promise<{ id: string }>;
 };
 
-const createCargoSchema = z.object({
+export const createCargoSchema = z.object({
   nome: z.string().min(1, "Nome do cargo é obrigatório"),
   descricao: z.string().nullable().optional(),
   ordem: z.number().int().default(0),
 });
 
-const updateCargoSchema = z.object({
+export const updateCargoSchema = z.object({
   nome: z.string().min(1, "Nome do cargo é obrigatório").optional(),
   descricao: z.string().nullable().optional(),
   ordem: z.number().int().optional(),

--- a/src/app/api/entidades/[id]/cargos/route.ts
+++ b/src/app/api/entidades/[id]/cargos/route.ts
@@ -4,22 +4,11 @@ import { z } from "zod";
 import { withAuth } from "@/lib/server/services/auth/middleware";
 import { getContainer } from "@/lib/server/container";
 import { ApiError, fromZodError } from "@/lib/server/errors";
+import { createCargoSchema, updateCargoSchema } from "@/lib/server/api-schemas/entidades";
 
 type RouteContext = {
   params: Promise<{ id: string }>;
 };
-
-export const createCargoSchema = z.object({
-  nome: z.string().min(1, "Nome do cargo é obrigatório"),
-  descricao: z.string().nullable().optional(),
-  ordem: z.number().int().default(0),
-});
-
-export const updateCargoSchema = z.object({
-  nome: z.string().min(1, "Nome do cargo é obrigatório").optional(),
-  descricao: z.string().nullable().optional(),
-  ordem: z.number().int().optional(),
-});
 
 // GET - List all cargos for an entidade
 export async function GET(_request: Request, context: RouteContext) {

--- a/src/app/api/entidades/[id]/membros/[membroId]/route.ts
+++ b/src/app/api/entidades/[id]/membros/[membroId]/route.ts
@@ -9,7 +9,7 @@ type RouteContext = {
   params: Promise<{ id: string; membroId: string }>;
 };
 
-const updateMemberSchema = z.object({
+export const updateMemberSchema = z.object({
   papel: z.enum(["ADMIN", "MEMBRO"]).optional(),
   cargoId: z.string().uuid("ID de cargo inválido").nullable().optional(),
   startedAt: z.string().optional(), // ISO date string

--- a/src/app/api/entidades/[id]/membros/[membroId]/route.ts
+++ b/src/app/api/entidades/[id]/membros/[membroId]/route.ts
@@ -4,17 +4,11 @@ import { z } from "zod";
 import { withAuth } from "@/lib/server/services/auth/middleware";
 import { getContainer } from "@/lib/server/container";
 import { ApiError, fromZodError } from "@/lib/server/errors";
+import { updateMemberSchema } from "@/lib/server/api-schemas/entidades";
 
 type RouteContext = {
   params: Promise<{ id: string; membroId: string }>;
 };
-
-export const updateMemberSchema = z.object({
-  papel: z.enum(["ADMIN", "MEMBRO"]).optional(),
-  cargoId: z.string().uuid("ID de cargo inválido").nullable().optional(),
-  startedAt: z.string().optional(), // ISO date string
-  endedAt: z.string().nullable().optional(), // ISO date string or null
-});
 
 export async function PUT(request: Request, context: RouteContext) {
   return await withAuth(request, async (req, usuario) => {

--- a/src/app/api/entidades/[id]/membros/route.ts
+++ b/src/app/api/entidades/[id]/membros/route.ts
@@ -4,18 +4,11 @@ import { z } from "zod";
 import { getContainer } from "@/lib/server/container";
 import { withAuth } from "@/lib/server/services/auth/middleware";
 import { ApiError, fromZodError } from "@/lib/server/errors";
+import { addMemberSchema } from "@/lib/server/api-schemas/entidades";
 
 type RouteContext = {
   params: Promise<{ id: string }>;
 };
-
-export const addMemberSchema = z.object({
-  usuarioId: z.string().uuid("ID de usuário inválido"),
-  papel: z.enum(["ADMIN", "MEMBRO"]),
-  cargoId: z.string().uuid("ID de cargo inválido").nullable().optional(),
-  startedAt: z.string().optional(), // ISO date string
-  endedAt: z.string().nullable().optional(), // ISO date string or null
-});
 
 export async function POST(request: Request, context: RouteContext) {
   return await withAuth(request, async (req, usuario) => {

--- a/src/app/api/entidades/[id]/membros/route.ts
+++ b/src/app/api/entidades/[id]/membros/route.ts
@@ -9,7 +9,7 @@ type RouteContext = {
   params: Promise<{ id: string }>;
 };
 
-const addMemberSchema = z.object({
+export const addMemberSchema = z.object({
   usuarioId: z.string().uuid("ID de usuário inválido"),
   papel: z.enum(["ADMIN", "MEMBRO"]),
   cargoId: z.string().uuid("ID de cargo inválido").nullable().optional(),

--- a/src/app/api/entidades/[id]/route.ts
+++ b/src/app/api/entidades/[id]/route.ts
@@ -4,35 +4,11 @@ import { z } from "zod";
 import { getContainer } from "@/lib/server/container";
 import { withAuth } from "@/lib/server/services/auth/middleware";
 import { ApiError, fromZodError } from "@/lib/server/errors";
+import { updateEntidadeSchema } from "@/lib/server/api-schemas/entidades";
 
 type RouteContext = {
   params: Promise<{ id: string }>;
 };
-
-export const updateEntidadeSchema = z.object({
-  nome: z.string().optional(),
-  subtitle: z.string().nullable().optional(),
-  descricao: z.string().nullable().optional(),
-  tipo: z
-    .enum([
-      "LABORATORIO",
-      "GRUPO",
-      "LIGA_ACADEMICA",
-      "EMPRESA",
-      "ATLETICA",
-      "CENTRO_ACADEMICO",
-      "OUTRO",
-    ])
-    .optional(),
-  urlFoto: z.string().nullable().optional(),
-  contato: z.string().nullable().optional(),
-  instagram: z.string().nullable().optional(),
-  linkedin: z.string().nullable().optional(),
-  website: z.string().nullable().optional(),
-  location: z.string().nullable().optional(),
-  foundingDate: z.string().nullable().optional(),
-  slug: z.string().optional(),
-});
 
 export function PUT(request: Request, context: RouteContext) {
   return withAuth(request, async (req, usuario) => {

--- a/src/app/api/entidades/[id]/route.ts
+++ b/src/app/api/entidades/[id]/route.ts
@@ -9,7 +9,7 @@ type RouteContext = {
   params: Promise<{ id: string }>;
 };
 
-const updateEntidadeSchema = z.object({
+export const updateEntidadeSchema = z.object({
   nome: z.string().optional(),
   subtitle: z.string().nullable().optional(),
   descricao: z.string().nullable().optional(),

--- a/src/app/api/openapi/__tests__/route.test.ts
+++ b/src/app/api/openapi/__tests__/route.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @jest-environment node
+ *
+ * The route handler and its transitive imports (via the OpenAPI generator)
+ * pull in Next.js runtime modules that need Node's global Request/Response.
+ */
+import { describe, it, expect, beforeEach } from "@jest/globals";
+
+import { __resetOpenApiCacheForTests } from "@/lib/server/openapi/generator";
+
+import { GET, OPTIONS } from "../route";
+
+describe("GET /api/openapi", () => {
+  beforeEach(() => {
+    __resetOpenApiCacheForTests();
+  });
+
+  it("responds with status 200", () => {
+    const response = GET();
+    expect(response.status).toBe(200);
+  });
+
+  it("responds with content-type application/json", () => {
+    const response = GET();
+    expect(response.headers.get("content-type")).toMatch(/application\/json/);
+  });
+
+  it("sets CORS headers so external tools can import the spec", () => {
+    const response = GET();
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
+    expect(response.headers.get("access-control-allow-methods")).toContain("GET");
+  });
+
+  it("returns a body that parses as an OpenAPI 3.1 document", async () => {
+    const response = GET();
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(body.openapi).toBe("3.1.0");
+    expect(body.info).toBeDefined();
+    expect(body.paths).toBeDefined();
+    expect(Object.keys(body.paths as Record<string, unknown>).length).toBeGreaterThan(0);
+  });
+
+  it("returns the same cached document across multiple requests", async () => {
+    const first = (await GET().json()) as { info: { version: string } };
+    const second = (await GET().json()) as { info: { version: string } };
+
+    // We can't check reference equality across serialized JSON responses, so
+    // we assert that the version field is stable (the underlying cache is
+    // validated separately in generator.test.ts).
+    expect(second.info.version).toBe(first.info.version);
+  });
+});
+
+describe("OPTIONS /api/openapi (CORS preflight)", () => {
+  it("responds with status 204", () => {
+    const response = OPTIONS();
+    expect(response.status).toBe(204);
+  });
+
+  it("sets the preflight CORS headers", () => {
+    const response = OPTIONS();
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
+    expect(response.headers.get("access-control-allow-methods")).toContain("GET");
+    expect(response.headers.get("access-control-max-age")).toBeTruthy();
+  });
+
+  it("returns an empty body", async () => {
+    const response = OPTIONS();
+    const text = await response.text();
+    expect(text).toBe("");
+  });
+});

--- a/src/app/api/openapi/__tests__/route.test.ts
+++ b/src/app/api/openapi/__tests__/route.test.ts
@@ -41,14 +41,11 @@ describe("GET /api/openapi", () => {
     expect(Object.keys(body.paths as Record<string, unknown>).length).toBeGreaterThan(0);
   });
 
-  it("returns the same cached document across multiple requests", async () => {
-    const first = (await GET().json()) as { info: { version: string } };
-    const second = (await GET().json()) as { info: { version: string } };
+  it("returns a deterministic OpenAPI payload across multiple requests", async () => {
+    const first = (await GET().json()) as Record<string, unknown>;
+    const second = (await GET().json()) as Record<string, unknown>;
 
-    // We can't check reference equality across serialized JSON responses, so
-    // we assert that the version field is stable (the underlying cache is
-    // validated separately in generator.test.ts).
-    expect(second.info.version).toBe(first.info.version);
+    expect(second).toEqual(first);
   });
 });
 

--- a/src/app/api/openapi/route.ts
+++ b/src/app/api/openapi/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+
+import { getOpenApiDocument } from "@/lib/server/openapi/generator";
+
+/**
+ * GET /api/openapi
+ *
+ * Returns the generated OpenAPI 3.1 document describing every public endpoint
+ * of the Aquário API. The spec is built once per process on first request and
+ * served from a module-level cache afterwards (see `getOpenApiDocument`).
+ *
+ * This route intentionally does NOT set `export const dynamic = "force-dynamic"`:
+ * the spec is a pure function of the deployed code, so letting Next.js cache
+ * the response is correct and avoids recomputing the document on every request.
+ *
+ * The `Access-Control-Allow-Origin: *` header is set explicitly so third-party
+ * tools (Postman, Insomnia, Scalar cloud) can import the spec without hitting
+ * CORS errors — the documentation is public by design.
+ */
+export function GET() {
+  return NextResponse.json(getOpenApiDocument(), {
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+    },
+  });
+}
+
+/**
+ * Handle CORS preflight for the spec endpoint.
+ * Some HTTP clients send an OPTIONS request before the actual GET when
+ * fetching the spec cross-origin.
+ */
+export function OPTIONS() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+      "Access-Control-Max-Age": "86400",
+    },
+  });
+}

--- a/src/app/api/usuarios/[id]/info/route.ts
+++ b/src/app/api/usuarios/[id]/info/route.ts
@@ -9,7 +9,7 @@ type RouteContext = {
   params: Promise<{ id: string }>;
 };
 
-const updateUserInfoSchema = z.object({
+export const updateUserInfoSchema = z.object({
   centroId: z.string().optional(),
   cursoId: z.string().optional(),
 });

--- a/src/app/api/usuarios/[id]/info/route.ts
+++ b/src/app/api/usuarios/[id]/info/route.ts
@@ -4,15 +4,11 @@ import { withAdmin } from "@/lib/server/services/auth/middleware";
 import { getContainer } from "@/lib/server/container";
 import { z } from "zod";
 import { ApiError, fromZodError } from "@/lib/server/errors";
+import { updateUserInfoSchema } from "@/lib/server/api-schemas/usuarios";
 
 type RouteContext = {
   params: Promise<{ id: string }>;
 };
-
-export const updateUserInfoSchema = z.object({
-  centroId: z.string().optional(),
-  cursoId: z.string().optional(),
-});
 
 export function PATCH(request: Request, context: RouteContext) {
   return withAdmin(request, async req => {

--- a/src/app/api/usuarios/[id]/role/route.ts
+++ b/src/app/api/usuarios/[id]/role/route.ts
@@ -4,14 +4,11 @@ import { z } from "zod";
 import { withAdmin } from "@/lib/server/services/auth/middleware";
 import { getContainer } from "@/lib/server/container";
 import { ApiError, fromZodError } from "@/lib/server/errors";
+import { updateRoleSchema } from "@/lib/server/api-schemas/usuarios";
 
 type RouteContext = {
   params: Promise<{ id: string }>;
 };
-
-export const updateRoleSchema = z.object({
-  papelPlataforma: z.enum(["USER", "MASTER_ADMIN"]),
-});
 
 export function PATCH(request: Request, context: RouteContext) {
   return withAdmin(request, async (req, currentUser) => {

--- a/src/app/api/usuarios/[id]/role/route.ts
+++ b/src/app/api/usuarios/[id]/role/route.ts
@@ -9,7 +9,7 @@ type RouteContext = {
   params: Promise<{ id: string }>;
 };
 
-const updateRoleSchema = z.object({
+export const updateRoleSchema = z.object({
   papelPlataforma: z.enum(["USER", "MASTER_ADMIN"]),
 });
 

--- a/src/app/api/usuarios/[id]/slug/route.ts
+++ b/src/app/api/usuarios/[id]/slug/route.ts
@@ -4,14 +4,11 @@ import { z } from "zod";
 import { withAdmin } from "@/lib/server/services/auth/middleware";
 import { getContainer } from "@/lib/server/container";
 import { ApiError, fromZodError } from "@/lib/server/errors";
+import { updateSlugSchema } from "@/lib/server/api-schemas/usuarios";
 
 type RouteContext = {
   params: Promise<{ id: string }>;
 };
-
-export const updateSlugSchema = z.object({
-  slug: z.string().nullable(),
-});
 
 export function PATCH(request: Request, context: RouteContext) {
   return withAdmin(request, async req => {

--- a/src/app/api/usuarios/[id]/slug/route.ts
+++ b/src/app/api/usuarios/[id]/slug/route.ts
@@ -9,7 +9,7 @@ type RouteContext = {
   params: Promise<{ id: string }>;
 };
 
-const updateSlugSchema = z.object({
+export const updateSlugSchema = z.object({
   slug: z.string().nullable(),
 });
 

--- a/src/app/api/usuarios/facade/route.ts
+++ b/src/app/api/usuarios/facade/route.ts
@@ -5,7 +5,7 @@ import { withAdmin } from "@/lib/server/services/auth/middleware";
 import { getContainer } from "@/lib/server/container";
 import { ApiError, fromZodError } from "@/lib/server/errors";
 
-const createFacadeUserSchema = z.object({
+export const createFacadeUserSchema = z.object({
   nome: z.string().min(2, "Nome deve ter pelo menos 2 caracteres"),
   centroId: z.string().uuid("Centro inválido"),
   cursoId: z.string().uuid("Curso inválido"),

--- a/src/app/api/usuarios/facade/route.ts
+++ b/src/app/api/usuarios/facade/route.ts
@@ -4,12 +4,7 @@ import { z } from "zod";
 import { withAdmin } from "@/lib/server/services/auth/middleware";
 import { getContainer } from "@/lib/server/container";
 import { ApiError, fromZodError } from "@/lib/server/errors";
-
-export const createFacadeUserSchema = z.object({
-  nome: z.string().min(2, "Nome deve ter pelo menos 2 caracteres"),
-  centroId: z.string().uuid("Centro inválido"),
-  cursoId: z.string().uuid("Curso inválido"),
-});
+import { createFacadeUserSchema } from "@/lib/server/api-schemas/usuarios";
 
 export async function POST(request: Request) {
   return await withAdmin(request, async () => {

--- a/src/app/api/usuarios/me/disciplinas/marcar/route.ts
+++ b/src/app/api/usuarios/me/disciplinas/marcar/route.ts
@@ -2,14 +2,9 @@ import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/server/services/auth/middleware";
 import { ApiError } from "@/lib/server/errors";
 import { getContainer } from "@/lib/server/container";
-import { z } from "zod";
+import { marcarDisciplinasSchema } from "@/lib/server/api-schemas/usuarios";
 
 export const dynamic = "force-dynamic";
-
-export const marcarDisciplinasSchema = z.object({
-  disciplinaIds: z.array(z.string().uuid()).min(1),
-  status: z.enum(["concluida", "cursando", "none"]),
-});
 
 /**
  * POST /api/usuarios/me/disciplinas/marcar

--- a/src/app/api/usuarios/me/disciplinas/marcar/route.ts
+++ b/src/app/api/usuarios/me/disciplinas/marcar/route.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 
 export const dynamic = "force-dynamic";
 
-const marcarSchema = z.object({
+export const marcarDisciplinasSchema = z.object({
   disciplinaIds: z.array(z.string().uuid()).min(1),
   status: z.enum(["concluida", "cursando", "none"]),
 });
@@ -25,7 +25,7 @@ export function POST(request: Request) {
       } catch {
         return ApiError.badRequest("Corpo da requisição inválido");
       }
-      const parsed = marcarSchema.safeParse(body);
+      const parsed = marcarDisciplinasSchema.safeParse(body);
       if (!parsed.success) {
         return ApiError.badRequest("disciplinaIds deve ser um array de UUIDs e status válido");
       }

--- a/src/app/api/usuarios/me/disciplinas/route.ts
+++ b/src/app/api/usuarios/me/disciplinas/route.ts
@@ -2,13 +2,9 @@ import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/server/services/auth/middleware";
 import { ApiError } from "@/lib/server/errors";
 import { getContainer } from "@/lib/server/container";
-import { z } from "zod";
+import { updateCompletedDisciplinasSchema } from "@/lib/server/api-schemas/usuarios";
 
 export const dynamic = "force-dynamic";
-
-export const updateCompletedDisciplinasSchema = z.object({
-  disciplinaIds: z.array(z.string().uuid()),
-});
 
 /**
  * GET /api/usuarios/me/disciplinas

--- a/src/app/api/usuarios/me/disciplinas/route.ts
+++ b/src/app/api/usuarios/me/disciplinas/route.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 
 export const dynamic = "force-dynamic";
 
-const updateSchema = z.object({
+export const updateCompletedDisciplinasSchema = z.object({
   disciplinaIds: z.array(z.string().uuid()),
 });
 
@@ -36,7 +36,7 @@ export function PUT(request: Request) {
   return withAuth(request, async (req, usuario) => {
     try {
       const body = await req.json();
-      const parsed = updateSchema.safeParse(body);
+      const parsed = updateCompletedDisciplinasSchema.safeParse(body);
 
       if (!parsed.success) {
         return ApiError.badRequest("disciplinaIds deve ser um array de UUIDs válidos");

--- a/src/app/api/usuarios/me/membros/[membroId]/route.ts
+++ b/src/app/api/usuarios/me/membros/[membroId]/route.ts
@@ -4,21 +4,11 @@ import { z } from "zod";
 import { withAuth } from "@/lib/server/services/auth/middleware";
 import { getContainer } from "@/lib/server/container";
 import { ApiError, fromZodError } from "@/lib/server/errors";
+import { updateOwnMembershipSchema } from "@/lib/server/api-schemas/usuarios";
 
 type RouteContext = {
   params: Promise<{ membroId: string }>;
 };
-
-const dateStringSchema = z
-  .string()
-  .refine(v => !isNaN(Date.parse(v)), { message: "Data inválida" });
-
-export const updateOwnMembershipSchema = z.object({
-  papel: z.enum(["ADMIN", "MEMBRO"]).optional(),
-  cargoId: z.string().uuid("ID de cargo inválido").nullable().optional(),
-  startedAt: dateStringSchema.optional(),
-  endedAt: dateStringSchema.nullable().optional(),
-});
 
 export async function PUT(request: Request, context: RouteContext) {
   return await withAuth(request, async (req, usuario) => {

--- a/src/app/api/usuarios/me/membros/[membroId]/route.ts
+++ b/src/app/api/usuarios/me/membros/[membroId]/route.ts
@@ -13,7 +13,7 @@ const dateStringSchema = z
   .string()
   .refine(v => !isNaN(Date.parse(v)), { message: "Data inválida" });
 
-const updateOwnMembershipSchema = z.object({
+export const updateOwnMembershipSchema = z.object({
   papel: z.enum(["ADMIN", "MEMBRO"]).optional(),
   cargoId: z.string().uuid("ID de cargo inválido").nullable().optional(),
   startedAt: dateStringSchema.optional(),

--- a/src/app/api/usuarios/me/membros/route.ts
+++ b/src/app/api/usuarios/me/membros/route.ts
@@ -9,7 +9,7 @@ const dateStringSchema = z
   .string()
   .refine(v => !isNaN(Date.parse(v)), { message: "Data inválida" });
 
-const createOwnMembershipSchema = z.object({
+export const createOwnMembershipSchema = z.object({
   entidadeId: z.string().uuid("ID de entidade inválido"),
   papel: z.enum(["ADMIN", "MEMBRO"]).optional().default("MEMBRO"),
   cargoId: z.string().uuid("ID de cargo inválido").nullable().optional(),

--- a/src/app/api/usuarios/me/membros/route.ts
+++ b/src/app/api/usuarios/me/membros/route.ts
@@ -4,18 +4,7 @@ import { z } from "zod";
 import { withAuth } from "@/lib/server/services/auth/middleware";
 import { getContainer } from "@/lib/server/container";
 import { ApiError, fromZodError } from "@/lib/server/errors";
-
-const dateStringSchema = z
-  .string()
-  .refine(v => !isNaN(Date.parse(v)), { message: "Data inválida" });
-
-export const createOwnMembershipSchema = z.object({
-  entidadeId: z.string().uuid("ID de entidade inválido"),
-  papel: z.enum(["ADMIN", "MEMBRO"]).optional().default("MEMBRO"),
-  cargoId: z.string().uuid("ID de cargo inválido").nullable().optional(),
-  startedAt: dateStringSchema.optional(),
-  endedAt: dateStringSchema.nullable().optional(),
-});
+import { createOwnMembershipSchema } from "@/lib/server/api-schemas/usuarios";
 
 export function GET(request: Request) {
   return withAuth(request, async (_req, usuario) => {

--- a/src/app/api/usuarios/me/onboarding/route.ts
+++ b/src/app/api/usuarios/me/onboarding/route.ts
@@ -13,7 +13,7 @@ const stepStateSchema = z
   })
   .strict();
 
-const patchSchema = z
+export const patchSchema = z
   .object({
     welcome: z.object({ completedAt: z.string() }).strict().optional(),
     periodo: stepStateSchema.optional(),

--- a/src/app/api/usuarios/me/onboarding/route.ts
+++ b/src/app/api/usuarios/me/onboarding/route.ts
@@ -2,37 +2,9 @@ import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/server/services/auth/middleware";
 import { getContainer } from "@/lib/server/container";
 import { handleError } from "@/lib/server/errors";
-import { z } from "zod";
+import { onboardingPatchSchema } from "@/lib/server/api-schemas/usuarios";
 
 export const dynamic = "force-dynamic";
-
-const stepStateSchema = z
-  .object({
-    completedAt: z.string().optional(),
-    skippedAt: z.string().optional(),
-  })
-  .strict();
-
-export const patchSchema = z
-  .object({
-    welcome: z.object({ completedAt: z.string() }).strict().optional(),
-    periodo: stepStateSchema.optional(),
-    concluidas: stepStateSchema.optional(),
-    entidades: stepStateSchema.optional(),
-    done: z.object({ completedAt: z.string() }).strict().optional(),
-    semesters: z
-      .record(
-        z.string(),
-        z
-          .object({
-            cursando: stepStateSchema.optional(),
-            turmas: stepStateSchema.optional(),
-          })
-          .strict()
-      )
-      .optional(),
-  })
-  .strict();
 
 export function GET(request: Request) {
   return withAuth(request, async (_req, usuario) => {
@@ -50,7 +22,7 @@ export function PATCH(request: Request) {
   return withAuth(request, async (req, usuario) => {
     try {
       const body = await req.json();
-      const parsed = patchSchema.parse(body);
+      const parsed = onboardingPatchSchema.parse(body);
       const { usuariosRepository } = getContainer();
       await usuariosRepository.updateOnboardingMetadata(usuario.id, parsed);
       const updated = await usuariosRepository.getOnboardingMetadata(usuario.id);

--- a/src/app/api/usuarios/me/periodo/route.ts
+++ b/src/app/api/usuarios/me/periodo/route.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 
 export const dynamic = "force-dynamic";
 
-const patchSchema = z.object({
+export const patchSchema = z.object({
   periodoAtual: z.string().min(1).nullable(),
 });
 

--- a/src/app/api/usuarios/me/periodo/route.ts
+++ b/src/app/api/usuarios/me/periodo/route.ts
@@ -2,19 +2,15 @@ import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/server/services/auth/middleware";
 import { getContainer } from "@/lib/server/container";
 import { handleError } from "@/lib/server/errors";
-import { z } from "zod";
+import { updatePeriodoSchema } from "@/lib/server/api-schemas/usuarios";
 
 export const dynamic = "force-dynamic";
-
-export const patchSchema = z.object({
-  periodoAtual: z.string().min(1).nullable(),
-});
 
 export function PATCH(request: Request) {
   return withAuth(request, async (req, usuario) => {
     try {
       const body = await req.json();
-      const parsed = patchSchema.parse(body);
+      const parsed = updatePeriodoSchema.parse(body);
       const { usuariosRepository } = getContainer();
       await usuariosRepository.updatePeriodoAtual(usuario.id, parsed.periodoAtual);
       return NextResponse.json({ periodoAtual: parsed.periodoAtual });

--- a/src/app/api/usuarios/me/photo/route.ts
+++ b/src/app/api/usuarios/me/photo/route.ts
@@ -9,7 +9,7 @@ import { ApiError, fromZodError } from "@/lib/server/errors";
 
 const log = createLogger("Photo");
 
-const updatePhotoSchema = z.object({
+export const updatePhotoSchema = z.object({
   urlFotoPerfil: z.string().url().nullable().optional(),
 });
 

--- a/src/app/api/usuarios/me/photo/route.ts
+++ b/src/app/api/usuarios/me/photo/route.ts
@@ -6,12 +6,9 @@ import { formatUserResponse } from "@/lib/server/utils/format-user-response";
 import { z } from "zod";
 import { createLogger } from "@/lib/server/utils/logger";
 import { ApiError, fromZodError } from "@/lib/server/errors";
+import { updatePhotoSchema } from "@/lib/server/api-schemas/usuarios";
 
 const log = createLogger("Photo");
-
-export const updatePhotoSchema = z.object({
-  urlFotoPerfil: z.string().url().nullable().optional(),
-});
 
 /**
  * PATCH /api/usuarios/me/photo

--- a/src/app/api/usuarios/me/semestres/[semestreId]/disciplinas/[disciplinaSemestreId]/route.ts
+++ b/src/app/api/usuarios/me/semestres/[semestreId]/disciplinas/[disciplinaSemestreId]/route.ts
@@ -2,20 +2,13 @@ import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/server/services/auth/middleware";
 import { ApiError } from "@/lib/server/errors";
 import { getContainer } from "@/lib/server/container";
-import { z } from "zod";
+import { updateDisciplinaSemestreSchema } from "@/lib/server/api-schemas/usuarios";
 
 export const dynamic = "force-dynamic";
 
 type RouteContext = {
   params: Promise<{ semestreId: string; disciplinaSemestreId: string }>;
 };
-
-export const patchSchema = z.object({
-  turma: z.string().nullish(),
-  docente: z.string().nullish(),
-  horario: z.string().nullish(),
-  codigoPaas: z.number().int().nullish(),
-});
 
 async function resolveSemestreId(semestreId: string): Promise<string | null> {
   if (semestreId === "ativo") {
@@ -59,7 +52,7 @@ export function PATCH(request: Request, context: RouteContext) {
       } catch {
         return ApiError.badRequest("Corpo da requisição inválido");
       }
-      const parsed = patchSchema.safeParse(body);
+      const parsed = updateDisciplinaSemestreSchema.safeParse(body);
       if (!parsed.success) {
         return ApiError.badRequest("Dados inválidos");
       }

--- a/src/app/api/usuarios/me/semestres/[semestreId]/disciplinas/[disciplinaSemestreId]/route.ts
+++ b/src/app/api/usuarios/me/semestres/[semestreId]/disciplinas/[disciplinaSemestreId]/route.ts
@@ -10,7 +10,7 @@ type RouteContext = {
   params: Promise<{ semestreId: string; disciplinaSemestreId: string }>;
 };
 
-const patchSchema = z.object({
+export const patchSchema = z.object({
   turma: z.string().nullish(),
   docente: z.string().nullish(),
   horario: z.string().nullish(),

--- a/src/app/api/usuarios/me/semestres/[semestreId]/disciplinas/route.ts
+++ b/src/app/api/usuarios/me/semestres/[semestreId]/disciplinas/route.ts
@@ -2,24 +2,12 @@ import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/server/services/auth/middleware";
 import { ApiError } from "@/lib/server/errors";
 import { getContainer } from "@/lib/server/container";
-import { z } from "zod";
+import { saveSemestreDisciplinasSchema } from "@/lib/server/api-schemas/usuarios";
 import type { DisciplinaSemestreWithDisciplina } from "@/lib/server/db/interfaces/disciplina-semestre-repository.interface";
 
 export const dynamic = "force-dynamic";
 
 type RouteContext = { params: Promise<{ semestreId: string }> };
-
-export const saveSchema = z.object({
-  disciplinas: z.array(
-    z.object({
-      codigoDisciplina: z.string().min(1),
-      turma: z.string().nullish(),
-      docente: z.string().nullish(),
-      horario: z.string().nullish(),
-      codigoPaas: z.number().int().nullish(),
-    })
-  ),
-});
 
 async function resolveSemestreId(semestreId: string): Promise<string | null> {
   if (semestreId === "ativo") {
@@ -97,7 +85,7 @@ export function PUT(request: Request, context: RouteContext) {
       } catch {
         return ApiError.badRequest("Corpo da requisição inválido");
       }
-      const parsed = saveSchema.safeParse(body);
+      const parsed = saveSemestreDisciplinasSchema.safeParse(body);
       if (!parsed.success) {
         return ApiError.badRequest("Dados de disciplinas inválidos");
       }

--- a/src/app/api/usuarios/me/semestres/[semestreId]/disciplinas/route.ts
+++ b/src/app/api/usuarios/me/semestres/[semestreId]/disciplinas/route.ts
@@ -9,7 +9,7 @@ export const dynamic = "force-dynamic";
 
 type RouteContext = { params: Promise<{ semestreId: string }> };
 
-const saveSchema = z.object({
+export const saveSchema = z.object({
   disciplinas: z.array(
     z.object({
       codigoDisciplina: z.string().min(1),

--- a/src/app/api/usuarios/merge-facade/route.ts
+++ b/src/app/api/usuarios/merge-facade/route.ts
@@ -5,12 +5,7 @@ import { withAdmin } from "@/lib/server/services/auth/middleware";
 import { mergeFacadeUser } from "@/lib/server/services/admin/merge-facade-user";
 import { getContainer } from "@/lib/server/container";
 import { ApiError, fromZodError } from "@/lib/server/errors";
-
-export const mergeFacadeUserSchema = z.object({
-  facadeUserId: z.string().uuid("ID de usuário facade inválido"),
-  realUserId: z.string().uuid("ID de usuário real inválido"),
-  deleteFacade: z.boolean().default(true),
-});
+import { mergeFacadeUserSchema } from "@/lib/server/api-schemas/usuarios";
 
 export async function POST(request: Request) {
   return await withAdmin(request, async () => {

--- a/src/app/api/usuarios/merge-facade/route.ts
+++ b/src/app/api/usuarios/merge-facade/route.ts
@@ -6,7 +6,7 @@ import { mergeFacadeUser } from "@/lib/server/services/admin/merge-facade-user";
 import { getContainer } from "@/lib/server/container";
 import { ApiError, fromZodError } from "@/lib/server/errors";
 
-const mergeFacadeUserSchema = z.object({
+export const mergeFacadeUserSchema = z.object({
   facadeUserId: z.string().uuid("ID de usuário facade inválido"),
   realUserId: z.string().uuid("ID de usuário real inválido"),
   deleteFacade: z.boolean().default(true),

--- a/src/app/api/vagas/route.ts
+++ b/src/app/api/vagas/route.ts
@@ -5,37 +5,7 @@ import { getContainer } from "@/lib/server/container";
 import { withAuth, canManageVagaForEntidade } from "@/lib/server/services/auth/middleware";
 import { ApiError, fromZodError } from "@/lib/server/errors";
 import { mapVagaToJson } from "@/lib/server/utils/vaga-mapper";
-
-const TIPO_VAGA_VALUES = [
-  "ESTAGIO",
-  "TRAINEE",
-  "VOLUNTARIO",
-  "PESQUISA",
-  "CLT",
-  "PJ",
-  "OUTRO",
-] as const;
-
-export const createVagaSchema = z.object({
-  titulo: z.string().min(1, "Título é obrigatório").max(200, "Título muito longo"),
-  descricao: z.string().min(1, "Descrição é obrigatória").max(10000, "Descrição muito longa"),
-  tipoVaga: z.enum(TIPO_VAGA_VALUES),
-  entidadeId: z.string().uuid("ID de entidade inválido"),
-  linkInscricao: z
-    .string()
-    .url("Link para inscrição deve ser uma URL válida")
-    .max(2048, "URL muito longa"),
-  dataFinalizacao: z.string().refine(v => !isNaN(Date.parse(v)), {
-    message: "Data de finalização inválida",
-  }),
-  areas: z.array(z.string().min(1).max(100)).max(20).optional().default([]),
-  salario: z.string().max(100, "Salário muito longo").nullable().optional(),
-  sobreEmpresa: z.string().max(5000, "Texto muito longo").nullable().optional(),
-  responsabilidades: z.array(z.string().min(1).max(500)).max(30).optional().default([]),
-  requisitos: z.array(z.string().min(1).max(500)).max(30).optional().default([]),
-  informacoesAdicionais: z.string().max(5000, "Texto muito longo").nullable().optional(),
-  etapasProcesso: z.array(z.string().min(1).max(500)).max(20).optional().default([]),
-});
+import { createVagaSchema, TIPO_VAGA_VALUES } from "@/lib/server/api-schemas/vagas";
 
 export async function GET(request: Request) {
   try {

--- a/src/app/api/vagas/route.ts
+++ b/src/app/api/vagas/route.ts
@@ -16,7 +16,7 @@ const TIPO_VAGA_VALUES = [
   "OUTRO",
 ] as const;
 
-const createVagaSchema = z.object({
+export const createVagaSchema = z.object({
   titulo: z.string().min(1, "Título é obrigatório").max(200, "Título muito longo"),
   descricao: z.string().min(1, "Descrição é obrigatória").max(10000, "Descrição muito longa"),
   tipoVaga: z.enum(TIPO_VAGA_VALUES),

--- a/src/lib/server/api-schemas/auth.ts
+++ b/src/lib/server/api-schemas/auth.ts
@@ -13,11 +13,13 @@ import { z } from "zod";
  * import the full route handler tree.
  */
 
+/** Schema de validação para login (email + senha). */
 export const loginSchema = z.object({
   email: z.string().email("Email inválido"),
   senha: z.string().min(1, "Senha é obrigatória"),
 });
 
+/** Schema de validação para cadastro de novo usuário. */
 export const registerSchema = z.object({
   nome: z.string().min(2, "Nome deve ter pelo menos 2 caracteres"),
   email: z.string().email("Email inválido"),
@@ -30,19 +32,23 @@ export const registerSchema = z.object({
   urlFotoPerfil: z.string().url().optional(),
 });
 
+/** Schema de validação para verificação de email via token. */
 export const verifySchema = z.object({
   token: z.string().min(1, "Token é obrigatório"),
 });
 
+/** Schema de validação para solicitação de recuperação de senha. */
 export const forgotPasswordSchema = z.object({
   email: z.string().email("Email inválido"),
 });
 
+/** Schema de validação para redefinição de senha (token + nova senha). */
 export const resetPasswordSchema = z.object({
   token: z.string().min(1, "Token é obrigatório"),
   novaSenha: z.string().min(8, "Senha deve ter pelo menos 8 caracteres"),
 });
 
+/** Schema de validação para reenvio do email de verificação. */
 export const resendVerificationRequestSchema = z.object({
   email: z.string().email("Email inválido"),
 });

--- a/src/lib/server/api-schemas/auth.ts
+++ b/src/lib/server/api-schemas/auth.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+
+/**
+ * Zod request schemas for the /api/auth/* endpoints.
+ *
+ * These are defined outside of the route.ts files because Next.js 15 only
+ * allows HTTP handler names (GET, POST, ...) and a small set of config
+ * constants to be exported from a route module. Any other export breaks
+ * the build with: "X is not a valid Route export field".
+ *
+ * Keeping them in a dedicated module also makes it trivial to reuse the
+ * exact same validation rules client-side or in tests, without having to
+ * import the full route handler tree.
+ */
+
+export const loginSchema = z.object({
+  email: z.string().email("Email inválido"),
+  senha: z.string().min(1, "Senha é obrigatória"),
+});
+
+export const registerSchema = z.object({
+  nome: z.string().min(2, "Nome deve ter pelo menos 2 caracteres"),
+  email: z.string().email("Email inválido"),
+  senha: z
+    .string()
+    .min(8, "Senha deve ter pelo menos 8 caracteres")
+    .max(128, "Senha deve ter no máximo 128 caracteres"),
+  centroId: z.string().uuid("Centro inválido"),
+  cursoId: z.string().uuid("Curso inválido"),
+  urlFotoPerfil: z.string().url().optional(),
+});
+
+export const verifySchema = z.object({
+  token: z.string().min(1, "Token é obrigatório"),
+});
+
+export const forgotPasswordSchema = z.object({
+  email: z.string().email("Email inválido"),
+});
+
+export const resetPasswordSchema = z.object({
+  token: z.string().min(1, "Token é obrigatório"),
+  novaSenha: z.string().min(8, "Senha deve ter pelo menos 8 caracteres"),
+});
+
+export const resendVerificationRequestSchema = z.object({
+  email: z.string().email("Email inválido"),
+});

--- a/src/lib/server/api-schemas/calendario.ts
+++ b/src/lib/server/api-schemas/calendario.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+
+import { ALL_CATEGORIAS } from "@/lib/shared/config/calendario-academico";
+
+/**
+ * Zod request schemas for the /api/calendario-academico/* endpoints.
+ *
+ * See src/lib/server/api-schemas/auth.ts for the rationale on why these
+ * live outside of the route.ts files (Next.js 15 route export restrictions).
+ */
+
+/**
+ * Required ISO date string — used by the create schemas where dates are
+ * mandatory. Rejects empty strings and anything that can't be parsed by
+ * `new Date()`.
+ */
+const requiredDateString = z
+  .string()
+  .min(1, "Data é obrigatória")
+  .refine(s => !isNaN(new Date(s).getTime()), { message: "Data inválida" });
+
+/**
+ * Optional ISO date string — used by the patch schemas where dates are
+ * optional but must still be valid when provided.
+ */
+const optionalDateString = z
+  .string()
+  .refine(s => !isNaN(new Date(s).getTime()), { message: "Data inválida" });
+
+// ---------------------------------------------------------------------------
+// Semesters
+// ---------------------------------------------------------------------------
+
+export const createSemestreSchema = z.object({
+  nome: z.string().min(1, "Nome é obrigatório"),
+  dataInicio: requiredDateString,
+  dataFim: requiredDateString,
+});
+
+export const updateSemestreSchema = z.object({
+  nome: z.string().min(1).optional(),
+  dataInicio: optionalDateString.optional(),
+  dataFim: optionalDateString.optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+export const createEventoSchema = z.object({
+  descricao: z.string().min(1, "Descrição é obrigatória"),
+  dataInicio: requiredDateString,
+  dataFim: requiredDateString,
+  categoria: z.enum(ALL_CATEGORIAS).default("OUTRA"),
+});
+
+export const updateEventoSchema = z.object({
+  descricao: z.string().min(1).optional(),
+  dataInicio: optionalDateString.optional(),
+  dataFim: optionalDateString.optional(),
+  categoria: z.enum(ALL_CATEGORIAS).optional(),
+});
+
+export const batchCreateSchema = z.object({
+  eventos: z.array(
+    z.object({
+      descricao: z.string().min(1),
+      dataInicio: requiredDateString,
+      dataFim: requiredDateString,
+      categoria: z.enum(ALL_CATEGORIAS).default("OUTRA"),
+    })
+  ),
+  replace: z.boolean().default(false),
+});

--- a/src/lib/server/api-schemas/calendario.ts
+++ b/src/lib/server/api-schemas/calendario.ts
@@ -31,12 +31,14 @@ const optionalDateString = z
 // Semesters
 // ---------------------------------------------------------------------------
 
+/** Schema de validação para criação de semestre letivo. */
 export const createSemestreSchema = z.object({
   nome: z.string().min(1, "Nome é obrigatório"),
   dataInicio: requiredDateString,
   dataFim: requiredDateString,
 });
 
+/** Schema de validação para atualização de semestre letivo. */
 export const updateSemestreSchema = z.object({
   nome: z.string().min(1).optional(),
   dataInicio: optionalDateString.optional(),
@@ -47,6 +49,7 @@ export const updateSemestreSchema = z.object({
 // Events
 // ---------------------------------------------------------------------------
 
+/** Schema de validação para criação de evento do calendário. */
 export const createEventoSchema = z.object({
   descricao: z.string().min(1, "Descrição é obrigatória"),
   dataInicio: requiredDateString,
@@ -54,6 +57,7 @@ export const createEventoSchema = z.object({
   categoria: z.enum(ALL_CATEGORIAS).default("OUTRA"),
 });
 
+/** Schema de validação para atualização de evento do calendário. */
 export const updateEventoSchema = z.object({
   descricao: z.string().min(1).optional(),
   dataInicio: optionalDateString.optional(),
@@ -61,6 +65,7 @@ export const updateEventoSchema = z.object({
   categoria: z.enum(ALL_CATEGORIAS).optional(),
 });
 
+/** Schema de validação para criação em lote de eventos do calendário. */
 export const batchCreateSchema = z.object({
   eventos: z.array(
     z.object({

--- a/src/lib/server/api-schemas/entidades.ts
+++ b/src/lib/server/api-schemas/entidades.ts
@@ -1,0 +1,60 @@
+import { z } from "zod";
+
+/**
+ * Zod request schemas for the /api/entidades/* endpoints.
+ *
+ * See src/lib/server/api-schemas/auth.ts for the rationale on why these
+ * live outside of the route.ts files (Next.js 15 route export restrictions).
+ */
+
+export const updateEntidadeSchema = z.object({
+  nome: z.string().optional(),
+  subtitle: z.string().nullable().optional(),
+  descricao: z.string().nullable().optional(),
+  tipo: z
+    .enum([
+      "LABORATORIO",
+      "GRUPO",
+      "LIGA_ACADEMICA",
+      "EMPRESA",
+      "ATLETICA",
+      "CENTRO_ACADEMICO",
+      "OUTRO",
+    ])
+    .optional(),
+  urlFoto: z.string().nullable().optional(),
+  contato: z.string().nullable().optional(),
+  instagram: z.string().nullable().optional(),
+  linkedin: z.string().nullable().optional(),
+  website: z.string().nullable().optional(),
+  location: z.string().nullable().optional(),
+  foundingDate: z.string().nullable().optional(),
+  slug: z.string().optional(),
+});
+
+export const addMemberSchema = z.object({
+  usuarioId: z.string().uuid("ID de usuário inválido"),
+  papel: z.enum(["ADMIN", "MEMBRO"]),
+  cargoId: z.string().uuid("ID de cargo inválido").nullable().optional(),
+  startedAt: z.string().optional(), // ISO date string
+  endedAt: z.string().nullable().optional(), // ISO date string or null
+});
+
+export const updateMemberSchema = z.object({
+  papel: z.enum(["ADMIN", "MEMBRO"]).optional(),
+  cargoId: z.string().uuid("ID de cargo inválido").nullable().optional(),
+  startedAt: z.string().optional(), // ISO date string
+  endedAt: z.string().nullable().optional(), // ISO date string or null
+});
+
+export const createCargoSchema = z.object({
+  nome: z.string().min(1, "Nome do cargo é obrigatório"),
+  descricao: z.string().nullable().optional(),
+  ordem: z.number().int().default(0),
+});
+
+export const updateCargoSchema = z.object({
+  nome: z.string().min(1, "Nome do cargo é obrigatório").optional(),
+  descricao: z.string().nullable().optional(),
+  ordem: z.number().int().optional(),
+});

--- a/src/lib/server/api-schemas/entidades.ts
+++ b/src/lib/server/api-schemas/entidades.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
  * live outside of the route.ts files (Next.js 15 route export restrictions).
  */
 
+/** Schema de validação para atualização de entidade. */
 export const updateEntidadeSchema = z.object({
   nome: z.string().optional(),
   subtitle: z.string().nullable().optional(),
@@ -32,6 +33,7 @@ export const updateEntidadeSchema = z.object({
   slug: z.string().optional(),
 });
 
+/** Schema de validação para adição de membro a uma entidade. */
 export const addMemberSchema = z.object({
   usuarioId: z.string().uuid("ID de usuário inválido"),
   papel: z.enum(["ADMIN", "MEMBRO"]),
@@ -40,6 +42,7 @@ export const addMemberSchema = z.object({
   endedAt: z.string().nullable().optional(), // ISO date string or null
 });
 
+/** Schema de validação para atualização de membro de uma entidade. */
 export const updateMemberSchema = z.object({
   papel: z.enum(["ADMIN", "MEMBRO"]).optional(),
   cargoId: z.string().uuid("ID de cargo inválido").nullable().optional(),
@@ -47,12 +50,14 @@ export const updateMemberSchema = z.object({
   endedAt: z.string().nullable().optional(), // ISO date string or null
 });
 
+/** Schema de validação para criação de cargo em uma entidade. */
 export const createCargoSchema = z.object({
   nome: z.string().min(1, "Nome do cargo é obrigatório"),
   descricao: z.string().nullable().optional(),
   ordem: z.number().int().default(0),
 });
 
+/** Schema de validação para atualização de cargo em uma entidade. */
 export const updateCargoSchema = z.object({
   nome: z.string().min(1, "Nome do cargo é obrigatório").optional(),
   descricao: z.string().nullable().optional(),

--- a/src/lib/server/api-schemas/usuarios.ts
+++ b/src/lib/server/api-schemas/usuarios.ts
@@ -29,15 +29,18 @@ const stepStateSchema = z
 // Admin endpoints on /api/usuarios/{id}/*
 // ---------------------------------------------------------------------------
 
+/** Schema de validação para atualização de centro/curso do usuário (admin). */
 export const updateUserInfoSchema = z.object({
   centroId: z.string().optional(),
   cursoId: z.string().optional(),
 });
 
+/** Schema de validação para atualização do papel de plataforma do usuário (admin). */
 export const updateRoleSchema = z.object({
   papelPlataforma: z.enum(["USER", "MASTER_ADMIN"]),
 });
 
+/** Schema de validação para atualização do slug do usuário. */
 export const updateSlugSchema = z.object({
   slug: z.string().nullable(),
 });
@@ -46,12 +49,14 @@ export const updateSlugSchema = z.object({
 // Facade user management (admin only)
 // ---------------------------------------------------------------------------
 
+/** Schema de validação para criação de usuário facade (placeholder sem login). */
 export const createFacadeUserSchema = z.object({
   nome: z.string().min(2, "Nome deve ter pelo menos 2 caracteres"),
   centroId: z.string().uuid("Centro inválido"),
   cursoId: z.string().uuid("Curso inválido"),
 });
 
+/** Schema de validação para fusão de usuário facade com usuário real. */
 export const mergeFacadeUserSchema = z.object({
   facadeUserId: z.string().uuid("ID de usuário facade inválido"),
   realUserId: z.string().uuid("ID de usuário real inválido"),

--- a/src/lib/server/api-schemas/usuarios.ts
+++ b/src/lib/server/api-schemas/usuarios.ts
@@ -1,0 +1,171 @@
+import { z } from "zod";
+
+/**
+ * Zod request schemas for the /api/usuarios/* endpoints.
+ *
+ * See src/lib/server/api-schemas/auth.ts for the rationale on why these
+ * live outside of the route.ts files (Next.js 15 route export restrictions).
+ */
+
+/**
+ * ISO date string validator used by the membership endpoints. Accepts any
+ * string parseable by `new Date()`.
+ */
+const dateString = z.string().refine(v => !isNaN(Date.parse(v)), { message: "Data inválida" });
+
+/**
+ * Nested step-state shape used by the onboarding metadata schema. Every
+ * onboarding step tracks either a `completedAt` or a `skippedAt` ISO
+ * timestamp (or neither).
+ */
+const stepStateSchema = z
+  .object({
+    completedAt: z.string().optional(),
+    skippedAt: z.string().optional(),
+  })
+  .strict();
+
+// ---------------------------------------------------------------------------
+// Admin endpoints on /api/usuarios/{id}/*
+// ---------------------------------------------------------------------------
+
+export const updateUserInfoSchema = z.object({
+  centroId: z.string().optional(),
+  cursoId: z.string().optional(),
+});
+
+export const updateRoleSchema = z.object({
+  papelPlataforma: z.enum(["USER", "MASTER_ADMIN"]),
+});
+
+export const updateSlugSchema = z.object({
+  slug: z.string().nullable(),
+});
+
+// ---------------------------------------------------------------------------
+// Facade user management (admin only)
+// ---------------------------------------------------------------------------
+
+export const createFacadeUserSchema = z.object({
+  nome: z.string().min(2, "Nome deve ter pelo menos 2 caracteres"),
+  centroId: z.string().uuid("Centro inválido"),
+  cursoId: z.string().uuid("Curso inválido"),
+});
+
+export const mergeFacadeUserSchema = z.object({
+  facadeUserId: z.string().uuid("ID de usuário facade inválido"),
+  realUserId: z.string().uuid("ID de usuário real inválido"),
+  deleteFacade: z.boolean().default(true),
+});
+
+// ---------------------------------------------------------------------------
+// Self-service endpoints on /api/usuarios/me/*
+// ---------------------------------------------------------------------------
+
+/**
+ * Replaces the full set of completed disciplines for the current user.
+ */
+export const updateCompletedDisciplinasSchema = z.object({
+  disciplinaIds: z.array(z.string().uuid()),
+});
+
+/**
+ * Marks disciplines with a status (concluida, cursando, or none). Used by
+ * the onboarding flow and the curriculum page.
+ */
+export const marcarDisciplinasSchema = z.object({
+  disciplinaIds: z.array(z.string().uuid()).min(1),
+  status: z.enum(["concluida", "cursando", "none"]),
+});
+
+/**
+ * Create a new membership for the current user in the given entity.
+ */
+export const createOwnMembershipSchema = z.object({
+  entidadeId: z.string().uuid("ID de entidade inválido"),
+  papel: z.enum(["ADMIN", "MEMBRO"]).optional().default("MEMBRO"),
+  cargoId: z.string().uuid("ID de cargo inválido").nullable().optional(),
+  startedAt: dateString.optional(),
+  endedAt: dateString.nullable().optional(),
+});
+
+/**
+ * Update fields on a membership owned by the current user.
+ */
+export const updateOwnMembershipSchema = z.object({
+  papel: z.enum(["ADMIN", "MEMBRO"]).optional(),
+  cargoId: z.string().uuid("ID de cargo inválido").nullable().optional(),
+  startedAt: dateString.optional(),
+  endedAt: dateString.nullable().optional(),
+});
+
+/**
+ * Onboarding metadata patch. The API deep-merges the provided fields into
+ * the stored metadata, so every field is optional.
+ */
+export const onboardingPatchSchema = z
+  .object({
+    welcome: z.object({ completedAt: z.string() }).strict().optional(),
+    periodo: stepStateSchema.optional(),
+    concluidas: stepStateSchema.optional(),
+    entidades: stepStateSchema.optional(),
+    done: z.object({ completedAt: z.string() }).strict().optional(),
+    semesters: z
+      .record(
+        z.string(),
+        z
+          .object({
+            cursando: stepStateSchema.optional(),
+            turmas: stepStateSchema.optional(),
+          })
+          .strict()
+      )
+      .optional(),
+  })
+  .strict();
+
+/**
+ * Patch the current user's academic period (semester 1-12, "12+" or "graduado").
+ * Pass `null` to clear the field.
+ */
+export const updatePeriodoSchema = z.object({
+  periodoAtual: z.string().min(1).nullable(),
+});
+
+/**
+ * Patch the current user's profile photo URL. Pass `null` to clear.
+ */
+export const updatePhotoSchema = z.object({
+  urlFotoPerfil: z.string().url().nullable().optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Semester-scoped enrolled disciplines (/usuarios/me/semestres/{id}/...)
+// ---------------------------------------------------------------------------
+
+/**
+ * Replaces the full list of enrolled disciplines for a specific semester.
+ * Disciplines are referenced by their PAAS `codigoDisciplina` and resolved
+ * to internal IDs server-side.
+ */
+export const saveSemestreDisciplinasSchema = z.object({
+  disciplinas: z.array(
+    z.object({
+      codigoDisciplina: z.string().min(1),
+      turma: z.string().nullish(),
+      docente: z.string().nullish(),
+      horario: z.string().nullish(),
+      codigoPaas: z.number().int().nullish(),
+    })
+  ),
+});
+
+/**
+ * Patch the turma snapshot fields on a single DisciplinaSemestre record.
+ */
+export const updateDisciplinaSemestreSchema = z.object({
+  turma: z.string().nullish(),
+  docente: z.string().nullish(),
+  horario: z.string().nullish(),
+  codigoPaas: z.number().int().nullish(),
+});

--- a/src/lib/server/api-schemas/vagas.ts
+++ b/src/lib/server/api-schemas/vagas.ts
@@ -21,6 +21,7 @@ export const TIPO_VAGA_VALUES = [
   "OUTRO",
 ] as const;
 
+/** Schema de validação para criação de vaga. */
 export const createVagaSchema = z.object({
   titulo: z.string().min(1, "Título é obrigatório").max(200, "Título muito longo"),
   descricao: z.string().min(1, "Descrição é obrigatória").max(10000, "Descrição muito longa"),

--- a/src/lib/server/api-schemas/vagas.ts
+++ b/src/lib/server/api-schemas/vagas.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+
+/**
+ * Zod request schemas for the /api/vagas endpoints.
+ *
+ * See src/lib/server/api-schemas/auth.ts for the rationale on why these
+ * live outside of the route.ts files (Next.js 15 route export restrictions).
+ */
+
+/**
+ * Allowed job listing types. Re-exported alongside the schema so consumers
+ * (handlers, query parsers, tests) can refer to the same canonical tuple.
+ */
+export const TIPO_VAGA_VALUES = [
+  "ESTAGIO",
+  "TRAINEE",
+  "VOLUNTARIO",
+  "PESQUISA",
+  "CLT",
+  "PJ",
+  "OUTRO",
+] as const;
+
+export const createVagaSchema = z.object({
+  titulo: z.string().min(1, "Título é obrigatório").max(200, "Título muito longo"),
+  descricao: z.string().min(1, "Descrição é obrigatória").max(10000, "Descrição muito longa"),
+  tipoVaga: z.enum(TIPO_VAGA_VALUES),
+  entidadeId: z.string().uuid("ID de entidade inválido"),
+  linkInscricao: z
+    .string()
+    .url("Link para inscrição deve ser uma URL válida")
+    .max(2048, "URL muito longa"),
+  dataFinalizacao: z.string().refine(v => !isNaN(Date.parse(v)), {
+    message: "Data de finalização inválida",
+  }),
+  areas: z.array(z.string().min(1).max(100)).max(20).optional().default([]),
+  salario: z.string().max(100, "Salário muito longo").nullable().optional(),
+  sobreEmpresa: z.string().max(5000, "Texto muito longo").nullable().optional(),
+  responsabilidades: z.array(z.string().min(1).max(500)).max(30).optional().default([]),
+  requisitos: z.array(z.string().min(1).max(500)).max(30).optional().default([]),
+  informacoesAdicionais: z.string().max(5000, "Texto muito longo").nullable().optional(),
+  etapasProcesso: z.array(z.string().min(1).max(500)).max(20).optional().default([]),
+});

--- a/src/lib/server/openapi/__tests__/common-schemas.test.ts
+++ b/src/lib/server/openapi/__tests__/common-schemas.test.ts
@@ -5,10 +5,11 @@
  * Next.js route handlers that require the Node `Request`/`Response` globals.
  */
 import { describe, it, expect, beforeEach } from "@jest/globals";
+import { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 
 import { ErrorCode } from "@/lib/shared/errors/error-codes";
 
-import { ApiErrorBodySchema, errorResponses } from "../common-schemas";
+import { registerCommonSchemas, type CommonSchemas } from "../common-schemas";
 import { __resetOpenApiCacheForTests, getOpenApiDocument } from "../generator";
 
 describe("common-schemas", () => {
@@ -16,7 +17,7 @@ describe("common-schemas", () => {
     __resetOpenApiCacheForTests();
   });
 
-  describe("registered component schemas", () => {
+  describe("registered component schemas (via full document generation)", () => {
     it("registers ApiErrorBody in components/schemas", () => {
       const doc = getOpenApiDocument();
       const schemas = doc.components?.schemas ?? {};
@@ -49,9 +50,26 @@ describe("common-schemas", () => {
     });
   });
 
-  describe("ApiErrorBodySchema Zod shape", () => {
-    it("accepts a valid error body with message and code", () => {
-      const parsed = ApiErrorBodySchema.safeParse({
+  describe("registerCommonSchemas() in isolation", () => {
+    let registry: OpenAPIRegistry;
+    let schemas: CommonSchemas;
+
+    beforeEach(() => {
+      // Each test gets a fresh registry + schemas, mirroring how
+      // getOpenApiDocument() builds them.
+      registry = new OpenAPIRegistry();
+      schemas = registerCommonSchemas(registry);
+    });
+
+    it("returns all four common component schemas", () => {
+      expect(schemas.ErrorCodeSchema).toBeDefined();
+      expect(schemas.FieldErrorSchema).toBeDefined();
+      expect(schemas.ApiErrorBodySchema).toBeDefined();
+      expect(schemas.PaginationMetaSchema).toBeDefined();
+    });
+
+    it("accepts a valid error body through ApiErrorBodySchema", () => {
+      const parsed = schemas.ApiErrorBodySchema.safeParse({
         message: "Email inválido",
         code: ErrorCode.VALIDATION_ERROR,
       });
@@ -59,7 +77,7 @@ describe("common-schemas", () => {
     });
 
     it("accepts a validation error with field-level errors", () => {
-      const parsed = ApiErrorBodySchema.safeParse({
+      const parsed = schemas.ApiErrorBodySchema.safeParse({
         message: "Dados inválidos",
         code: ErrorCode.VALIDATION_ERROR,
         errors: [{ field: "email", message: "Email inválido" }],
@@ -68,14 +86,33 @@ describe("common-schemas", () => {
     });
 
     it("rejects a body missing the required code field", () => {
-      const parsed = ApiErrorBodySchema.safeParse({
-        message: "Erro",
-      });
+      const parsed = schemas.ApiErrorBodySchema.safeParse({ message: "Erro" });
       expect(parsed.success).toBe(false);
+    });
+
+    it("does NOT share Zod schema instances between successive registry calls", () => {
+      // Building a second registry should return fresh schema references,
+      // not the same objects as the first call. This is what guarantees
+      // getOpenApiDocument() is a pure function of the code — no cross-call
+      // state leaks through shared Zod schemas.
+      const secondRegistry = new OpenAPIRegistry();
+      const secondSchemas = registerCommonSchemas(secondRegistry);
+
+      expect(secondSchemas.ApiErrorBodySchema).not.toBe(schemas.ApiErrorBodySchema);
+      expect(secondSchemas.ErrorCodeSchema).not.toBe(schemas.ErrorCodeSchema);
+      expect(secondSchemas.FieldErrorSchema).not.toBe(schemas.FieldErrorSchema);
+      expect(secondSchemas.PaginationMetaSchema).not.toBe(schemas.PaginationMetaSchema);
     });
   });
 
   describe("errorResponses() helper", () => {
+    let errorResponses: CommonSchemas["errorResponses"];
+
+    beforeEach(() => {
+      const registry = new OpenAPIRegistry();
+      errorResponses = registerCommonSchemas(registry).errorResponses;
+    });
+
     it("returns a map with one entry per provided status code", () => {
       const responses = errorResponses([400, 401, 404, 500]);
 

--- a/src/lib/server/openapi/__tests__/common-schemas.test.ts
+++ b/src/lib/server/openapi/__tests__/common-schemas.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @jest-environment node
+ *
+ * See the note in generator.test.ts — importing the generator pulls in
+ * Next.js route handlers that require the Node `Request`/`Response` globals.
+ */
+import { describe, it, expect, beforeEach } from "@jest/globals";
+
+import { ErrorCode } from "@/lib/shared/errors/error-codes";
+
+import { ApiErrorBodySchema, errorResponses } from "../common-schemas";
+import { __resetOpenApiCacheForTests, getOpenApiDocument } from "../generator";
+
+describe("common-schemas", () => {
+  beforeEach(() => {
+    __resetOpenApiCacheForTests();
+  });
+
+  describe("registered component schemas", () => {
+    it("registers ApiErrorBody in components/schemas", () => {
+      const doc = getOpenApiDocument();
+      const schemas = doc.components?.schemas ?? {};
+
+      expect(schemas.ApiErrorBody).toBeDefined();
+    });
+
+    it("registers the ErrorCode enum with all ErrorCode values", () => {
+      const doc = getOpenApiDocument();
+      const errorCodeSchema = doc.components?.schemas?.ErrorCode as { enum?: string[] } | undefined;
+
+      expect(errorCodeSchema).toBeDefined();
+      expect(errorCodeSchema?.enum).toBeDefined();
+
+      // Every value in the ErrorCode const object must appear in the spec enum.
+      // This is the test that catches drift when somebody adds a new error code
+      // to src/lib/shared/errors/error-codes.ts without thinking about docs.
+      const expectedValues = Object.values(ErrorCode);
+      for (const value of expectedValues) {
+        expect(errorCodeSchema?.enum).toContain(value);
+      }
+    });
+
+    it("registers FieldError and PaginationMeta", () => {
+      const doc = getOpenApiDocument();
+      const schemas = doc.components?.schemas ?? {};
+
+      expect(schemas.FieldError).toBeDefined();
+      expect(schemas.PaginationMeta).toBeDefined();
+    });
+  });
+
+  describe("ApiErrorBodySchema Zod shape", () => {
+    it("accepts a valid error body with message and code", () => {
+      const parsed = ApiErrorBodySchema.safeParse({
+        message: "Email inválido",
+        code: ErrorCode.VALIDATION_ERROR,
+      });
+      expect(parsed.success).toBe(true);
+    });
+
+    it("accepts a validation error with field-level errors", () => {
+      const parsed = ApiErrorBodySchema.safeParse({
+        message: "Dados inválidos",
+        code: ErrorCode.VALIDATION_ERROR,
+        errors: [{ field: "email", message: "Email inválido" }],
+      });
+      expect(parsed.success).toBe(true);
+    });
+
+    it("rejects a body missing the required code field", () => {
+      const parsed = ApiErrorBodySchema.safeParse({
+        message: "Erro",
+      });
+      expect(parsed.success).toBe(false);
+    });
+  });
+
+  describe("errorResponses() helper", () => {
+    it("returns a map with one entry per provided status code", () => {
+      const responses = errorResponses([400, 401, 404, 500]);
+
+      expect(Object.keys(responses)).toEqual(["400", "401", "404", "500"]);
+    });
+
+    it("each entry references ApiErrorBody via application/json", () => {
+      const responses = errorResponses([400, 401, 500]);
+
+      for (const code of ["400", "401", "500"]) {
+        const entry = responses[code];
+        expect(entry).toBeDefined();
+        expect(entry.description).toBeTruthy();
+        expect(entry.content).toBeDefined();
+        expect(entry.content?.["application/json"]).toBeDefined();
+      }
+    });
+
+    it("provides distinct human descriptions for each status code", () => {
+      const responses = errorResponses([400, 401, 403, 404, 409, 429, 500]);
+      const descriptions = Object.values(responses).map(r => r.description);
+      const unique = new Set(descriptions);
+
+      // Every known status code has its own description line in STATUS_DESCRIPTIONS.
+      expect(unique.size).toBe(descriptions.length);
+    });
+
+    it("throws on unknown status codes to force contributors to add them explicitly", () => {
+      expect(() => errorResponses([418])).toThrow(/unknown status code 418/);
+    });
+  });
+});

--- a/src/lib/server/openapi/__tests__/generator.test.ts
+++ b/src/lib/server/openapi/__tests__/generator.test.ts
@@ -59,21 +59,21 @@ describe("getOpenApiDocument", () => {
     const tagNames = (doc.tags ?? []).map(t => t.name);
 
     const expectedTags = [
-      "Auth",
-      "Users",
-      "Entities",
+      "Autenticação",
+      "Usuários",
+      "Entidades",
       "Vagas",
-      "Guides",
-      "Courses",
-      "Academic Centers",
+      "Guias",
+      "Cursos",
+      "Centros Acadêmicos",
       "Campus",
-      "Disciplines",
-      "Curricula",
-      "Academic Calendar",
-      "Search",
+      "Disciplinas",
+      "Currículos",
+      "Calendário Acadêmico",
+      "Busca",
       "Health",
       "Upload",
-      "Content Images",
+      "Imagens de Conteúdo",
     ];
 
     for (const expected of expectedTags) {

--- a/src/lib/server/openapi/__tests__/generator.test.ts
+++ b/src/lib/server/openapi/__tests__/generator.test.ts
@@ -1,0 +1,182 @@
+/**
+ * @jest-environment node
+ *
+ * This suite imports the OpenAPI generator, which in turn pulls in Next.js
+ * route handlers via the paths registry. `next/server` relies on the global
+ * `Request` and `Response` objects, which are present in Node 18+ but not in
+ * jsdom. Forcing the `node` environment here keeps the import chain working.
+ */
+import { describe, it, expect, beforeEach } from "@jest/globals";
+
+import packageJson from "../../../../../package.json";
+import { __resetOpenApiCacheForTests, getOpenApiDocument } from "../generator";
+
+describe("getOpenApiDocument", () => {
+  beforeEach(() => {
+    __resetOpenApiCacheForTests();
+  });
+
+  it("returns a document with the required OpenAPI 3.1 top-level fields", () => {
+    const doc = getOpenApiDocument();
+
+    expect(doc.openapi).toBe("3.1.0");
+    expect(doc.info).toBeDefined();
+    expect(doc.info.title).toBeTruthy();
+    expect(doc.info.version).toBeTruthy();
+    expect(doc.paths).toBeDefined();
+    expect(doc.components).toBeDefined();
+  });
+
+  it("uses the current package.json version in info.version", () => {
+    const doc = getOpenApiDocument();
+    expect(doc.info.version).toBe(packageJson.version);
+  });
+
+  it("declares at least the production and localhost servers", () => {
+    const doc = getOpenApiDocument();
+    const serverUrls = (doc.servers ?? []).map(s => s.url);
+
+    expect(serverUrls).toContain("https://www.aquarioufpb.com");
+    expect(serverUrls).toContain("http://localhost:3000");
+  });
+
+  it("registers the bearerAuth security scheme", () => {
+    const doc = getOpenApiDocument();
+    const schemes = doc.components?.securitySchemes ?? {};
+
+    expect(schemes).toHaveProperty("bearerAuth");
+    // openapi3-ts types for security schemes are a union; we assert the shape
+    // we actually registered in registry.ts.
+    expect(schemes.bearerAuth).toMatchObject({
+      type: "http",
+      scheme: "bearer",
+      bearerFormat: "JWT",
+    });
+  });
+
+  it("registers every expected resource tag in info.tags", () => {
+    const doc = getOpenApiDocument();
+    const tagNames = (doc.tags ?? []).map(t => t.name);
+
+    const expectedTags = [
+      "Auth",
+      "Users",
+      "Entities",
+      "Vagas",
+      "Guides",
+      "Courses",
+      "Academic Centers",
+      "Campus",
+      "Disciplines",
+      "Curricula",
+      "Academic Calendar",
+      "Search",
+      "Health",
+      "Upload",
+      "Content Images",
+    ];
+
+    for (const expected of expectedTags) {
+      expect(tagNames).toContain(expected);
+    }
+  });
+
+  it("registers exactly the expected number of paths (no /dev/* leakage)", () => {
+    const doc = getOpenApiDocument();
+    const paths = Object.keys(doc.paths ?? {});
+
+    // The aquario has 59 total route.ts files under src/app/api/,
+    // of which 3 live under /dev and must NEVER appear in the public spec.
+    // This leaves 56 documented paths.
+    expect(paths.length).toBe(56);
+  });
+
+  it("does not leak any /dev/* endpoints into the public spec", () => {
+    const doc = getOpenApiDocument();
+    const devPaths = Object.keys(doc.paths ?? {}).filter(p => p.startsWith("/dev"));
+
+    // Dev endpoints (/api/dev/promote-admin, /api/dev/toggle-entidade-admin,
+    // /api/dev/clear-onboarding) only run when IS_DEV is true and return 404
+    // in production. Exposing them in the public OpenAPI would mislead clients
+    // into believing they can call routes that always 404 in prod.
+    expect(devPaths).toEqual([]);
+  });
+
+  it("every operation has at least one 2xx response", () => {
+    const doc = getOpenApiDocument();
+
+    for (const [pathKey, pathItem] of Object.entries(doc.paths ?? {})) {
+      const methods = ["get", "post", "put", "patch", "delete"] as const;
+      for (const method of methods) {
+        const operation = pathItem[method];
+        if (!operation) {
+          continue;
+        }
+        const statusCodes = Object.keys(operation.responses ?? {});
+        const has2xx = statusCodes.some(code => /^2\d\d$/.test(code));
+        expect(has2xx).toBe(true);
+        if (!has2xx) {
+          throw new Error(`Operation ${method.toUpperCase()} ${pathKey} has no 2xx response`);
+        }
+      }
+    }
+  });
+
+  it("every bearerAuth-protected operation references the security scheme", () => {
+    const doc = getOpenApiDocument();
+
+    // Walk every operation and find the ones that declare `security`
+    const securedOperations: Array<{ path: string; method: string; security: unknown }> = [];
+    for (const [pathKey, pathItem] of Object.entries(doc.paths ?? {})) {
+      const methods = ["get", "post", "put", "patch", "delete"] as const;
+      for (const method of methods) {
+        const operation = pathItem[method];
+        if (operation?.security && operation.security.length > 0) {
+          securedOperations.push({ path: pathKey, method, security: operation.security });
+        }
+      }
+    }
+
+    // Auth has ~3 secured (me, refresh, reenviar-verificacao), usuarios many, etc.
+    // We don't assert an exact count (would drift), but we do assert:
+    //   1. At least some operations are marked as secured
+    //   2. Every one that is, uses bearerAuth
+    expect(securedOperations.length).toBeGreaterThan(10);
+    for (const op of securedOperations) {
+      // Shape is: security: [{ bearerAuth: [] }]
+      expect(Array.isArray(op.security)).toBe(true);
+      const securityArray = op.security as Array<Record<string, unknown>>;
+      expect(securityArray[0]).toHaveProperty("bearerAuth");
+    }
+  });
+
+  it("caches the generated document across calls (lazy singleton)", () => {
+    const first = getOpenApiDocument();
+    const second = getOpenApiDocument();
+
+    // Strict identity: same object reference, not just deep-equal.
+    // This is what validates the lazy singleton cache behavior.
+    expect(second).toBe(first);
+  });
+
+  it("re-generates the document after __resetOpenApiCacheForTests is called", () => {
+    const first = getOpenApiDocument();
+    __resetOpenApiCacheForTests();
+    const second = getOpenApiDocument();
+
+    // After reset, identity should differ but structure should match.
+    expect(second).not.toBe(first);
+    expect(second.openapi).toBe(first.openapi);
+    expect(Object.keys(second.paths ?? {}).length).toBe(Object.keys(first.paths ?? {}).length);
+  });
+
+  it("includes the canonical ApiErrorBody component schema", () => {
+    const doc = getOpenApiDocument();
+    const schemas = doc.components?.schemas ?? {};
+
+    expect(schemas).toHaveProperty("ApiErrorBody");
+    expect(schemas).toHaveProperty("ErrorCode");
+    expect(schemas).toHaveProperty("FieldError");
+    expect(schemas).toHaveProperty("PaginationMeta");
+  });
+});

--- a/src/lib/server/openapi/__tests__/paths.test.ts
+++ b/src/lib/server/openapi/__tests__/paths.test.ts
@@ -1,0 +1,201 @@
+/**
+ * @jest-environment node
+ *
+ * See the note in generator.test.ts — importing the generator pulls in
+ * Next.js route handlers that require the Node `Request`/`Response` globals.
+ */
+import { describe, it, expect, beforeEach } from "@jest/globals";
+
+import { __resetOpenApiCacheForTests, getOpenApiDocument } from "../generator";
+
+/**
+ * Sanity-check suite that asserts each resource group registers the operations
+ * we expect. This catches the "removed an endpoint but forgot to update docs"
+ * class of bugs for the code introduced in THIS PR. It does NOT enforce
+ * sync between src/app/api/**\/route.ts and src/lib/server/openapi/paths/** —
+ * that decision belongs to the maintainers (see the "Follow-up suggestions"
+ * section in the PR description).
+ */
+
+type OperationKey = `${"get" | "post" | "put" | "patch" | "delete"} ${string}`;
+
+function collectRegisteredOperations(): Set<OperationKey> {
+  const doc = getOpenApiDocument();
+  const collected = new Set<OperationKey>();
+
+  for (const [path, pathItem] of Object.entries(doc.paths ?? {})) {
+    const methods = ["get", "post", "put", "patch", "delete"] as const;
+    for (const method of methods) {
+      if (pathItem[method]) {
+        collected.add(`${method} ${path}` as OperationKey);
+      }
+    }
+  }
+
+  return collected;
+}
+
+describe("paths registry sanity checks", () => {
+  let operations: Set<OperationKey>;
+
+  beforeEach(() => {
+    __resetOpenApiCacheForTests();
+    operations = collectRegisteredOperations();
+  });
+
+  describe("auth", () => {
+    it("registers all auth operations", () => {
+      const expected: OperationKey[] = [
+        "post /auth/login",
+        "post /auth/register",
+        "get /auth/me",
+        "post /auth/refresh",
+        "post /auth/verificar-email",
+        "post /auth/esqueci-senha",
+        "post /auth/resetar-senha",
+        "post /auth/reenviar-verificacao",
+        "post /auth/solicitar-reenvio-verificacao",
+      ];
+      for (const op of expected) {
+        expect(operations.has(op)).toBe(true);
+      }
+    });
+  });
+
+  describe("usuarios", () => {
+    it("registers the three admin endpoints", () => {
+      expect(operations.has("delete /usuarios/{id}")).toBe(true);
+      expect(operations.has("post /usuarios/facade")).toBe(true);
+      expect(operations.has("post /usuarios/merge-facade")).toBe(true);
+    });
+
+    it("registers the multi-method /usuarios/me/* endpoints", () => {
+      const expected: OperationKey[] = [
+        "get /usuarios/me/disciplinas",
+        "put /usuarios/me/disciplinas",
+        "get /usuarios/me/membros",
+        "post /usuarios/me/membros",
+        "put /usuarios/me/membros/{membroId}",
+        "delete /usuarios/me/membros/{membroId}",
+        "get /usuarios/me/onboarding",
+        "patch /usuarios/me/onboarding",
+        "patch /usuarios/me/photo",
+        "delete /usuarios/me/photo",
+      ];
+      for (const op of expected) {
+        expect(operations.has(op)).toBe(true);
+      }
+    });
+
+    it("registers the semester-scoped endpoints (including the UUID|'ativo' params)", () => {
+      expect(operations.has("get /usuarios/me/semestres/{semestreId}/disciplinas")).toBe(true);
+      expect(operations.has("put /usuarios/me/semestres/{semestreId}/disciplinas")).toBe(true);
+      expect(
+        operations.has(
+          "patch /usuarios/me/semestres/{semestreId}/disciplinas/{disciplinaSemestreId}"
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe("entidades", () => {
+    it("registers the core entidades operations", () => {
+      const expected: OperationKey[] = [
+        "get /entidades",
+        "get /entidades/slug/{slug}",
+        "put /entidades/{id}",
+        "post /entidades/{id}/membros",
+        "put /entidades/{id}/membros/{membroId}",
+        "delete /entidades/{id}/membros/{membroId}",
+      ];
+      for (const op of expected) {
+        expect(operations.has(op)).toBe(true);
+      }
+    });
+
+    it("registers all four cargos methods on the shared /cargos path", () => {
+      expect(operations.has("get /entidades/{id}/cargos")).toBe(true);
+      expect(operations.has("post /entidades/{id}/cargos")).toBe(true);
+      expect(operations.has("put /entidades/{id}/cargos")).toBe(true);
+      expect(operations.has("delete /entidades/{id}/cargos")).toBe(true);
+    });
+  });
+
+  describe("vagas", () => {
+    it("registers list, create, detail and delete", () => {
+      expect(operations.has("get /vagas")).toBe(true);
+      expect(operations.has("post /vagas")).toBe(true);
+      expect(operations.has("get /vagas/{id}")).toBe(true);
+      expect(operations.has("delete /vagas/{id}")).toBe(true);
+    });
+  });
+
+  describe("guias", () => {
+    it("registers all three guides endpoints", () => {
+      expect(operations.has("get /guias")).toBe(true);
+      expect(operations.has("get /guias/{id}/secoes")).toBe(true);
+      expect(operations.has("get /guias/secoes/{id}/subsecoes")).toBe(true);
+    });
+  });
+
+  describe("cursos, centros and campus (admin CRUD)", () => {
+    it("registers cursos CRUD plus centros /{id}/cursos", () => {
+      expect(operations.has("get /cursos")).toBe(true);
+      expect(operations.has("post /cursos")).toBe(true);
+      expect(operations.has("put /cursos/{id}")).toBe(true);
+      expect(operations.has("delete /cursos/{id}")).toBe(true);
+      expect(operations.has("get /centros/{id}/cursos")).toBe(true);
+    });
+
+    it("registers centros CRUD", () => {
+      expect(operations.has("get /centros")).toBe(true);
+      expect(operations.has("post /centros")).toBe(true);
+      expect(operations.has("put /centros/{id}")).toBe(true);
+      expect(operations.has("delete /centros/{id}")).toBe(true);
+    });
+
+    it("registers campus CRUD", () => {
+      expect(operations.has("get /campus")).toBe(true);
+      expect(operations.has("post /campus")).toBe(true);
+      expect(operations.has("put /campus/{id}")).toBe(true);
+      expect(operations.has("delete /campus/{id}")).toBe(true);
+    });
+  });
+
+  describe("disciplinas and curriculos", () => {
+    it("registers disciplinas search", () => {
+      expect(operations.has("get /disciplinas/search")).toBe(true);
+    });
+
+    it("registers curriculos grade", () => {
+      expect(operations.has("get /curriculos/grade")).toBe(true);
+    });
+  });
+
+  describe("calendario-academico", () => {
+    it("registers semester CRUD", () => {
+      expect(operations.has("get /calendario-academico")).toBe(true);
+      expect(operations.has("post /calendario-academico")).toBe(true);
+      expect(operations.has("get /calendario-academico/{id}")).toBe(true);
+      expect(operations.has("put /calendario-academico/{id}")).toBe(true);
+      expect(operations.has("delete /calendario-academico/{id}")).toBe(true);
+    });
+
+    it("registers events CRUD and batch", () => {
+      expect(operations.has("get /calendario-academico/{id}/eventos")).toBe(true);
+      expect(operations.has("post /calendario-academico/{id}/eventos")).toBe(true);
+      expect(operations.has("put /calendario-academico/{id}/eventos/{eventoId}")).toBe(true);
+      expect(operations.has("delete /calendario-academico/{id}/eventos/{eventoId}")).toBe(true);
+      expect(operations.has("post /calendario-academico/{id}/eventos/batch")).toBe(true);
+    });
+  });
+
+  describe("misc (search, health, upload, content-images)", () => {
+    it("registers search, health, upload and content-images", () => {
+      expect(operations.has("get /search")).toBe(true);
+      expect(operations.has("get /health")).toBe(true);
+      expect(operations.has("post /upload/photo")).toBe(true);
+      expect(operations.has("get /content-images/{path}")).toBe(true);
+    });
+  });
+});

--- a/src/lib/server/openapi/common-schemas.ts
+++ b/src/lib/server/openapi/common-schemas.ts
@@ -39,13 +39,13 @@ export type CommonSchemas = {
  * Pure data, kept module-level since it has no lifecycle.
  */
 const STATUS_DESCRIPTIONS: Record<number, string> = {
-  400: "Validation error",
-  401: "Unauthorized",
-  403: "Forbidden",
-  404: "Not found",
-  409: "Conflict",
-  429: "Rate limited",
-  500: "Internal server error",
+  400: "Erro de validação",
+  401: "Não autorizado",
+  403: "Sem permissão",
+  404: "Não encontrado",
+  409: "Conflito",
+  429: "Limite de requisições excedido",
+  500: "Erro interno do servidor",
 };
 
 /**
@@ -61,7 +61,7 @@ export function registerCommonSchemas(registry: OpenAPIRegistry): CommonSchemas 
   const ErrorCodeSchema = registry.register(
     "ErrorCode",
     z.enum(Object.values(ErrorCode) as [string, ...string[]]).openapi({
-      description: "Machine-readable error code returned in every error response.",
+      description: "Código de erro legível por máquina, retornado em toda resposta de erro.",
       example: ErrorCode.VALIDATION_ERROR,
     })
   );
@@ -71,16 +71,16 @@ export function registerCommonSchemas(registry: OpenAPIRegistry): CommonSchemas 
     z
       .object({
         field: z.string().openapi({
-          description: "Dot-notation path to the field that failed validation.",
+          description: "Caminho (dot-notation) do campo que falhou na validação.",
           example: "email",
         }),
         message: z.string().openapi({
-          description: "Human-readable message describing the validation failure.",
+          description: "Mensagem legível descrevendo a falha de validação.",
           example: "Email inválido",
         }),
       })
       .openapi({
-        description: "Details about a single field-level validation failure.",
+        description: "Detalhes de uma falha de validação em um campo específico.",
       })
   );
 
@@ -89,18 +89,18 @@ export function registerCommonSchemas(registry: OpenAPIRegistry): CommonSchemas 
     z
       .object({
         message: z.string().openapi({
-          description: "Human-readable error message, localized in Portuguese.",
+          description: "Mensagem de erro legível, em português.",
           example: "Email inválido",
         }),
         code: ErrorCodeSchema.openapi({
-          description: "Machine-readable error code. See the ErrorCode enum.",
+          description: "Código de erro legível por máquina. Ver o enum ErrorCode.",
         }),
         errors: z.array(FieldErrorSchema).optional().openapi({
-          description: "Field-level validation errors (present only for VALIDATION_ERROR).",
+          description: "Erros de validação por campo (presente apenas em VALIDATION_ERROR).",
         }),
       })
       .openapi({
-        description: "Standard error response returned for every 4xx and 5xx status code.",
+        description: "Formato padrão de resposta de erro retornado em todo 4xx e 5xx.",
       })
   );
 
@@ -114,7 +114,7 @@ export function registerCommonSchemas(registry: OpenAPIRegistry): CommonSchemas 
         totalPages: z.number().int().nonnegative().openapi({ example: 14 }),
       })
       .openapi({
-        description: "Pagination metadata returned alongside paginated result lists.",
+        description: "Metadados de paginação retornados junto com listas paginadas.",
       })
   );
 

--- a/src/lib/server/openapi/common-schemas.ts
+++ b/src/lib/server/openapi/common-schemas.ts
@@ -1,0 +1,141 @@
+import { z } from "zod";
+import type { ResponseConfig } from "@asteasolutions/zod-to-openapi";
+
+import { ErrorCode } from "@/lib/shared/errors/error-codes";
+
+import { registry } from "./registry";
+
+/**
+ * Reusable component schemas registered under #/components/schemas.
+ *
+ * Every path that can return a validation or error response should reference
+ * these via the errorResponses() helper below, to keep the OpenAPI document
+ * consistent and avoid duplicating error shapes in every operation.
+ */
+
+/**
+ * Registered as `ErrorCode` — the full list of machine-readable error codes
+ * that the API returns in error responses. Consumers can use this enum to
+ * programmatically handle specific failure modes (e.g., retry on 429, redirect
+ * to login on TOKEN_EXPIRED).
+ *
+ * Mirrors `ErrorCode` in src/lib/shared/errors/error-codes.ts — keep in sync.
+ */
+export const ErrorCodeSchema = registry.register(
+  "ErrorCode",
+  z.enum(Object.values(ErrorCode) as [string, ...string[]]).openapi({
+    description: "Machine-readable error code returned in every error response.",
+    example: ErrorCode.VALIDATION_ERROR,
+  })
+);
+
+/**
+ * Registered as `FieldError` — represents a single field-level validation failure,
+ * returned inside `ApiErrorBody.errors` for 400 VALIDATION_ERROR responses.
+ */
+export const FieldErrorSchema = registry.register(
+  "FieldError",
+  z
+    .object({
+      field: z.string().openapi({
+        description: "Dot-notation path to the field that failed validation.",
+        example: "email",
+      }),
+      message: z.string().openapi({
+        description: "Human-readable message describing the validation failure.",
+        example: "Email inválido",
+      }),
+    })
+    .openapi({
+      description: "Details about a single field-level validation failure.",
+    })
+);
+
+/**
+ * Registered as `ApiErrorBody` — the standard error response shape used by
+ * every 4xx and 5xx response from the API. Produced by `ApiError` helpers
+ * in src/lib/server/errors/api-error.ts.
+ */
+export const ApiErrorBodySchema = registry.register(
+  "ApiErrorBody",
+  z
+    .object({
+      message: z.string().openapi({
+        description: "Human-readable error message, localized in Portuguese.",
+        example: "Email inválido",
+      }),
+      code: ErrorCodeSchema.openapi({
+        description: "Machine-readable error code. See the ErrorCode enum.",
+      }),
+      errors: z.array(FieldErrorSchema).optional().openapi({
+        description: "Field-level validation errors (present only for VALIDATION_ERROR).",
+      }),
+    })
+    .openapi({
+      description: "Standard error response returned for every 4xx and 5xx status code.",
+    })
+);
+
+/**
+ * Registered as `PaginationMeta` — envelope metadata used by paginated list
+ * endpoints (e.g., GET /usuarios with ?page and ?limit).
+ */
+export const PaginationMetaSchema = registry.register(
+  "PaginationMeta",
+  z
+    .object({
+      page: z.number().int().positive().openapi({ example: 1 }),
+      limit: z.number().int().positive().openapi({ example: 25 }),
+      total: z.number().int().nonnegative().openapi({ example: 342 }),
+      totalPages: z.number().int().nonnegative().openapi({ example: 14 }),
+    })
+    .openapi({
+      description: "Pagination metadata returned alongside paginated result lists.",
+    })
+);
+
+/**
+ * Default descriptions for well-known HTTP status codes used in the API.
+ * Kept short since each operation can override via its own description when needed.
+ */
+const STATUS_DESCRIPTIONS: Record<number, string> = {
+  400: "Bad request — invalid input or validation failure",
+  401: "Unauthorized — missing, invalid or expired token",
+  403: "Forbidden — authenticated but lacking permission",
+  404: "Not found — the requested resource does not exist",
+  409: "Conflict — the request conflicts with current state",
+  429: "Too many requests — rate limit exceeded",
+  500: "Internal server error",
+};
+
+/**
+ * Build a map of common error responses referencing the shared `ApiErrorBody`
+ * schema. Usage in a path registration:
+ *
+ *   responses: {
+ *     200: { description: "OK", content: {...} },
+ *     ...errorResponses([400, 401, 404, 500]),
+ *   }
+ *
+ * @param codes HTTP status codes to include (must be one of the keys in STATUS_DESCRIPTIONS).
+ */
+export function errorResponses(codes: number[]): Record<string, ResponseConfig> {
+  const responses: Record<string, ResponseConfig> = {};
+  for (const code of codes) {
+    const description = STATUS_DESCRIPTIONS[code];
+    if (!description) {
+      throw new Error(
+        `errorResponses(): unknown status code ${code}. Add it to STATUS_DESCRIPTIONS in common-schemas.ts.`
+      );
+    }
+    responses[String(code)] = {
+      description,
+      content: {
+        "application/json": {
+          schema: ApiErrorBodySchema,
+        },
+      },
+    };
+  }
+  return responses;
+}

--- a/src/lib/server/openapi/common-schemas.ts
+++ b/src/lib/server/openapi/common-schemas.ts
@@ -31,7 +31,10 @@ export type CommonSchemas = {
    * `ApiErrorBody` component. Returned as a closure so each call captures
    * the ApiErrorBody schema bound to the enclosing registry.
    */
-  errorResponses: (codes: number[]) => Record<string, ResponseConfig>;
+  errorResponses: (
+    codes: number[],
+    examples?: Partial<Record<number, { message: string; code: string }>>
+  ) => Record<string, ResponseConfig>;
 };
 
 /**
@@ -123,7 +126,10 @@ export function registerCommonSchemas(registry: OpenAPIRegistry): CommonSchemas 
    * references the same schema registered above. Fresh on every call, which
    * eliminates the risk of cross-registry schema leakage.
    */
-  function errorResponses(codes: number[]): Record<string, ResponseConfig> {
+  function errorResponses(
+    codes: number[],
+    examples?: Partial<Record<number, { message: string; code: string }>>
+  ): Record<string, ResponseConfig> {
     const responses: Record<string, ResponseConfig> = {};
     for (const code of codes) {
       const description = STATUS_DESCRIPTIONS[code];
@@ -132,11 +138,13 @@ export function registerCommonSchemas(registry: OpenAPIRegistry): CommonSchemas 
           `errorResponses(): unknown status code ${code}. Add it to STATUS_DESCRIPTIONS in common-schemas.ts.`
         );
       }
+      const example = examples?.[code];
       responses[String(code)] = {
         description,
         content: {
           "application/json": {
             schema: ApiErrorBodySchema,
+            ...(example && { example }),
           },
         },
       };

--- a/src/lib/server/openapi/common-schemas.ts
+++ b/src/lib/server/openapi/common-schemas.ts
@@ -39,12 +39,12 @@ export type CommonSchemas = {
  * Pure data, kept module-level since it has no lifecycle.
  */
 const STATUS_DESCRIPTIONS: Record<number, string> = {
-  400: "Bad request — invalid input or validation failure",
-  401: "Unauthorized — missing, invalid or expired token",
-  403: "Forbidden — authenticated but lacking permission",
-  404: "Not found — the requested resource does not exist",
-  409: "Conflict — the request conflicts with current state",
-  429: "Too many requests — rate limit exceeded",
+  400: "Validation error",
+  401: "Unauthorized",
+  403: "Forbidden",
+  404: "Not found",
+  409: "Conflict",
+  429: "Rate limited",
   500: "Internal server error",
 };
 

--- a/src/lib/server/openapi/common-schemas.ts
+++ b/src/lib/server/openapi/common-schemas.ts
@@ -3,6 +3,8 @@ import type { OpenAPIRegistry, ResponseConfig } from "@asteasolutions/zod-to-ope
 
 import { ErrorCode } from "@/lib/shared/errors/error-codes";
 
+type ErrorCodeValue = (typeof ErrorCode)[keyof typeof ErrorCode];
+
 /**
  * Reusable component schemas shared across every path.
  *
@@ -33,7 +35,7 @@ export type CommonSchemas = {
    */
   errorResponses: (
     codes: number[],
-    examples?: Partial<Record<number, { message: string; code: string }>>
+    examples?: Partial<Record<number, { message: string; code: ErrorCodeValue }>>
   ) => Record<string, ResponseConfig>;
 };
 
@@ -128,7 +130,7 @@ export function registerCommonSchemas(registry: OpenAPIRegistry): CommonSchemas 
    */
   function errorResponses(
     codes: number[],
-    examples?: Partial<Record<number, { message: string; code: string }>>
+    examples?: Partial<Record<number, { message: string; code: ErrorCodeValue }>>
   ): Record<string, ResponseConfig> {
     const responses: Record<string, ResponseConfig> = {};
     for (const code of codes) {

--- a/src/lib/server/openapi/common-schemas.ts
+++ b/src/lib/server/openapi/common-schemas.ts
@@ -3,6 +3,7 @@ import type { OpenAPIRegistry, ResponseConfig } from "@asteasolutions/zod-to-ope
 
 import { ErrorCode } from "@/lib/shared/errors/error-codes";
 
+/** Tipo utilitário: valores possíveis do enum ErrorCode. */
 type ErrorCodeValue = (typeof ErrorCode)[keyof typeof ErrorCode];
 
 /**

--- a/src/lib/server/openapi/common-schemas.ts
+++ b/src/lib/server/openapi/common-schemas.ts
@@ -1,102 +1,42 @@
 import { z } from "zod";
-import type { ResponseConfig } from "@asteasolutions/zod-to-openapi";
+import type { OpenAPIRegistry, ResponseConfig } from "@asteasolutions/zod-to-openapi";
 
 import { ErrorCode } from "@/lib/shared/errors/error-codes";
 
-import { registry } from "./registry";
-
 /**
- * Reusable component schemas registered under #/components/schemas.
+ * Reusable component schemas shared across every path.
  *
- * Every path that can return a validation or error response should reference
- * these via the errorResponses() helper below, to keep the OpenAPI document
- * consistent and avoid duplicating error shapes in every operation.
+ * Unlike an earlier version of this file, schemas are no longer registered as
+ * module-level side effects: calling `registerCommonSchemas(registry)` now
+ * both registers the schemas on the given registry AND returns fresh Zod
+ * references that can be reused by path definitions built around the same
+ * registry. This keeps the registry ephemeral (see registry.ts) and makes
+ * `getOpenApiDocument()` a pure function of the deployed code.
  */
 
 /**
- * Registered as `ErrorCode` — the full list of machine-readable error codes
- * that the API returns in error responses. Consumers can use this enum to
- * programmatically handle specific failure modes (e.g., retry on 429, redirect
- * to login on TOKEN_EXPIRED).
- *
- * Mirrors `ErrorCode` in src/lib/shared/errors/error-codes.ts — keep in sync.
+ * The set of references returned by `registerCommonSchemas`. Path modules
+ * receive this object as their second argument so they can reference the
+ * shared error body schema and build consistent error responses without
+ * importing anything from the module graph that might depend on a specific
+ * registry instance.
  */
-export const ErrorCodeSchema = registry.register(
-  "ErrorCode",
-  z.enum(Object.values(ErrorCode) as [string, ...string[]]).openapi({
-    description: "Machine-readable error code returned in every error response.",
-    example: ErrorCode.VALIDATION_ERROR,
-  })
-);
-
-/**
- * Registered as `FieldError` — represents a single field-level validation failure,
- * returned inside `ApiErrorBody.errors` for 400 VALIDATION_ERROR responses.
- */
-export const FieldErrorSchema = registry.register(
-  "FieldError",
-  z
-    .object({
-      field: z.string().openapi({
-        description: "Dot-notation path to the field that failed validation.",
-        example: "email",
-      }),
-      message: z.string().openapi({
-        description: "Human-readable message describing the validation failure.",
-        example: "Email inválido",
-      }),
-    })
-    .openapi({
-      description: "Details about a single field-level validation failure.",
-    })
-);
-
-/**
- * Registered as `ApiErrorBody` — the standard error response shape used by
- * every 4xx and 5xx response from the API. Produced by `ApiError` helpers
- * in src/lib/server/errors/api-error.ts.
- */
-export const ApiErrorBodySchema = registry.register(
-  "ApiErrorBody",
-  z
-    .object({
-      message: z.string().openapi({
-        description: "Human-readable error message, localized in Portuguese.",
-        example: "Email inválido",
-      }),
-      code: ErrorCodeSchema.openapi({
-        description: "Machine-readable error code. See the ErrorCode enum.",
-      }),
-      errors: z.array(FieldErrorSchema).optional().openapi({
-        description: "Field-level validation errors (present only for VALIDATION_ERROR).",
-      }),
-    })
-    .openapi({
-      description: "Standard error response returned for every 4xx and 5xx status code.",
-    })
-);
-
-/**
- * Registered as `PaginationMeta` — envelope metadata used by paginated list
- * endpoints (e.g., GET /usuarios with ?page and ?limit).
- */
-export const PaginationMetaSchema = registry.register(
-  "PaginationMeta",
-  z
-    .object({
-      page: z.number().int().positive().openapi({ example: 1 }),
-      limit: z.number().int().positive().openapi({ example: 25 }),
-      total: z.number().int().nonnegative().openapi({ example: 342 }),
-      totalPages: z.number().int().nonnegative().openapi({ example: 14 }),
-    })
-    .openapi({
-      description: "Pagination metadata returned alongside paginated result lists.",
-    })
-);
+export type CommonSchemas = {
+  ErrorCodeSchema: z.ZodTypeAny;
+  FieldErrorSchema: z.ZodTypeAny;
+  ApiErrorBodySchema: z.ZodTypeAny;
+  PaginationMetaSchema: z.ZodTypeAny;
+  /**
+   * Build a map of common error responses referencing the shared
+   * `ApiErrorBody` component. Returned as a closure so each call captures
+   * the ApiErrorBody schema bound to the enclosing registry.
+   */
+  errorResponses: (codes: number[]) => Record<string, ResponseConfig>;
+};
 
 /**
  * Default descriptions for well-known HTTP status codes used in the API.
- * Kept short since each operation can override via its own description when needed.
+ * Pure data, kept module-level since it has no lifecycle.
  */
 const STATUS_DESCRIPTIONS: Record<number, string> = {
   400: "Bad request — invalid input or validation failure",
@@ -109,33 +49,106 @@ const STATUS_DESCRIPTIONS: Record<number, string> = {
 };
 
 /**
- * Build a map of common error responses referencing the shared `ApiErrorBody`
- * schema. Usage in a path registration:
+ * Register the shared component schemas on the given registry and return the
+ * Zod references that path definitions should use.
  *
- *   responses: {
- *     200: { description: "OK", content: {...} },
- *     ...errorResponses([400, 401, 404, 500]),
- *   }
- *
- * @param codes HTTP status codes to include (must be one of the keys in STATUS_DESCRIPTIONS).
+ * IMPORTANT: call this exactly once per registry, before any `registerPath`
+ * calls, so paths can safely reference the returned schemas. The schemas
+ * themselves are instantiated freshly on every invocation — no two calls
+ * share Zod instances — so there is no risk of cross-registry state leakage.
  */
-export function errorResponses(codes: number[]): Record<string, ResponseConfig> {
-  const responses: Record<string, ResponseConfig> = {};
-  for (const code of codes) {
-    const description = STATUS_DESCRIPTIONS[code];
-    if (!description) {
-      throw new Error(
-        `errorResponses(): unknown status code ${code}. Add it to STATUS_DESCRIPTIONS in common-schemas.ts.`
-      );
-    }
-    responses[String(code)] = {
-      description,
-      content: {
-        "application/json": {
-          schema: ApiErrorBodySchema,
+export function registerCommonSchemas(registry: OpenAPIRegistry): CommonSchemas {
+  const ErrorCodeSchema = registry.register(
+    "ErrorCode",
+    z.enum(Object.values(ErrorCode) as [string, ...string[]]).openapi({
+      description: "Machine-readable error code returned in every error response.",
+      example: ErrorCode.VALIDATION_ERROR,
+    })
+  );
+
+  const FieldErrorSchema = registry.register(
+    "FieldError",
+    z
+      .object({
+        field: z.string().openapi({
+          description: "Dot-notation path to the field that failed validation.",
+          example: "email",
+        }),
+        message: z.string().openapi({
+          description: "Human-readable message describing the validation failure.",
+          example: "Email inválido",
+        }),
+      })
+      .openapi({
+        description: "Details about a single field-level validation failure.",
+      })
+  );
+
+  const ApiErrorBodySchema = registry.register(
+    "ApiErrorBody",
+    z
+      .object({
+        message: z.string().openapi({
+          description: "Human-readable error message, localized in Portuguese.",
+          example: "Email inválido",
+        }),
+        code: ErrorCodeSchema.openapi({
+          description: "Machine-readable error code. See the ErrorCode enum.",
+        }),
+        errors: z.array(FieldErrorSchema).optional().openapi({
+          description: "Field-level validation errors (present only for VALIDATION_ERROR).",
+        }),
+      })
+      .openapi({
+        description: "Standard error response returned for every 4xx and 5xx status code.",
+      })
+  );
+
+  const PaginationMetaSchema = registry.register(
+    "PaginationMeta",
+    z
+      .object({
+        page: z.number().int().positive().openapi({ example: 1 }),
+        limit: z.number().int().positive().openapi({ example: 25 }),
+        total: z.number().int().nonnegative().openapi({ example: 342 }),
+        totalPages: z.number().int().nonnegative().openapi({ example: 14 }),
+      })
+      .openapi({
+        description: "Pagination metadata returned alongside paginated result lists.",
+      })
+  );
+
+  /**
+   * Closure over ApiErrorBodySchema so every response returned by this helper
+   * references the same schema registered above. Fresh on every call, which
+   * eliminates the risk of cross-registry schema leakage.
+   */
+  function errorResponses(codes: number[]): Record<string, ResponseConfig> {
+    const responses: Record<string, ResponseConfig> = {};
+    for (const code of codes) {
+      const description = STATUS_DESCRIPTIONS[code];
+      if (!description) {
+        throw new Error(
+          `errorResponses(): unknown status code ${code}. Add it to STATUS_DESCRIPTIONS in common-schemas.ts.`
+        );
+      }
+      responses[String(code)] = {
+        description,
+        content: {
+          "application/json": {
+            schema: ApiErrorBodySchema,
+          },
         },
-      },
-    };
+      };
+    }
+    return responses;
   }
-  return responses;
+
+  return {
+    ErrorCodeSchema,
+    FieldErrorSchema,
+    ApiErrorBodySchema,
+    PaginationMetaSchema,
+    errorResponses,
+  };
 }

--- a/src/lib/server/openapi/generator.ts
+++ b/src/lib/server/openapi/generator.ts
@@ -1,0 +1,98 @@
+import { OpenApiGeneratorV31 } from "@asteasolutions/zod-to-openapi";
+import type { OpenAPIObject } from "openapi3-ts/oas31";
+
+import packageJson from "../../../../package.json";
+
+// Importing these modules has the side effect of registering their schemas
+// and (eventually) paths on the shared registry. The order matters: the
+// registry must exist first, then the shared component schemas, then the
+// per-resource paths are registered on demand via registerAllPaths().
+import { registry, OPENAPI_TAGS } from "./registry";
+import "./common-schemas";
+import { registerAllPaths } from "./paths";
+
+/**
+ * Module-level cache for the generated document. Filled on first call and
+ * reused for every subsequent request during the lifetime of the process.
+ *
+ * In development Next.js reloads modules when source files change, which
+ * naturally invalidates this cache so contributors see fresh docs without
+ * any extra plumbing. In production the cache persists for the lifetime of
+ * the serverless function instance.
+ */
+let cachedDocument: OpenAPIObject | null = null;
+
+/**
+ * Human-readable top-level description shown on the Scalar docs homepage.
+ * Explains how to authenticate via the "Authorize" button so API consumers
+ * can immediately test protected endpoints using a real login flow.
+ */
+const API_DESCRIPTION = `
+Interactive documentation for the Aquário UFPB API.
+
+**Authentication:** most endpoints require a JWT bearer token. To test authenticated
+endpoints in this UI:
+
+1. Call \`POST /auth/login\` with valid credentials to obtain a token.
+2. Copy the \`token\` value from the response.
+3. Click the **Authorize** button at the top right of this page.
+4. Paste the token as a Bearer credential and click **Authorize**.
+
+All subsequent "Try it out" requests will include the token automatically.
+
+**Error responses:** every 4xx and 5xx response follows the shared \`ApiErrorBody\`
+schema with a \`message\` (human-readable) and a \`code\` (machine-readable, see the
+\`ErrorCode\` enum). Use the \`code\` for programmatic handling.
+
+**Languages:** descriptions are written in English for a broader audience, but
+error messages returned by the API are in Portuguese (as served to end users).
+`.trim();
+
+/**
+ * Lazily build and cache the OpenAPI document. Subsequent calls return the
+ * exact same object reference so the underlying JSON serialization can be
+ * cached by Next.js and downstream consumers.
+ */
+export function getOpenApiDocument(): OpenAPIObject {
+  if (cachedDocument) {
+    return cachedDocument;
+  }
+
+  registerAllPaths(registry);
+
+  const generator = new OpenApiGeneratorV31(registry.definitions);
+
+  cachedDocument = generator.generateDocument({
+    openapi: "3.1.0",
+    info: {
+      title: "Aquário UFPB API",
+      version: packageJson.version,
+      description: API_DESCRIPTION,
+      contact: {
+        name: "Aquário UFPB",
+        email: "aquarioufpb@gmail.com",
+        url: "https://www.aquarioufpb.com",
+      },
+      license: {
+        name: "MIT",
+        url: "https://github.com/aquario-ufpb/aquario/blob/main/LICENSE",
+      },
+    },
+    servers: [
+      { url: "https://www.aquarioufpb.com", description: "Production" },
+      { url: "http://localhost:3000", description: "Local development" },
+    ],
+    tags: OPENAPI_TAGS.map(tag => ({ ...tag })),
+  });
+
+  return cachedDocument;
+}
+
+/**
+ * Test-only helper: reset the cached document so tests can re-run document
+ * generation in isolation. Not exported from any public module outside of
+ * __tests__ consumers.
+ */
+export function __resetOpenApiCacheForTests(): void {
+  cachedDocument = null;
+}

--- a/src/lib/server/openapi/generator.ts
+++ b/src/lib/server/openapi/generator.ts
@@ -3,12 +3,8 @@ import type { OpenAPIObject } from "openapi3-ts/oas31";
 
 import packageJson from "../../../../package.json";
 
-// Importing these modules has the side effect of registering their schemas
-// and (eventually) paths on the shared registry. The order matters: the
-// registry must exist first, then the shared component schemas, then the
-// per-resource paths are registered on demand via registerAllPaths().
-import { registry, OPENAPI_TAGS } from "./registry";
-import "./common-schemas";
+import { registerCommonSchemas } from "./common-schemas";
+import { createRegistry, OPENAPI_TAGS } from "./registry";
 import { registerAllPaths } from "./paths";
 
 /**
@@ -19,6 +15,11 @@ import { registerAllPaths } from "./paths";
  * naturally invalidates this cache so contributors see fresh docs without
  * any extra plumbing. In production the cache persists for the lifetime of
  * the serverless function instance.
+ *
+ * Note that ONLY the generated document is cached — the registry used to
+ * build it is ephemeral, created fresh inside `getOpenApiDocument` on each
+ * cache miss. That ensures every invocation is a pure function of the code:
+ * calling the generator multiple times never leaks state between calls.
  */
 let cachedDocument: OpenAPIObject | null = null;
 
@@ -52,13 +53,20 @@ error messages returned by the API are in Portuguese (as served to end users).
  * Lazily build and cache the OpenAPI document. Subsequent calls return the
  * exact same object reference so the underlying JSON serialization can be
  * cached by Next.js and downstream consumers.
+ *
+ * On a cache miss, a fresh registry is created, the common component schemas
+ * are registered on it, and every path group is registered in turn. The
+ * resulting document is frozen in the module-level cache and returned on all
+ * subsequent calls until the cache is cleared (in tests or on hot reload).
  */
 export function getOpenApiDocument(): OpenAPIObject {
   if (cachedDocument) {
     return cachedDocument;
   }
 
-  registerAllPaths(registry);
+  const registry = createRegistry();
+  const schemas = registerCommonSchemas(registry);
+  registerAllPaths(registry, schemas);
 
   const generator = new OpenApiGeneratorV31(registry.definitions);
 
@@ -90,8 +98,9 @@ export function getOpenApiDocument(): OpenAPIObject {
 
 /**
  * Test-only helper: reset the cached document so tests can re-run document
- * generation in isolation. Not exported from any public module outside of
- * __tests__ consumers.
+ * generation in isolation. Safe to call repeatedly — since each call to
+ * `getOpenApiDocument()` now builds its own registry, there is no cross-call
+ * state to leak.
  */
 export function __resetOpenApiCacheForTests(): void {
   cachedDocument = null;

--- a/src/lib/server/openapi/generator.ts
+++ b/src/lib/server/openapi/generator.ts
@@ -29,24 +29,22 @@ let cachedDocument: OpenAPIObject | null = null;
  * can immediately test protected endpoints using a real login flow.
  */
 const API_DESCRIPTION = `
-Interactive documentation for the Aquário UFPB API.
+Documentação interativa da API do Aquário UFPB.
 
-**Authentication:** most endpoints require a JWT bearer token. To test authenticated
-endpoints in this UI:
+**Autenticação:** a maior parte dos endpoints exige um token JWT. Para testar
+endpoints autenticados aqui na UI:
 
-1. Call \`POST /auth/login\` with valid credentials to obtain a token.
-2. Copy the \`token\` value from the response.
-3. Click the **Authorize** button at the top right of this page.
-4. Paste the token as a Bearer credential and click **Authorize**.
+1. Chame \`POST /auth/login\` com credenciais válidas para obter um token.
+2. Copie o valor do campo \`token\` da resposta.
+3. Clique no botão **Authorize** no topo da página.
+4. Cole o token como credencial Bearer e clique em **Authorize**.
 
-All subsequent "Try it out" requests will include the token automatically.
+A partir daí, todas as chamadas "Try it out" incluirão o token automaticamente.
 
-**Error responses:** every 4xx and 5xx response follows the shared \`ApiErrorBody\`
-schema with a \`message\` (human-readable) and a \`code\` (machine-readable, see the
-\`ErrorCode\` enum). Use the \`code\` for programmatic handling.
-
-**Languages:** descriptions are written in English for a broader audience, but
-error messages returned by the API are in Portuguese (as served to end users).
+**Respostas de erro:** toda resposta 4xx e 5xx segue o formato \`ApiErrorBody\`,
+com um campo \`message\` (legível por humanos, em português) e um \`code\`
+(legível por máquina — ver o enum \`ErrorCode\`). Use o \`code\` para tratamento
+programático dos erros.
 `.trim();
 
 /**
@@ -87,8 +85,8 @@ export function getOpenApiDocument(): OpenAPIObject {
       },
     },
     servers: [
-      { url: "https://www.aquarioufpb.com", description: "Production" },
-      { url: "http://localhost:3000", description: "Local development" },
+      { url: "https://www.aquarioufpb.com", description: "Produção" },
+      { url: "http://localhost:3000", description: "Desenvolvimento local" },
     ],
     tags: OPENAPI_TAGS.map(tag => ({ ...tag })),
   });

--- a/src/lib/server/openapi/generator.ts
+++ b/src/lib/server/openapi/generator.ts
@@ -7,27 +7,9 @@ import { registerCommonSchemas } from "./common-schemas";
 import { createRegistry, OPENAPI_TAGS } from "./registry";
 import { registerAllPaths } from "./paths";
 
-/**
- * Module-level cache for the generated document. Filled on first call and
- * reused for every subsequent request during the lifetime of the process.
- *
- * In development Next.js reloads modules when source files change, which
- * naturally invalidates this cache so contributors see fresh docs without
- * any extra plumbing. In production the cache persists for the lifetime of
- * the serverless function instance.
- *
- * Note that ONLY the generated document is cached — the registry used to
- * build it is ephemeral, created fresh inside `getOpenApiDocument` on each
- * cache miss. That ensures every invocation is a pure function of the code:
- * calling the generator multiple times never leaks state between calls.
- */
+// Cached per process lifetime; reset on hot reload in dev and by __resetOpenApiCacheForTests in tests.
 let cachedDocument: OpenAPIObject | null = null;
 
-/**
- * Human-readable top-level description shown on the Scalar docs homepage.
- * Explains how to authenticate via the "Authorize" button so API consumers
- * can immediately test protected endpoints using a real login flow.
- */
 const API_DESCRIPTION = `
 Documentação interativa da API do Aquário UFPB.
 
@@ -47,16 +29,6 @@ com um campo \`message\` (legível por humanos, em português) e um \`code\`
 programático dos erros.
 `.trim();
 
-/**
- * Lazily build and cache the OpenAPI document. Subsequent calls return the
- * exact same object reference so the underlying JSON serialization can be
- * cached by Next.js and downstream consumers.
- *
- * On a cache miss, a fresh registry is created, the common component schemas
- * are registered on it, and every path group is registered in turn. The
- * resulting document is frozen in the module-level cache and returned on all
- * subsequent calls until the cache is cleared (in tests or on hot reload).
- */
 export function getOpenApiDocument(): OpenAPIObject {
   if (cachedDocument) {
     return cachedDocument;
@@ -94,12 +66,6 @@ export function getOpenApiDocument(): OpenAPIObject {
   return cachedDocument;
 }
 
-/**
- * Test-only helper: reset the cached document so tests can re-run document
- * generation in isolation. Safe to call repeatedly — since each call to
- * `getOpenApiDocument()` now builds its own registry, there is no cross-call
- * state to leak.
- */
 export function __resetOpenApiCacheForTests(): void {
   cachedDocument = null;
 }

--- a/src/lib/server/openapi/paths/auth.ts
+++ b/src/lib/server/openapi/paths/auth.ts
@@ -122,7 +122,7 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
     tags: ["Auth"],
     summary: "Log in with email and password",
     description:
-      "Authenticate with email and password and receive a JWT bearer token. **Rate limited to 5 attempts per minute per IP address.** On rate limit exceeded, the response includes `X-RateLimit-*` headers and `Retry-After`. For security, this endpoint does not disclose whether the email exists — any invalid email/password combination returns a generic 401 response.",
+      "Authenticate with email and password. Returns a JWT bearer token valid for 7 days. Rate limited to 5 attempts/min per IP. Invalid credentials always return a generic 401 to prevent user enumeration.",
     request: {
       body: {
         required: true,
@@ -139,21 +139,7 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
     },
     responses: {
       200: {
-        description: "Login successful. The returned token is valid for 7 days.",
-        headers: {
-          "X-RateLimit-Limit": {
-            description: "Maximum number of login attempts allowed per minute per IP.",
-            schema: { type: "integer", example: 5 },
-          },
-          "X-RateLimit-Remaining": {
-            description: "Remaining login attempts in the current window.",
-            schema: { type: "integer", example: 4 },
-          },
-          "X-RateLimit-Reset": {
-            description: "Unix timestamp (ms) when the rate limit window resets.",
-            schema: { type: "integer", example: 1712668800000 },
-          },
-        },
+        description: "Login successful.",
         content: {
           "application/json": {
             schema: tokenResponseSchema,
@@ -162,15 +148,12 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
         },
       },
       429: {
-        description: "Too many login attempts. Wait for `Retry-After` seconds before trying again.",
+        description: "Rate limited — wait `Retry-After` seconds before retrying.",
         headers: {
           "Retry-After": {
-            description: "Number of seconds to wait before retrying.",
+            description: "Seconds until the rate limit window resets.",
             schema: { type: "integer", example: 42 },
           },
-          "X-RateLimit-Limit": { schema: { type: "integer", example: 5 } },
-          "X-RateLimit-Remaining": { schema: { type: "integer", example: 0 } },
-          "X-RateLimit-Reset": { schema: { type: "integer", example: 1712668800000 } },
         },
         content: {
           "application/json": {
@@ -178,7 +161,7 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
           },
         },
       },
-      ...errorResponses([400, 401, 500]),
+      ...errorResponses([400]),
     },
   });
 
@@ -188,7 +171,7 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
     tags: ["Auth"],
     summary: "Register a new user account",
     description:
-      "Create a new user account. In production environments, a verification email is sent and the user must click the link before logging in. In development environments (no email provider configured), the user is auto-verified and can log in immediately. Email addresses must belong to a UFPB domain (any subdomain of `.ufpb.br`).",
+      "Create a new user account. Only UFPB email domains (`*.ufpb.br`) are accepted. In prod a verification email is sent; in dev (no email provider) users are auto-verified.",
     request: {
       body: {
         required: true,
@@ -220,7 +203,7 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
           },
         },
       },
-      ...errorResponses([400, 409, 500]),
+      ...errorResponses([400, 409]),
     },
   });
 
@@ -229,8 +212,7 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
     path: "/auth/me",
     tags: ["Auth"],
     summary: "Get the currently authenticated user",
-    description:
-      "Return the profile of the user whose bearer token is supplied. Sensitive fields (password hash, verification tokens, etc) are never included in the response.",
+    description: "Return the authenticated user's profile. Sensitive fields are never included.",
     security: [{ bearerAuth: [] }],
     responses: {
       200: {
@@ -260,7 +242,6 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
           },
         },
       },
-      ...errorResponses([401, 500]),
     },
   });
 
@@ -269,8 +250,7 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
     path: "/auth/refresh",
     tags: ["Auth"],
     summary: "Refresh the current JWT token",
-    description:
-      "Issue a fresh JWT for the authenticated user without requiring email/password. Useful for extending sessions before the current token expires.",
+    description: "Issue a fresh JWT for the authenticated user.",
     security: [{ bearerAuth: [] }],
     responses: {
       200: {
@@ -282,7 +262,6 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
           },
         },
       },
-      ...errorResponses([401, 500]),
     },
   });
 
@@ -291,8 +270,7 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
     path: "/auth/verificar-email",
     tags: ["Auth"],
     summary: "Verify an email address using a token",
-    description:
-      "Consume a verification token sent by email (when registering or requesting a resend). On success, the user is marked as verified and can log in.",
+    description: "Consume a verification token sent by email and mark the user as verified.",
     request: {
       body: {
         required: true,
@@ -314,7 +292,7 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
           },
         },
       },
-      ...errorResponses([400, 500]),
+      ...errorResponses([400]),
     },
   });
 
@@ -324,7 +302,7 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
     tags: ["Auth"],
     summary: "Request a password reset email",
     description:
-      "Send a password reset email to the provided address if it exists in the system. **Returns 200 regardless of whether the email is registered** to prevent user enumeration attacks. Clients should never rely on the response to determine account existence.",
+      "Always returns 200, whether the email is registered or not, to prevent user enumeration.",
     request: {
       body: {
         required: true,
@@ -338,8 +316,7 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
     },
     responses: {
       200: {
-        description:
-          "Request accepted. A reset email is sent only if the address is registered — clients should not interpret this response as confirmation that the account exists.",
+        description: "Request accepted.",
         content: {
           "application/json": {
             schema: messageResponseSchema,
@@ -358,8 +335,7 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
     path: "/auth/resetar-senha",
     tags: ["Auth"],
     summary: "Reset password using a reset token",
-    description:
-      "Consume a password reset token (sent via email from /auth/esqueci-senha) and set a new password for the associated account.",
+    description: "Consume a reset token (sent via email) and set a new password.",
     request: {
       body: {
         required: true,
@@ -384,7 +360,7 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
           },
         },
       },
-      ...errorResponses([400, 500]),
+      ...errorResponses([400]),
     },
   });
 
@@ -394,7 +370,7 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
     tags: ["Auth"],
     summary: "Resend verification email (authenticated)",
     description:
-      "Request a new verification email for the currently authenticated user. Use this when the original verification email was lost or expired. The user must be authenticated — for an unauthenticated flow, use POST /auth/solicitar-reenvio-verificacao instead.",
+      "Resend the verification email for the authenticated user. For the unauthenticated flow, see `/auth/solicitar-reenvio-verificacao`.",
     security: [{ bearerAuth: [] }],
     responses: {
       200: {
@@ -406,7 +382,7 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
           },
         },
       },
-      ...errorResponses([400, 401, 500]),
+      ...errorResponses([400]),
     },
   });
 
@@ -416,7 +392,7 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
     tags: ["Auth"],
     summary: "Request verification email resend by email address",
     description:
-      "Unauthenticated version of the resend flow: provide an email address and, if it corresponds to a registered but unverified account, a new verification email will be sent. **Returns 200 regardless of whether the email is registered** to prevent user enumeration attacks.",
+      "Unauthenticated resend flow. Always returns 200 regardless of whether the email exists (prevents user enumeration).",
     request: {
       body: {
         required: true,

--- a/src/lib/server/openapi/paths/auth.ts
+++ b/src/lib/server/openapi/paths/auth.ts
@@ -1,0 +1,439 @@
+import { z } from "zod";
+import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
+
+import { loginSchema } from "@/app/api/auth/login/route";
+import { registerSchema } from "@/app/api/auth/register/route";
+import { verifySchema } from "@/app/api/auth/verificar-email/route";
+import { forgotPasswordSchema } from "@/app/api/auth/esqueci-senha/route";
+import { resetPasswordSchema } from "@/app/api/auth/resetar-senha/route";
+import { resendVerificationRequestSchema } from "@/app/api/auth/solicitar-reenvio-verificacao/route";
+
+import { errorResponses, ApiErrorBodySchema } from "../common-schemas";
+
+/**
+ * Shared JWT example used across token responses. Truncated to keep the
+ * rendered examples readable — the real token is a long opaque string.
+ */
+const EXAMPLE_JWT =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI1NTBlODQwMC1lMjliLTQxZDQtYTcxNi00NDY2NTU0NDAwMDAifQ.signature";
+
+/**
+ * Schema for the `{ token }` response returned by login and refresh endpoints.
+ */
+const tokenResponseSchema = z
+  .object({
+    token: z.string().openapi({
+      description: "JWT bearer token. Use it in the Authorization header as 'Bearer <token>'.",
+      example: EXAMPLE_JWT,
+    }),
+  })
+  .openapi("TokenResponse");
+
+/**
+ * Generic `{ message }` response used by several auth flows that do not
+ * return structured data (verification, password reset, etc).
+ */
+const messageResponseSchema = z
+  .object({
+    message: z.string().openapi({
+      description: "Human-readable status message, localized in Portuguese.",
+      example: "Operação realizada com sucesso.",
+    }),
+  })
+  .openapi("MessageResponse");
+
+/**
+ * Response shape for POST /auth/register — includes the new user id and whether
+ * email verification was skipped (happens automatically in dev/test environments).
+ */
+const registerResponseSchema = z
+  .object({
+    message: z.string().openapi({
+      example: "Cadastro realizado! Verifique seu email para ativar sua conta.",
+    }),
+    usuarioId: z.string().uuid().openapi({
+      description: "UUID of the newly created user.",
+      example: "550e8400-e29b-41d4-a716-446655440000",
+    }),
+    verificado: z.boolean().openapi({
+      description: "Whether the user was auto-verified (true) or needs email verification (false).",
+      example: false,
+    }),
+  })
+  .openapi("RegisterResponse");
+
+/**
+ * Response shape for GET /auth/me — the authenticated user's profile with
+ * sensitive fields (password hash, etc) stripped out. Matches the object
+ * returned by src/app/api/auth/me/route.ts.
+ */
+const currentUserResponseSchema = z
+  .object({
+    id: z.string().uuid().openapi({ example: "550e8400-e29b-41d4-a716-446655440000" }),
+    nome: z.string().openapi({ example: "João Silva" }),
+    email: z.string().email().openapi({ example: "joao.silva@academico.ufpb.br" }),
+    slug: z.string().openapi({ example: "joao-silva" }),
+    papelPlataforma: z.enum(["USER", "MASTER_ADMIN"]).openapi({
+      description: "Platform-wide role: regular user or master admin.",
+      example: "USER",
+    }),
+    eVerificado: z.boolean().openapi({ example: true }),
+    urlFotoPerfil: z
+      .string()
+      .url()
+      .nullable()
+      .openapi({ example: "https://www.aquarioufpb.com/photos/joao.webp" }),
+    centro: z
+      .object({
+        id: z.string().uuid(),
+        nome: z.string().openapi({ example: "Centro de Informática" }),
+        sigla: z.string().openapi({ example: "CI" }),
+      })
+      .openapi({ description: "User's academic center." }),
+    curso: z
+      .object({
+        id: z.string().uuid(),
+        nome: z.string().openapi({ example: "Ciência da Computação" }),
+      })
+      .openapi({ description: "User's course/major." }),
+    permissoes: z.array(z.string()).openapi({
+      description: "List of permission strings derived from the user's roles and memberships.",
+      example: ["entidade:admin:a1b2c3d4-e5f6-7890-abcd-ef1234567890"],
+    }),
+  })
+  .openapi("CurrentUserResponse");
+
+/**
+ * Register all authentication-related paths on the OpenAPI registry.
+ * Called from registerAllPaths() in paths/index.ts during document generation.
+ */
+export function registerAuthPaths(registry: OpenAPIRegistry): void {
+  registry.registerPath({
+    method: "post",
+    path: "/auth/login",
+    tags: ["Auth"],
+    summary: "Log in with email and password",
+    description:
+      "Authenticate with email and password and receive a JWT bearer token. **Rate limited to 5 attempts per minute per IP address.** On rate limit exceeded, the response includes `X-RateLimit-*` headers and `Retry-After`. For security, this endpoint does not disclose whether the email exists — any invalid email/password combination returns a generic 401 response.",
+    request: {
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: loginSchema,
+            example: {
+              email: "joao.silva@academico.ufpb.br",
+              senha: "senhaSegura123",
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Login successful. The returned token is valid for 7 days.",
+        headers: {
+          "X-RateLimit-Limit": {
+            description: "Maximum number of login attempts allowed per minute per IP.",
+            schema: { type: "integer", example: 5 },
+          },
+          "X-RateLimit-Remaining": {
+            description: "Remaining login attempts in the current window.",
+            schema: { type: "integer", example: 4 },
+          },
+          "X-RateLimit-Reset": {
+            description: "Unix timestamp (ms) when the rate limit window resets.",
+            schema: { type: "integer", example: 1712668800000 },
+          },
+        },
+        content: {
+          "application/json": {
+            schema: tokenResponseSchema,
+            example: { token: EXAMPLE_JWT },
+          },
+        },
+      },
+      429: {
+        description: "Too many login attempts. Wait for `Retry-After` seconds before trying again.",
+        headers: {
+          "Retry-After": {
+            description: "Number of seconds to wait before retrying.",
+            schema: { type: "integer", example: 42 },
+          },
+          "X-RateLimit-Limit": { schema: { type: "integer", example: 5 } },
+          "X-RateLimit-Remaining": { schema: { type: "integer", example: 0 } },
+          "X-RateLimit-Reset": { schema: { type: "integer", example: 1712668800000 } },
+        },
+        content: {
+          "application/json": {
+            schema: ApiErrorBodySchema,
+          },
+        },
+      },
+      ...errorResponses([400, 401, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/auth/register",
+    tags: ["Auth"],
+    summary: "Register a new user account",
+    description:
+      "Create a new user account. In production environments, a verification email is sent and the user must click the link before logging in. In development environments (no email provider configured), the user is auto-verified and can log in immediately. Email addresses must belong to a UFPB domain (any subdomain of `.ufpb.br`).",
+    request: {
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: registerSchema,
+            example: {
+              nome: "João Silva",
+              email: "joao.silva@academico.ufpb.br",
+              senha: "senhaSegura123",
+              centroId: "550e8400-e29b-41d4-a716-446655440000",
+              cursoId: "661f9511-f30b-52e5-b827-557766551111",
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "User created successfully.",
+        content: {
+          "application/json": {
+            schema: registerResponseSchema,
+            example: {
+              message: "Cadastro realizado! Verifique seu email para ativar sua conta.",
+              usuarioId: "550e8400-e29b-41d4-a716-446655440000",
+              verificado: false,
+            },
+          },
+        },
+      },
+      ...errorResponses([400, 409, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/auth/me",
+    tags: ["Auth"],
+    summary: "Get the currently authenticated user",
+    description:
+      "Return the profile of the user whose bearer token is supplied. Sensitive fields (password hash, verification tokens, etc) are never included in the response.",
+    security: [{ bearerAuth: [] }],
+    responses: {
+      200: {
+        description: "The authenticated user's profile.",
+        content: {
+          "application/json": {
+            schema: currentUserResponseSchema,
+            example: {
+              id: "550e8400-e29b-41d4-a716-446655440000",
+              nome: "João Silva",
+              email: "joao.silva@academico.ufpb.br",
+              slug: "joao-silva",
+              papelPlataforma: "USER",
+              eVerificado: true,
+              urlFotoPerfil: "https://www.aquarioufpb.com/photos/joao.webp",
+              centro: {
+                id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                nome: "Centro de Informática",
+                sigla: "CI",
+              },
+              curso: {
+                id: "b2c3d4e5-f6a7-8901-bcde-f23456789012",
+                nome: "Ciência da Computação",
+              },
+              permissoes: ["entidade:admin:a1b2c3d4-e5f6-7890-abcd-ef1234567890"],
+            },
+          },
+        },
+      },
+      ...errorResponses([401, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/auth/refresh",
+    tags: ["Auth"],
+    summary: "Refresh the current JWT token",
+    description:
+      "Issue a fresh JWT for the authenticated user without requiring email/password. Useful for extending sessions before the current token expires.",
+    security: [{ bearerAuth: [] }],
+    responses: {
+      200: {
+        description: "A new valid JWT token.",
+        content: {
+          "application/json": {
+            schema: tokenResponseSchema,
+            example: { token: EXAMPLE_JWT },
+          },
+        },
+      },
+      ...errorResponses([401, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/auth/verificar-email",
+    tags: ["Auth"],
+    summary: "Verify an email address using a token",
+    description:
+      "Consume a verification token sent by email (when registering or requesting a resend). On success, the user is marked as verified and can log in.",
+    request: {
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: verifySchema,
+            example: { token: "a1b2c3d4e5f6789012345678901234567890abcd" },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Email verified successfully.",
+        content: {
+          "application/json": {
+            schema: messageResponseSchema,
+            example: { message: "Email verificado com sucesso." },
+          },
+        },
+      },
+      ...errorResponses([400, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/auth/esqueci-senha",
+    tags: ["Auth"],
+    summary: "Request a password reset email",
+    description:
+      "Send a password reset email to the provided address if it exists in the system. **Returns 200 regardless of whether the email is registered** to prevent user enumeration attacks. Clients should never rely on the response to determine account existence.",
+    request: {
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: forgotPasswordSchema,
+            example: { email: "joao.silva@academico.ufpb.br" },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description:
+          "Request accepted. A reset email is sent only if the address is registered — clients should not interpret this response as confirmation that the account exists.",
+        content: {
+          "application/json": {
+            schema: messageResponseSchema,
+            example: {
+              message:
+                "Se o email estiver cadastrado, você receberá um link para redefinir sua senha.",
+            },
+          },
+        },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/auth/resetar-senha",
+    tags: ["Auth"],
+    summary: "Reset password using a reset token",
+    description:
+      "Consume a password reset token (sent via email from /auth/esqueci-senha) and set a new password for the associated account.",
+    request: {
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: resetPasswordSchema,
+            example: {
+              token: "a1b2c3d4e5f6789012345678901234567890abcd",
+              novaSenha: "novaSenhaSegura123",
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Password reset successfully. The user can now log in with the new password.",
+        content: {
+          "application/json": {
+            schema: messageResponseSchema,
+            example: { message: "Senha redefinida com sucesso." },
+          },
+        },
+      },
+      ...errorResponses([400, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/auth/reenviar-verificacao",
+    tags: ["Auth"],
+    summary: "Resend verification email (authenticated)",
+    description:
+      "Request a new verification email for the currently authenticated user. Use this when the original verification email was lost or expired. The user must be authenticated — for an unauthenticated flow, use POST /auth/solicitar-reenvio-verificacao instead.",
+    security: [{ bearerAuth: [] }],
+    responses: {
+      200: {
+        description: "Verification email resent.",
+        content: {
+          "application/json": {
+            schema: messageResponseSchema,
+            example: { message: "Email de verificação reenviado." },
+          },
+        },
+      },
+      ...errorResponses([400, 401, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/auth/solicitar-reenvio-verificacao",
+    tags: ["Auth"],
+    summary: "Request verification email resend by email address",
+    description:
+      "Unauthenticated version of the resend flow: provide an email address and, if it corresponds to a registered but unverified account, a new verification email will be sent. **Returns 200 regardless of whether the email is registered** to prevent user enumeration attacks.",
+    request: {
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: resendVerificationRequestSchema,
+            example: { email: "joao.silva@academico.ufpb.br" },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description:
+          "Request accepted. A verification email is sent only if the address is registered and unverified.",
+        content: {
+          "application/json": {
+            schema: messageResponseSchema,
+            example: {
+              message:
+                "Se o email estiver cadastrado e não verificado, você receberá um novo email de verificação.",
+            },
+          },
+        },
+      },
+    },
+  });
+}

--- a/src/lib/server/openapi/paths/auth.ts
+++ b/src/lib/server/openapi/paths/auth.ts
@@ -8,7 +8,7 @@ import { forgotPasswordSchema } from "@/app/api/auth/esqueci-senha/route";
 import { resetPasswordSchema } from "@/app/api/auth/resetar-senha/route";
 import { resendVerificationRequestSchema } from "@/app/api/auth/solicitar-reenvio-verificacao/route";
 
-import { errorResponses, ApiErrorBodySchema } from "../common-schemas";
+import type { CommonSchemas } from "../common-schemas";
 
 /**
  * Shared JWT example used across token responses. Truncated to keep the
@@ -106,8 +106,14 @@ const currentUserResponseSchema = z
 /**
  * Register all authentication-related paths on the OpenAPI registry.
  * Called from registerAllPaths() in paths/index.ts during document generation.
+ *
+ * The `schemas` argument holds the shared component schemas and helpers
+ * registered by `registerCommonSchemas` on the same registry — we destructure
+ * it here so the rest of the file can use `errorResponses` and
+ * `ApiErrorBodySchema` with the familiar names.
  */
-export function registerAuthPaths(registry: OpenAPIRegistry): void {
+export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSchemas): void {
+  const { errorResponses, ApiErrorBodySchema } = schemas;
   registry.registerPath({
     method: "post",
     path: "/auth/login",

--- a/src/lib/server/openapi/paths/auth.ts
+++ b/src/lib/server/openapi/paths/auth.ts
@@ -77,7 +77,7 @@ const currentUserResponseSchema = z
     id: z.string().uuid().openapi({ example: "550e8400-e29b-41d4-a716-446655440000" }),
     nome: z.string().openapi({ example: "João Silva" }),
     email: z.string().email().openapi({ example: "joao.silva@academico.ufpb.br" }),
-    slug: z.string().openapi({ example: "joao-silva" }),
+    slug: z.string().nullable().openapi({ example: "joao-silva" }),
     papelPlataforma: z.enum(["USER", "MASTER_ADMIN"]).openapi({
       description: "Papel global na plataforma: usuário comum ou administrador master.",
       example: "USER",
@@ -170,7 +170,9 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
           },
         },
       },
-      ...errorResponses([400]),
+      ...errorResponses([400, 401], {
+        401: { message: "Email ou senha incorretos", code: "INVALID_CREDENTIALS" },
+      }),
     },
   });
 

--- a/src/lib/server/openapi/paths/auth.ts
+++ b/src/lib/server/openapi/paths/auth.ts
@@ -214,7 +214,9 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
           },
         },
       },
-      ...errorResponses([400]),
+      ...errorResponses([400, 409], {
+        409: { message: "Este e-mail já está em uso.", code: "EMAIL_ALREADY_EXISTS" },
+      }),
     },
   });
 

--- a/src/lib/server/openapi/paths/auth.ts
+++ b/src/lib/server/openapi/paths/auth.ts
@@ -163,6 +163,10 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
         content: {
           "application/json": {
             schema: ApiErrorBodySchema,
+            example: {
+              message: "Muitas tentativas de login. Tente novamente em alguns segundos.",
+              code: "RATE_LIMITED",
+            },
           },
         },
       },
@@ -208,7 +212,9 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
           },
         },
       },
-      ...errorResponses([400, 409]),
+      ...errorResponses([400, 409], {
+        409: { message: "Este email já está cadastrado", code: "EMAIL_ALREADY_EXISTS" },
+      }),
     },
   });
 

--- a/src/lib/server/openapi/paths/auth.ts
+++ b/src/lib/server/openapi/paths/auth.ts
@@ -13,40 +13,42 @@ import {
 import type { CommonSchemas } from "../common-schemas";
 
 /**
- * Shared JWT example used across token responses. Truncated to keep the
- * rendered examples readable — the real token is a long opaque string.
+ * Exemplo de JWT compartilhado entre as respostas de token. Truncado para
+ * manter os exemplos renderizados legíveis — o token real é uma string opaca
+ * bem mais longa.
  */
 const EXAMPLE_JWT =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI1NTBlODQwMC1lMjliLTQxZDQtYTcxNi00NDY2NTU0NDAwMDAifQ.signature";
 
 /**
- * Schema for the `{ token }` response returned by login and refresh endpoints.
+ * Schema da resposta `{ token }` retornada pelos endpoints de login e refresh.
  */
 const tokenResponseSchema = z
   .object({
     token: z.string().openapi({
-      description: "JWT bearer token. Use it in the Authorization header as 'Bearer <token>'.",
+      description: "Token JWT. Enviar no header `Authorization: Bearer <token>`.",
       example: EXAMPLE_JWT,
     }),
   })
   .openapi("TokenResponse");
 
 /**
- * Generic `{ message }` response used by several auth flows that do not
- * return structured data (verification, password reset, etc).
+ * Resposta genérica `{ message }` usada por vários fluxos de autenticação que
+ * não retornam dados estruturados (verificação, reset de senha, etc).
  */
 const messageResponseSchema = z
   .object({
     message: z.string().openapi({
-      description: "Human-readable status message, localized in Portuguese.",
+      description: "Mensagem de status legível, em português.",
       example: "Operação realizada com sucesso.",
     }),
   })
   .openapi("MessageResponse");
 
 /**
- * Response shape for POST /auth/register — includes the new user id and whether
- * email verification was skipped (happens automatically in dev/test environments).
+ * Shape da resposta de POST /auth/register — inclui o ID do novo usuário e se
+ * a verificação de email foi pulada (acontece automaticamente em
+ * desenvolvimento/teste).
  */
 const registerResponseSchema = z
   .object({
@@ -54,20 +56,21 @@ const registerResponseSchema = z
       example: "Cadastro realizado! Verifique seu email para ativar sua conta.",
     }),
     usuarioId: z.string().uuid().openapi({
-      description: "UUID of the newly created user.",
+      description: "UUID do usuário recém-criado.",
       example: "550e8400-e29b-41d4-a716-446655440000",
     }),
     verificado: z.boolean().openapi({
-      description: "Whether the user was auto-verified (true) or needs email verification (false).",
+      description:
+        "Indica se o usuário foi auto-verificado (true) ou se precisa verificar o email (false).",
       example: false,
     }),
   })
   .openapi("RegisterResponse");
 
 /**
- * Response shape for GET /auth/me — the authenticated user's profile with
- * sensitive fields (password hash, etc) stripped out. Matches the object
- * returned by src/app/api/auth/me/route.ts.
+ * Shape da resposta de GET /auth/me — o perfil do usuário autenticado, com os
+ * campos sensíveis (hash de senha, etc) removidos. Espelha o objeto retornado
+ * por src/app/api/auth/me/route.ts.
  */
 const currentUserResponseSchema = z
   .object({
@@ -76,7 +79,7 @@ const currentUserResponseSchema = z
     email: z.string().email().openapi({ example: "joao.silva@academico.ufpb.br" }),
     slug: z.string().openapi({ example: "joao-silva" }),
     papelPlataforma: z.enum(["USER", "MASTER_ADMIN"]).openapi({
-      description: "Platform-wide role: regular user or master admin.",
+      description: "Papel global na plataforma: usuário comum ou administrador master.",
       example: "USER",
     }),
     eVerificado: z.boolean().openapi({ example: true }),
@@ -91,38 +94,39 @@ const currentUserResponseSchema = z
         nome: z.string().openapi({ example: "Centro de Informática" }),
         sigla: z.string().openapi({ example: "CI" }),
       })
-      .openapi({ description: "User's academic center." }),
+      .openapi({ description: "Centro acadêmico do usuário." }),
     curso: z
       .object({
         id: z.string().uuid(),
         nome: z.string().openapi({ example: "Ciência da Computação" }),
       })
-      .openapi({ description: "User's course/major." }),
+      .openapi({ description: "Curso do usuário." }),
     permissoes: z.array(z.string()).openapi({
-      description: "List of permission strings derived from the user's roles and memberships.",
+      description: "Lista de strings de permissão derivadas dos papéis e vínculos do usuário.",
       example: ["entidade:admin:a1b2c3d4-e5f6-7890-abcd-ef1234567890"],
     }),
   })
   .openapi("CurrentUserResponse");
 
 /**
- * Register all authentication-related paths on the OpenAPI registry.
- * Called from registerAllPaths() in paths/index.ts during document generation.
+ * Registra todos os paths de autenticação no registry OpenAPI.
+ * Chamado por registerAllPaths() em paths/index.ts durante a geração do
+ * documento.
  *
- * The `schemas` argument holds the shared component schemas and helpers
- * registered by `registerCommonSchemas` on the same registry — we destructure
- * it here so the rest of the file can use `errorResponses` and
- * `ApiErrorBodySchema` with the familiar names.
+ * O argumento `schemas` carrega os schemas de componentes compartilhados e os
+ * helpers registrados por `registerCommonSchemas` no mesmo registry — fazemos
+ * destructuring para que o resto do arquivo possa usar `errorResponses` e
+ * `ApiErrorBodySchema` com os nomes familiares.
  */
 export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSchemas): void {
   const { errorResponses, ApiErrorBodySchema } = schemas;
   registry.registerPath({
     method: "post",
     path: "/auth/login",
-    tags: ["Auth"],
-    summary: "Log in with email and password",
+    tags: ["Autenticação"],
+    summary: "Login com email e senha",
     description:
-      "Authenticate with email and password. Returns a JWT bearer token valid for 7 days. Rate limited to 5 attempts/min per IP. Invalid credentials always return a generic 401 to prevent user enumeration.",
+      "Autentica com email e senha. Retorna um token JWT válido por 7 dias. Limitado a 5 tentativas/min por IP. Credenciais inválidas sempre retornam um 401 genérico para evitar enumeração de usuários.",
     request: {
       body: {
         required: true,
@@ -139,7 +143,7 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
     },
     responses: {
       200: {
-        description: "Login successful.",
+        description: "Login realizado com sucesso.",
         content: {
           "application/json": {
             schema: tokenResponseSchema,
@@ -148,10 +152,11 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
         },
       },
       429: {
-        description: "Rate limited — wait `Retry-After` seconds before retrying.",
+        description:
+          "Limite de requisições excedido — aguarde os segundos indicados em `Retry-After` antes de tentar novamente.",
         headers: {
           "Retry-After": {
-            description: "Seconds until the rate limit window resets.",
+            description: "Segundos até a janela de rate limit reabrir.",
             schema: { type: "integer", example: 42 },
           },
         },
@@ -168,10 +173,10 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
   registry.registerPath({
     method: "post",
     path: "/auth/register",
-    tags: ["Auth"],
-    summary: "Register a new user account",
+    tags: ["Autenticação"],
+    summary: "Cadastrar uma nova conta",
     description:
-      "Create a new user account. Only UFPB email domains (`*.ufpb.br`) are accepted. In prod a verification email is sent; in dev (no email provider) users are auto-verified.",
+      "Cria uma nova conta de usuário. Apenas domínios de email da UFPB (`*.ufpb.br`) são aceitos. Em produção, um email de verificação é enviado; em desenvolvimento (sem provider de email), usuários são auto-verificados.",
     request: {
       body: {
         required: true,
@@ -191,7 +196,7 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
     },
     responses: {
       200: {
-        description: "User created successfully.",
+        description: "Usuário criado com sucesso.",
         content: {
           "application/json": {
             schema: registerResponseSchema,
@@ -210,13 +215,13 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
   registry.registerPath({
     method: "get",
     path: "/auth/me",
-    tags: ["Auth"],
-    summary: "Get the currently authenticated user",
-    description: "Return the authenticated user's profile. Sensitive fields are never included.",
+    tags: ["Autenticação"],
+    summary: "Obter o usuário autenticado",
+    description: "Retorna o perfil do usuário autenticado. Campos sensíveis nunca são incluídos.",
     security: [{ bearerAuth: [] }],
     responses: {
       200: {
-        description: "The authenticated user's profile.",
+        description: "Perfil do usuário autenticado.",
         content: {
           "application/json": {
             schema: currentUserResponseSchema,
@@ -248,13 +253,13 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
   registry.registerPath({
     method: "post",
     path: "/auth/refresh",
-    tags: ["Auth"],
-    summary: "Refresh the current JWT token",
-    description: "Issue a fresh JWT for the authenticated user.",
+    tags: ["Autenticação"],
+    summary: "Renovar o token JWT atual",
+    description: "Emite um novo token JWT para o usuário autenticado.",
     security: [{ bearerAuth: [] }],
     responses: {
       200: {
-        description: "A new valid JWT token.",
+        description: "Novo token JWT válido.",
         content: {
           "application/json": {
             schema: tokenResponseSchema,
@@ -268,9 +273,10 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
   registry.registerPath({
     method: "post",
     path: "/auth/verificar-email",
-    tags: ["Auth"],
-    summary: "Verify an email address using a token",
-    description: "Consume a verification token sent by email and mark the user as verified.",
+    tags: ["Autenticação"],
+    summary: "Verificar email usando token",
+    description:
+      "Consome um token de verificação enviado por email e marca o usuário como verificado.",
     request: {
       body: {
         required: true,
@@ -284,7 +290,7 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
     },
     responses: {
       200: {
-        description: "Email verified successfully.",
+        description: "Email verificado com sucesso.",
         content: {
           "application/json": {
             schema: messageResponseSchema,
@@ -299,10 +305,10 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
   registry.registerPath({
     method: "post",
     path: "/auth/esqueci-senha",
-    tags: ["Auth"],
-    summary: "Request a password reset email",
+    tags: ["Autenticação"],
+    summary: "Solicitar email de redefinição de senha",
     description:
-      "Always returns 200, whether the email is registered or not, to prevent user enumeration.",
+      "Sempre retorna 200, independentemente do email estar cadastrado ou não, para evitar enumeração de usuários.",
     request: {
       body: {
         required: true,
@@ -316,7 +322,7 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
     },
     responses: {
       200: {
-        description: "Request accepted.",
+        description: "Solicitação aceita.",
         content: {
           "application/json": {
             schema: messageResponseSchema,
@@ -333,9 +339,9 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
   registry.registerPath({
     method: "post",
     path: "/auth/resetar-senha",
-    tags: ["Auth"],
-    summary: "Reset password using a reset token",
-    description: "Consume a reset token (sent via email) and set a new password.",
+    tags: ["Autenticação"],
+    summary: "Redefinir senha usando token",
+    description: "Consome um token de reset (enviado por email) e define uma nova senha.",
     request: {
       body: {
         required: true,
@@ -352,7 +358,8 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
     },
     responses: {
       200: {
-        description: "Password reset successfully. The user can now log in with the new password.",
+        description:
+          "Senha redefinida com sucesso. O usuário já pode fazer login com a nova senha.",
         content: {
           "application/json": {
             schema: messageResponseSchema,
@@ -367,14 +374,14 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
   registry.registerPath({
     method: "post",
     path: "/auth/reenviar-verificacao",
-    tags: ["Auth"],
-    summary: "Resend verification email (authenticated)",
+    tags: ["Autenticação"],
+    summary: "Reenviar email de verificação (autenticado)",
     description:
-      "Resend the verification email for the authenticated user. For the unauthenticated flow, see `/auth/solicitar-reenvio-verificacao`.",
+      "Reenvia o email de verificação para o usuário autenticado. Para o fluxo sem autenticação, veja `/auth/solicitar-reenvio-verificacao`.",
     security: [{ bearerAuth: [] }],
     responses: {
       200: {
-        description: "Verification email resent.",
+        description: "Email de verificação reenviado.",
         content: {
           "application/json": {
             schema: messageResponseSchema,
@@ -389,10 +396,10 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
   registry.registerPath({
     method: "post",
     path: "/auth/solicitar-reenvio-verificacao",
-    tags: ["Auth"],
-    summary: "Request verification email resend by email address",
+    tags: ["Autenticação"],
+    summary: "Solicitar reenvio de verificação pelo email",
     description:
-      "Unauthenticated resend flow. Always returns 200 regardless of whether the email exists (prevents user enumeration).",
+      "Fluxo de reenvio sem autenticação. Sempre retorna 200, independentemente do email existir (previne enumeração de usuários).",
     request: {
       body: {
         required: true,
@@ -407,7 +414,7 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
     responses: {
       200: {
         description:
-          "Request accepted. A verification email is sent only if the address is registered and unverified.",
+          "Solicitação aceita. Um email de verificação só é enviado se o endereço estiver cadastrado e ainda não verificado.",
         content: {
           "application/json": {
             schema: messageResponseSchema,

--- a/src/lib/server/openapi/paths/auth.ts
+++ b/src/lib/server/openapi/paths/auth.ts
@@ -1,12 +1,14 @@
 import { z } from "zod";
 import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 
-import { loginSchema } from "@/app/api/auth/login/route";
-import { registerSchema } from "@/app/api/auth/register/route";
-import { verifySchema } from "@/app/api/auth/verificar-email/route";
-import { forgotPasswordSchema } from "@/app/api/auth/esqueci-senha/route";
-import { resetPasswordSchema } from "@/app/api/auth/resetar-senha/route";
-import { resendVerificationRequestSchema } from "@/app/api/auth/solicitar-reenvio-verificacao/route";
+import {
+  loginSchema,
+  registerSchema,
+  verifySchema,
+  forgotPasswordSchema,
+  resetPasswordSchema,
+  resendVerificationRequestSchema,
+} from "@/lib/server/api-schemas/auth";
 
 import type { CommonSchemas } from "../common-schemas";
 

--- a/src/lib/server/openapi/paths/auth.ts
+++ b/src/lib/server/openapi/paths/auth.ts
@@ -212,9 +212,7 @@ export function registerAuthPaths(registry: OpenAPIRegistry, schemas: CommonSche
           },
         },
       },
-      ...errorResponses([400, 409], {
-        409: { message: "Este email já está cadastrado", code: "EMAIL_ALREADY_EXISTS" },
-      }),
+      ...errorResponses([400]),
     },
   });
 

--- a/src/lib/server/openapi/paths/calendario.ts
+++ b/src/lib/server/openapi/paths/calendario.ts
@@ -115,7 +115,9 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
         description: "Semestre criado.",
         content: { "application/json": { schema: semestreResponseSchema } },
       },
-      ...errorResponses([400, 409]),
+      ...errorResponses([400, 409], {
+        409: { message: "Já existe um semestre com este nome", code: "SEMESTRE_NOME_EXISTS" },
+      }),
     },
   });
 
@@ -134,7 +136,9 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
         description: "Detalhes do semestre.",
         content: { "application/json": { schema: semestreResponseSchema } },
       },
-      ...errorResponses([404]),
+      ...errorResponses([404], {
+        404: { message: "Semestre não encontrado", code: "SEMESTRE_NOT_FOUND" },
+      }),
     },
   });
 
@@ -163,7 +167,10 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
         description: "Semestre atualizado.",
         content: { "application/json": { schema: semestreResponseSchema } },
       },
-      ...errorResponses([400, 404, 409]),
+      ...errorResponses([400, 404, 409], {
+        404: { message: "Semestre não encontrado", code: "SEMESTRE_NOT_FOUND" },
+        409: { message: "Já existe um semestre com este nome", code: "SEMESTRE_NOME_EXISTS" },
+      }),
     },
   });
 
@@ -188,7 +195,9 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
           },
         },
       },
-      ...errorResponses([404]),
+      ...errorResponses([404], {
+        404: { message: "Semestre não encontrado", code: "SEMESTRE_NOT_FOUND" },
+      }),
     },
   });
 
@@ -207,7 +216,9 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
         description: "Lista de eventos do semestre.",
         content: { "application/json": { schema: z.array(eventoResponseSchema) } },
       },
-      ...errorResponses([404]),
+      ...errorResponses([404], {
+        404: { message: "Semestre não encontrado", code: "SEMESTRE_NOT_FOUND" },
+      }),
     },
   });
 
@@ -241,7 +252,9 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
         description: "Evento criado.",
         content: { "application/json": { schema: eventoResponseSchema } },
       },
-      ...errorResponses([400, 404]),
+      ...errorResponses([400, 404], {
+        404: { message: "Semestre não encontrado", code: "SEMESTRE_NOT_FOUND" },
+      }),
     },
   });
 
@@ -276,7 +289,9 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
         description: "Evento atualizado.",
         content: { "application/json": { schema: eventoResponseSchema } },
       },
-      ...errorResponses([400, 404]),
+      ...errorResponses([400, 404], {
+        404: { message: "Evento não encontrado", code: "EVENTO_NOT_FOUND" },
+      }),
     },
   });
 
@@ -303,7 +318,9 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
           },
         },
       },
-      ...errorResponses([404]),
+      ...errorResponses([404], {
+        404: { message: "Evento não encontrado", code: "EVENTO_NOT_FOUND" },
+      }),
     },
   });
 
@@ -352,7 +369,9 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
           },
         },
       },
-      ...errorResponses([400, 404]),
+      ...errorResponses([400, 404], {
+        404: { message: "Semestre não encontrado", code: "SEMESTRE_NOT_FOUND" },
+      }),
     },
   });
 }

--- a/src/lib/server/openapi/paths/calendario.ts
+++ b/src/lib/server/openapi/paths/calendario.ts
@@ -1,11 +1,13 @@
 import { z } from "zod";
 import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 
-import { createSemestreSchema } from "@/app/api/calendario-academico/route";
-import { updateSemestreSchema } from "@/app/api/calendario-academico/[id]/route";
-import { createEventoSchema } from "@/app/api/calendario-academico/[id]/eventos/route";
-import { updateEventoSchema } from "@/app/api/calendario-academico/[id]/eventos/[eventoId]/route";
-import { batchCreateSchema } from "@/app/api/calendario-academico/[id]/eventos/batch/route";
+import {
+  createSemestreSchema,
+  updateSemestreSchema,
+  createEventoSchema,
+  updateEventoSchema,
+  batchCreateSchema,
+} from "@/lib/server/api-schemas/calendario";
 import { ALL_CATEGORIAS } from "@/lib/shared/config/calendario-academico";
 
 import type { CommonSchemas } from "../common-schemas";

--- a/src/lib/server/openapi/paths/calendario.ts
+++ b/src/lib/server/openapi/paths/calendario.ts
@@ -58,6 +58,7 @@ const eventoResponseSchema = z
 
 const messageResponseSchema = z.object({ message: z.string() });
 
+/** Registra os paths de calendário acadêmico no registry OpenAPI. */
 export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: CommonSchemas): void {
   const { errorResponses } = schemas;
   registry.registerPath({

--- a/src/lib/server/openapi/paths/calendario.ts
+++ b/src/lib/server/openapi/paths/calendario.ts
@@ -1,0 +1,358 @@
+import { z } from "zod";
+import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
+
+import { createSemestreSchema } from "@/app/api/calendario-academico/route";
+import { updateSemestreSchema } from "@/app/api/calendario-academico/[id]/route";
+import { createEventoSchema } from "@/app/api/calendario-academico/[id]/eventos/route";
+import { updateEventoSchema } from "@/app/api/calendario-academico/[id]/eventos/[eventoId]/route";
+import { batchCreateSchema } from "@/app/api/calendario-academico/[id]/eventos/batch/route";
+import { ALL_CATEGORIAS } from "@/lib/shared/config/calendario-academico";
+
+import { errorResponses } from "../common-schemas";
+
+/**
+ * Enum of event categories. Mirrors ALL_CATEGORIAS in
+ * src/lib/shared/config/calendario-academico.ts — kept in sync via the import.
+ */
+const categoriaEventoSchema = z.enum(ALL_CATEGORIAS).openapi({
+  description:
+    "Category of the event. Used for display grouping and color coding in the calendar UI. 'OUTRA' is a catch-all for uncategorized events.",
+  example: "INICIO_PERIODO_LETIVO",
+});
+
+/**
+ * SemestreLetivo (academic semester) response shape.
+ */
+const semestreResponseSchema = z
+  .object({
+    id: z.string().uuid(),
+    nome: z.string().openapi({
+      description: "Semester name, typically in the 'YYYY.N' format.",
+      example: "2026.1",
+    }),
+    dataInicio: z.string().datetime().openapi({ example: "2026-03-10T00:00:00.000Z" }),
+    dataFim: z.string().datetime().openapi({ example: "2026-07-15T00:00:00.000Z" }),
+    ativo: z.boolean().optional().openapi({
+      description:
+        "Whether this is the currently active semester. Exactly one semester should be active at a time.",
+      example: true,
+    }),
+  })
+  .openapi("SemestreResponse");
+
+/**
+ * Evento (calendar event) response shape.
+ */
+const eventoResponseSchema = z
+  .object({
+    id: z.string().uuid(),
+    descricao: z.string().openapi({ example: "Início do período letivo 2026.1" }),
+    dataInicio: z.string().datetime().openapi({ example: "2026-03-10T00:00:00.000Z" }),
+    dataFim: z.string().datetime().openapi({ example: "2026-03-10T00:00:00.000Z" }),
+    categoria: categoriaEventoSchema,
+    semestreId: z.string().uuid(),
+  })
+  .openapi("EventoResponse");
+
+const messageResponseSchema = z.object({ message: z.string() });
+
+export function registerCalendarioPaths(registry: OpenAPIRegistry): void {
+  registry.registerPath({
+    method: "get",
+    path: "/calendario-academico",
+    tags: ["Academic Calendar"],
+    summary: "List semesters (or get the active one)",
+    description:
+      "Public endpoint for reading semesters from the academic calendar.\n\n**Response shape depends on the `ativo` query parameter:**\n- Without `?ativo=true`: returns an array of all semesters.\n- With `?ativo=true`: returns the currently active semester as a single object, or `null` if no semester is currently active.\n\nConsumers must inspect the response type and handle both cases.",
+    request: {
+      query: z.object({
+        ativo: z.enum(["true", "false"]).optional().openapi({
+          description:
+            "Set to 'true' to receive only the active semester as a single object (or null) instead of the full list.",
+          example: "true",
+        }),
+      }),
+    },
+    responses: {
+      200: {
+        description:
+          "Either an array of semesters (default) or a single semester object/null (when `?ativo=true`).",
+        content: {
+          "application/json": {
+            schema: z.union([z.array(semestreResponseSchema), semestreResponseSchema.nullable()]),
+          },
+        },
+      },
+      ...errorResponses([500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/calendario-academico",
+    tags: ["Academic Calendar"],
+    summary: "Create a new semester (admin only)",
+    description:
+      "Admin-only endpoint to create a new academic semester. Returns 409 with `SEMESTRE_NOME_EXISTS` if a semester with the same name already exists.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: createSemestreSchema,
+            example: {
+              nome: "2026.1",
+              dataInicio: "2026-03-10T00:00:00.000Z",
+              dataFim: "2026-07-15T00:00:00.000Z",
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      201: {
+        description: "Semester created.",
+        content: { "application/json": { schema: semestreResponseSchema } },
+      },
+      ...errorResponses([400, 401, 403, 409, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/calendario-academico/{id}",
+    tags: ["Academic Calendar"],
+    summary: "Get a semester by id",
+    description:
+      "Public endpoint returning the details of a specific semester. Returns 404 with `SEMESTRE_NOT_FOUND` if the id does not match any semester.",
+    request: {
+      params: z.object({ id: z.string().uuid() }),
+    },
+    responses: {
+      200: {
+        description: "Semester details.",
+        content: { "application/json": { schema: semestreResponseSchema } },
+      },
+      ...errorResponses([404, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "put",
+    path: "/calendario-academico/{id}",
+    tags: ["Academic Calendar"],
+    summary: "Update a semester (admin only)",
+    description:
+      "Admin-only endpoint to update a semester's name or dates. All fields are optional — only provided fields are updated.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      params: z.object({ id: z.string().uuid() }),
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: updateSemestreSchema,
+            example: { dataFim: "2026-07-22T00:00:00.000Z" },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Semester updated.",
+        content: { "application/json": { schema: semestreResponseSchema } },
+      },
+      ...errorResponses([400, 401, 403, 404, 409, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "delete",
+    path: "/calendario-academico/{id}",
+    tags: ["Academic Calendar"],
+    summary: "Delete a semester (admin only)",
+    description:
+      "Admin-only endpoint to delete a semester. Related events are also removed as part of the deletion.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      params: z.object({ id: z.string().uuid() }),
+    },
+    responses: {
+      200: {
+        description: "Semester deleted.",
+        content: {
+          "application/json": {
+            schema: messageResponseSchema,
+            example: { message: "Semestre removido com sucesso" },
+          },
+        },
+      },
+      ...errorResponses([401, 403, 404, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/calendario-academico/{id}/eventos",
+    tags: ["Academic Calendar"],
+    summary: "List events for a semester",
+    description:
+      "Public endpoint returning all events (holidays, registration deadlines, exam periods, etc) scheduled for the specified semester.",
+    request: {
+      params: z.object({ id: z.string().uuid() }),
+    },
+    responses: {
+      200: {
+        description: "List of events for the semester.",
+        content: { "application/json": { schema: z.array(eventoResponseSchema) } },
+      },
+      ...errorResponses([404, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/calendario-academico/{id}/eventos",
+    tags: ["Academic Calendar"],
+    summary: "Create a new event in a semester (admin only)",
+    description:
+      "Admin-only endpoint to add a new event to the specified semester. Events are categorized via the `categoria` field (holidays, exam periods, etc) for UI display grouping.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      params: z.object({ id: z.string().uuid() }),
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: createEventoSchema,
+            example: {
+              descricao: "Início do período letivo 2026.1",
+              dataInicio: "2026-03-10T00:00:00.000Z",
+              dataFim: "2026-03-10T00:00:00.000Z",
+              categoria: "INICIO_PERIODO_LETIVO",
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      201: {
+        description: "Event created.",
+        content: { "application/json": { schema: eventoResponseSchema } },
+      },
+      ...errorResponses([400, 401, 403, 404, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "put",
+    path: "/calendario-academico/{id}/eventos/{eventoId}",
+    tags: ["Academic Calendar"],
+    summary: "Update an event (admin only)",
+    description:
+      "Admin-only endpoint to update an event's description, dates, or category. All fields are optional. Returns 404 with `EVENTO_NOT_FOUND` if the event does not exist.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      params: z.object({
+        id: z.string().uuid(),
+        eventoId: z.string().uuid(),
+      }),
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: updateEventoSchema,
+            example: {
+              descricao: "Início do período letivo 2026.1 (reagendado)",
+              dataInicio: "2026-03-17T00:00:00.000Z",
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Event updated.",
+        content: { "application/json": { schema: eventoResponseSchema } },
+      },
+      ...errorResponses([400, 401, 403, 404, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "delete",
+    path: "/calendario-academico/{id}/eventos/{eventoId}",
+    tags: ["Academic Calendar"],
+    summary: "Delete an event (admin only)",
+    description: "Admin-only endpoint to delete an event from the semester.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      params: z.object({
+        id: z.string().uuid(),
+        eventoId: z.string().uuid(),
+      }),
+    },
+    responses: {
+      200: {
+        description: "Event deleted.",
+        content: {
+          "application/json": {
+            schema: messageResponseSchema,
+            example: { message: "Evento removido com sucesso" },
+          },
+        },
+      },
+      ...errorResponses([401, 403, 404, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/calendario-academico/{id}/eventos/batch",
+    tags: ["Academic Calendar"],
+    summary: "Batch create (or replace) events in a semester (admin only)",
+    description:
+      "Admin-only endpoint to create multiple events in a single request — used by the CSV import flow. When `replace: true`, ALL existing events for the semester are deleted before inserting the new batch (use with caution). When `replace: false` (default), new events are appended.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      params: z.object({ id: z.string().uuid() }),
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: batchCreateSchema,
+            example: {
+              replace: false,
+              eventos: [
+                {
+                  descricao: "Feriado municipal de São João",
+                  dataInicio: "2026-06-24T00:00:00.000Z",
+                  dataFim: "2026-06-24T00:00:00.000Z",
+                  categoria: "FERIADO",
+                },
+                {
+                  descricao: "Início das provas finais",
+                  dataInicio: "2026-07-01T00:00:00.000Z",
+                  dataFim: "2026-07-05T00:00:00.000Z",
+                  categoria: "EXAMES_FINAIS",
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      201: {
+        description: "Events created. Response includes the total number of events inserted.",
+        content: {
+          "application/json": {
+            schema: z.object({ count: z.number().int().openapi({ example: 2 }) }),
+          },
+        },
+      },
+      ...errorResponses([400, 401, 403, 404, 500]),
+    },
+  });
+}

--- a/src/lib/server/openapi/paths/calendario.ts
+++ b/src/lib/server/openapi/paths/calendario.ts
@@ -66,27 +66,24 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
     tags: ["Academic Calendar"],
     summary: "List semesters (or get the active one)",
     description:
-      "Public endpoint for reading semesters from the academic calendar.\n\n**Response shape depends on the `ativo` query parameter:**\n- Without `?ativo=true`: returns an array of all semesters.\n- With `?ativo=true`: returns the currently active semester as a single object, or `null` if no semester is currently active.\n\nConsumers must inspect the response type and handle both cases.",
+      "List semesters. Pass `?ativo=true` to get only the currently active semester (as a single object or `null`).",
     request: {
       query: z.object({
         ativo: z.enum(["true", "false"]).optional().openapi({
-          description:
-            "Set to 'true' to receive only the active semester as a single object (or null) instead of the full list.",
+          description: "If `true`, return only the active semester.",
           example: "true",
         }),
       }),
     },
     responses: {
       200: {
-        description:
-          "Either an array of semesters (default) or a single semester object/null (when `?ativo=true`).",
+        description: "Array of semesters, or a single semester when `?ativo=true`.",
         content: {
           "application/json": {
             schema: z.union([z.array(semestreResponseSchema), semestreResponseSchema.nullable()]),
           },
         },
       },
-      ...errorResponses([500]),
     },
   });
 
@@ -96,7 +93,7 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
     tags: ["Academic Calendar"],
     summary: "Create a new semester (admin only)",
     description:
-      "Admin-only endpoint to create a new academic semester. Returns 409 with `SEMESTRE_NOME_EXISTS` if a semester with the same name already exists.",
+      "Create a new semester. Returns 409 with `SEMESTRE_NOME_EXISTS` if the name already exists.",
     security: [{ bearerAuth: [] }],
     request: {
       body: {
@@ -118,7 +115,7 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
         description: "Semester created.",
         content: { "application/json": { schema: semestreResponseSchema } },
       },
-      ...errorResponses([400, 401, 403, 409, 500]),
+      ...errorResponses([400, 409]),
     },
   });
 
@@ -137,7 +134,7 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
         description: "Semester details.",
         content: { "application/json": { schema: semestreResponseSchema } },
       },
-      ...errorResponses([404, 500]),
+      ...errorResponses([404]),
     },
   });
 
@@ -166,7 +163,7 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
         description: "Semester updated.",
         content: { "application/json": { schema: semestreResponseSchema } },
       },
-      ...errorResponses([400, 401, 403, 404, 409, 500]),
+      ...errorResponses([400, 404, 409]),
     },
   });
 
@@ -191,7 +188,7 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
           },
         },
       },
-      ...errorResponses([401, 403, 404, 500]),
+      ...errorResponses([404]),
     },
   });
 
@@ -210,7 +207,7 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
         description: "List of events for the semester.",
         content: { "application/json": { schema: z.array(eventoResponseSchema) } },
       },
-      ...errorResponses([404, 500]),
+      ...errorResponses([404]),
     },
   });
 
@@ -244,7 +241,7 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
         description: "Event created.",
         content: { "application/json": { schema: eventoResponseSchema } },
       },
-      ...errorResponses([400, 401, 403, 404, 500]),
+      ...errorResponses([400, 404]),
     },
   });
 
@@ -279,7 +276,7 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
         description: "Event updated.",
         content: { "application/json": { schema: eventoResponseSchema } },
       },
-      ...errorResponses([400, 401, 403, 404, 500]),
+      ...errorResponses([400, 404]),
     },
   });
 
@@ -306,7 +303,7 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
           },
         },
       },
-      ...errorResponses([401, 403, 404, 500]),
+      ...errorResponses([404]),
     },
   });
 
@@ -355,7 +352,7 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
           },
         },
       },
-      ...errorResponses([400, 401, 403, 404, 500]),
+      ...errorResponses([400, 404]),
     },
   });
 }

--- a/src/lib/server/openapi/paths/calendario.ts
+++ b/src/lib/server/openapi/paths/calendario.ts
@@ -13,37 +13,37 @@ import { ALL_CATEGORIAS } from "@/lib/shared/config/calendario-academico";
 import type { CommonSchemas } from "../common-schemas";
 
 /**
- * Enum of event categories. Mirrors ALL_CATEGORIAS in
- * src/lib/shared/config/calendario-academico.ts — kept in sync via the import.
+ * Enum das categorias de evento. Espelha ALL_CATEGORIAS em
+ * src/lib/shared/config/calendario-academico.ts — mantido em sincronia via import.
  */
 const categoriaEventoSchema = z.enum(ALL_CATEGORIAS).openapi({
   description:
-    "Category of the event. Used for display grouping and color coding in the calendar UI. 'OUTRA' is a catch-all for uncategorized events.",
+    "Categoria do evento. Usada para agrupamento e cores no calendário. 'OUTRA' é o catch-all para eventos sem categoria definida.",
   example: "INICIO_PERIODO_LETIVO",
 });
 
 /**
- * SemestreLetivo (academic semester) response shape.
+ * Shape de resposta de SemestreLetivo (semestre acadêmico).
  */
 const semestreResponseSchema = z
   .object({
     id: z.string().uuid(),
     nome: z.string().openapi({
-      description: "Semester name, typically in the 'YYYY.N' format.",
+      description: "Nome do semestre, tipicamente no formato 'YYYY.N'.",
       example: "2026.1",
     }),
     dataInicio: z.string().datetime().openapi({ example: "2026-03-10T00:00:00.000Z" }),
     dataFim: z.string().datetime().openapi({ example: "2026-07-15T00:00:00.000Z" }),
     ativo: z.boolean().optional().openapi({
       description:
-        "Whether this is the currently active semester. Exactly one semester should be active at a time.",
+        "Indica se este é o semestre ativo no momento. Exatamente um semestre deve estar ativo por vez.",
       example: true,
     }),
   })
   .openapi("SemestreResponse");
 
 /**
- * Evento (calendar event) response shape.
+ * Shape de resposta de Evento do calendário.
  */
 const eventoResponseSchema = z
   .object({
@@ -63,21 +63,21 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
   registry.registerPath({
     method: "get",
     path: "/calendario-academico",
-    tags: ["Academic Calendar"],
-    summary: "List semesters (or get the active one)",
+    tags: ["Calendário Acadêmico"],
+    summary: "Listar semestres (ou obter o ativo)",
     description:
-      "List semesters. Pass `?ativo=true` to get only the currently active semester (as a single object or `null`).",
+      "Lista todos os semestres. Use `?ativo=true` para obter apenas o semestre ativo (como objeto único ou `null`).",
     request: {
       query: z.object({
         ativo: z.enum(["true", "false"]).optional().openapi({
-          description: "If `true`, return only the active semester.",
+          description: "Se `true`, retorna apenas o semestre ativo.",
           example: "true",
         }),
       }),
     },
     responses: {
       200: {
-        description: "Array of semesters, or a single semester when `?ativo=true`.",
+        description: "Array de semestres, ou um único semestre quando `?ativo=true`.",
         content: {
           "application/json": {
             schema: z.union([z.array(semestreResponseSchema), semestreResponseSchema.nullable()]),
@@ -90,10 +90,10 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
   registry.registerPath({
     method: "post",
     path: "/calendario-academico",
-    tags: ["Academic Calendar"],
-    summary: "Create a new semester (admin only)",
+    tags: ["Calendário Acadêmico"],
+    summary: "Criar um novo semestre (admin)",
     description:
-      "Create a new semester. Returns 409 with `SEMESTRE_NOME_EXISTS` if the name already exists.",
+      "Cria um novo semestre. Retorna 409 com `SEMESTRE_NOME_EXISTS` se já existir um semestre com esse nome.",
     security: [{ bearerAuth: [] }],
     request: {
       body: {
@@ -112,7 +112,7 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
     },
     responses: {
       201: {
-        description: "Semester created.",
+        description: "Semestre criado.",
         content: { "application/json": { schema: semestreResponseSchema } },
       },
       ...errorResponses([400, 409]),
@@ -122,16 +122,16 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
   registry.registerPath({
     method: "get",
     path: "/calendario-academico/{id}",
-    tags: ["Academic Calendar"],
-    summary: "Get a semester by id",
+    tags: ["Calendário Acadêmico"],
+    summary: "Buscar um semestre pelo ID",
     description:
-      "Public endpoint returning the details of a specific semester. Returns 404 with `SEMESTRE_NOT_FOUND` if the id does not match any semester.",
+      "Retorna os detalhes de um semestre específico. Retorna 404 com `SEMESTRE_NOT_FOUND` se o ID não corresponder a nenhum semestre.",
     request: {
       params: z.object({ id: z.string().uuid() }),
     },
     responses: {
       200: {
-        description: "Semester details.",
+        description: "Detalhes do semestre.",
         content: { "application/json": { schema: semestreResponseSchema } },
       },
       ...errorResponses([404]),
@@ -141,10 +141,10 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
   registry.registerPath({
     method: "put",
     path: "/calendario-academico/{id}",
-    tags: ["Academic Calendar"],
-    summary: "Update a semester (admin only)",
+    tags: ["Calendário Acadêmico"],
+    summary: "Atualizar um semestre (admin)",
     description:
-      "Admin-only endpoint to update a semester's name or dates. All fields are optional — only provided fields are updated.",
+      "Endpoint exclusivo para administradores. Atualiza nome ou datas de um semestre. Todos os campos são opcionais — apenas os enviados são atualizados.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({ id: z.string().uuid() }),
@@ -160,7 +160,7 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
     },
     responses: {
       200: {
-        description: "Semester updated.",
+        description: "Semestre atualizado.",
         content: { "application/json": { schema: semestreResponseSchema } },
       },
       ...errorResponses([400, 404, 409]),
@@ -170,17 +170,17 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
   registry.registerPath({
     method: "delete",
     path: "/calendario-academico/{id}",
-    tags: ["Academic Calendar"],
-    summary: "Delete a semester (admin only)",
+    tags: ["Calendário Acadêmico"],
+    summary: "Excluir um semestre (admin)",
     description:
-      "Admin-only endpoint to delete a semester. Related events are also removed as part of the deletion.",
+      "Endpoint exclusivo para administradores. Os eventos vinculados também são removidos como parte da exclusão.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({ id: z.string().uuid() }),
     },
     responses: {
       200: {
-        description: "Semester deleted.",
+        description: "Semestre excluído.",
         content: {
           "application/json": {
             schema: messageResponseSchema,
@@ -195,16 +195,16 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
   registry.registerPath({
     method: "get",
     path: "/calendario-academico/{id}/eventos",
-    tags: ["Academic Calendar"],
-    summary: "List events for a semester",
+    tags: ["Calendário Acadêmico"],
+    summary: "Listar eventos de um semestre",
     description:
-      "Public endpoint returning all events (holidays, registration deadlines, exam periods, etc) scheduled for the specified semester.",
+      "Retorna todos os eventos (feriados, prazos de matrícula, períodos de prova, etc) agendados para o semestre especificado.",
     request: {
       params: z.object({ id: z.string().uuid() }),
     },
     responses: {
       200: {
-        description: "List of events for the semester.",
+        description: "Lista de eventos do semestre.",
         content: { "application/json": { schema: z.array(eventoResponseSchema) } },
       },
       ...errorResponses([404]),
@@ -214,10 +214,10 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
   registry.registerPath({
     method: "post",
     path: "/calendario-academico/{id}/eventos",
-    tags: ["Academic Calendar"],
-    summary: "Create a new event in a semester (admin only)",
+    tags: ["Calendário Acadêmico"],
+    summary: "Criar um novo evento em um semestre (admin)",
     description:
-      "Admin-only endpoint to add a new event to the specified semester. Events are categorized via the `categoria` field (holidays, exam periods, etc) for UI display grouping.",
+      "Endpoint exclusivo para administradores. Adiciona um novo evento ao semestre especificado. Eventos são categorizados pelo campo `categoria` (feriados, períodos de prova, etc) para agrupamento na UI.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({ id: z.string().uuid() }),
@@ -238,7 +238,7 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
     },
     responses: {
       201: {
-        description: "Event created.",
+        description: "Evento criado.",
         content: { "application/json": { schema: eventoResponseSchema } },
       },
       ...errorResponses([400, 404]),
@@ -248,10 +248,10 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
   registry.registerPath({
     method: "put",
     path: "/calendario-academico/{id}/eventos/{eventoId}",
-    tags: ["Academic Calendar"],
-    summary: "Update an event (admin only)",
+    tags: ["Calendário Acadêmico"],
+    summary: "Atualizar um evento (admin)",
     description:
-      "Admin-only endpoint to update an event's description, dates, or category. All fields are optional. Returns 404 with `EVENTO_NOT_FOUND` if the event does not exist.",
+      "Endpoint exclusivo para administradores. Atualiza a descrição, datas ou categoria de um evento. Todos os campos são opcionais. Retorna 404 com `EVENTO_NOT_FOUND` se o evento não existir.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({
@@ -273,7 +273,7 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
     },
     responses: {
       200: {
-        description: "Event updated.",
+        description: "Evento atualizado.",
         content: { "application/json": { schema: eventoResponseSchema } },
       },
       ...errorResponses([400, 404]),
@@ -283,9 +283,9 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
   registry.registerPath({
     method: "delete",
     path: "/calendario-academico/{id}/eventos/{eventoId}",
-    tags: ["Academic Calendar"],
-    summary: "Delete an event (admin only)",
-    description: "Admin-only endpoint to delete an event from the semester.",
+    tags: ["Calendário Acadêmico"],
+    summary: "Excluir um evento (admin)",
+    description: "Endpoint exclusivo para administradores. Exclui um evento do semestre.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({
@@ -295,7 +295,7 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
     },
     responses: {
       200: {
-        description: "Event deleted.",
+        description: "Evento excluído.",
         content: {
           "application/json": {
             schema: messageResponseSchema,
@@ -310,10 +310,10 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
   registry.registerPath({
     method: "post",
     path: "/calendario-academico/{id}/eventos/batch",
-    tags: ["Academic Calendar"],
-    summary: "Batch create (or replace) events in a semester (admin only)",
+    tags: ["Calendário Acadêmico"],
+    summary: "Criar (ou substituir) eventos em lote em um semestre (admin)",
     description:
-      "Admin-only endpoint to create multiple events in a single request — used by the CSV import flow. When `replace: true`, ALL existing events for the semester are deleted before inserting the new batch (use with caution). When `replace: false` (default), new events are appended.",
+      "Endpoint exclusivo para administradores. Cria múltiplos eventos em uma única requisição — usado pelo fluxo de import via CSV. Quando `replace: true`, TODOS os eventos existentes do semestre são excluídos antes de inserir o novo lote (use com cuidado). Com `replace: false` (padrão), novos eventos são apenas adicionados.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({ id: z.string().uuid() }),
@@ -345,7 +345,7 @@ export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: Comm
     },
     responses: {
       201: {
-        description: "Events created. Response includes the total number of events inserted.",
+        description: "Eventos criados. A resposta inclui o total de eventos inseridos.",
         content: {
           "application/json": {
             schema: z.object({ count: z.number().int().openapi({ example: 2 }) }),

--- a/src/lib/server/openapi/paths/calendario.ts
+++ b/src/lib/server/openapi/paths/calendario.ts
@@ -8,7 +8,7 @@ import { updateEventoSchema } from "@/app/api/calendario-academico/[id]/eventos/
 import { batchCreateSchema } from "@/app/api/calendario-academico/[id]/eventos/batch/route";
 import { ALL_CATEGORIAS } from "@/lib/shared/config/calendario-academico";
 
-import { errorResponses } from "../common-schemas";
+import type { CommonSchemas } from "../common-schemas";
 
 /**
  * Enum of event categories. Mirrors ALL_CATEGORIAS in
@@ -56,7 +56,8 @@ const eventoResponseSchema = z
 
 const messageResponseSchema = z.object({ message: z.string() });
 
-export function registerCalendarioPaths(registry: OpenAPIRegistry): void {
+export function registerCalendarioPaths(registry: OpenAPIRegistry, schemas: CommonSchemas): void {
+  const { errorResponses } = schemas;
   registry.registerPath({
     method: "get",
     path: "/calendario-academico",

--- a/src/lib/server/openapi/paths/calendario.ts
+++ b/src/lib/server/openapi/paths/calendario.ts
@@ -56,6 +56,7 @@ const eventoResponseSchema = z
   })
   .openapi("EventoResponse");
 
+/** Resposta simples com mensagem de status. */
 const messageResponseSchema = z.object({ message: z.string() });
 
 /** Registra os paths de calendário acadêmico no registry OpenAPI. */

--- a/src/lib/server/openapi/paths/campus.ts
+++ b/src/lib/server/openapi/paths/campus.ts
@@ -4,8 +4,8 @@ import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 import type { CommonSchemas } from "../common-schemas";
 
 /**
- * Campus response shape. Handlers validate request bodies inline (no Zod),
- * so request/response shapes are defined here.
+ * Shape de resposta de Campus. Os handlers validam o corpo das requisições
+ * inline (sem Zod), então definimos os schemas de request/response aqui.
  */
 const campusResponseSchema = z
   .object({
@@ -26,12 +26,12 @@ export function registerCampusPaths(registry: OpenAPIRegistry, schemas: CommonSc
     method: "get",
     path: "/campus",
     tags: ["Campus"],
-    summary: "List all campi",
+    summary: "Listar todos os campi",
     description:
-      "Public endpoint returning all UFPB campi. UFPB has multiple campi across the state of Paraíba.",
+      "Retorna todos os campi da UFPB. A UFPB tem múltiplos campi espalhados pelo estado da Paraíba.",
     responses: {
       200: {
-        description: "List of all campi.",
+        description: "Lista de todos os campi.",
         content: { "application/json": { schema: z.array(campusResponseSchema) } },
       },
     },
@@ -41,9 +41,9 @@ export function registerCampusPaths(registry: OpenAPIRegistry, schemas: CommonSc
     method: "post",
     path: "/campus",
     tags: ["Campus"],
-    summary: "Create a new campus (admin only)",
+    summary: "Criar um novo campus (admin)",
     description:
-      "Admin-only endpoint to create a new campus. Returns 409 if a campus with the same name already exists.",
+      "Endpoint exclusivo para administradores. Retorna 409 se já existir um campus com o mesmo nome.",
     security: [{ bearerAuth: [] }],
     request: {
       body: {
@@ -58,7 +58,7 @@ export function registerCampusPaths(registry: OpenAPIRegistry, schemas: CommonSc
     },
     responses: {
       201: {
-        description: "Campus created.",
+        description: "Campus criado.",
         content: { "application/json": { schema: campusResponseSchema } },
       },
       ...errorResponses([400, 409]),
@@ -69,8 +69,8 @@ export function registerCampusPaths(registry: OpenAPIRegistry, schemas: CommonSc
     method: "put",
     path: "/campus/{id}",
     tags: ["Campus"],
-    summary: "Update a campus (admin only)",
-    description: "Admin-only endpoint to rename a campus.",
+    summary: "Atualizar um campus (admin)",
+    description: "Endpoint exclusivo para administradores. Renomeia um campus.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({ id: z.string().uuid() }),
@@ -86,7 +86,7 @@ export function registerCampusPaths(registry: OpenAPIRegistry, schemas: CommonSc
     },
     responses: {
       200: {
-        description: "Campus updated.",
+        description: "Campus atualizado.",
         content: { "application/json": { schema: campusResponseSchema } },
       },
       ...errorResponses([400, 404]),
@@ -97,16 +97,16 @@ export function registerCampusPaths(registry: OpenAPIRegistry, schemas: CommonSc
     method: "delete",
     path: "/campus/{id}",
     tags: ["Campus"],
-    summary: "Delete a campus (admin only)",
+    summary: "Excluir um campus (admin)",
     description:
-      "Admin-only endpoint to delete a campus. **Returns 409 with `HAS_DEPENDENCIES` if there are academic centers linked to this campus** — you must delete/reassign linked centers first.",
+      "Endpoint exclusivo para administradores. **Retorna 409 com `HAS_DEPENDENCIES` se houver centros acadêmicos vinculados a este campus** — você precisa excluir/reatribuir os centros vinculados antes.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({ id: z.string().uuid() }),
     },
     responses: {
       200: {
-        description: "Campus deleted.",
+        description: "Campus excluído.",
         content: {
           "application/json": {
             schema: z.object({ success: z.literal(true) }),

--- a/src/lib/server/openapi/paths/campus.ts
+++ b/src/lib/server/openapi/paths/campus.ts
@@ -34,7 +34,6 @@ export function registerCampusPaths(registry: OpenAPIRegistry, schemas: CommonSc
         description: "List of all campi.",
         content: { "application/json": { schema: z.array(campusResponseSchema) } },
       },
-      ...errorResponses([500]),
     },
   });
 
@@ -62,7 +61,7 @@ export function registerCampusPaths(registry: OpenAPIRegistry, schemas: CommonSc
         description: "Campus created.",
         content: { "application/json": { schema: campusResponseSchema } },
       },
-      ...errorResponses([400, 401, 403, 409, 500]),
+      ...errorResponses([400, 409]),
     },
   });
 
@@ -90,7 +89,7 @@ export function registerCampusPaths(registry: OpenAPIRegistry, schemas: CommonSc
         description: "Campus updated.",
         content: { "application/json": { schema: campusResponseSchema } },
       },
-      ...errorResponses([400, 401, 403, 404, 500]),
+      ...errorResponses([400, 404]),
     },
   });
 
@@ -115,7 +114,7 @@ export function registerCampusPaths(registry: OpenAPIRegistry, schemas: CommonSc
           },
         },
       },
-      ...errorResponses([401, 403, 404, 409, 500]),
+      ...errorResponses([404, 409]),
     },
   });
 }

--- a/src/lib/server/openapi/paths/campus.ts
+++ b/src/lib/server/openapi/paths/campus.ts
@@ -1,0 +1,120 @@
+import { z } from "zod";
+import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
+
+import { errorResponses } from "../common-schemas";
+
+/**
+ * Campus response shape. Handlers validate request bodies inline (no Zod),
+ * so request/response shapes are defined here.
+ */
+const campusResponseSchema = z
+  .object({
+    id: z.string().uuid(),
+    nome: z.string().openapi({ example: "Campus I - João Pessoa" }),
+  })
+  .openapi("CampusResponse");
+
+const createOrUpdateCampusSchema = z
+  .object({
+    nome: z.string().min(1).openapi({ example: "Campus I - João Pessoa" }),
+  })
+  .openapi("CreateOrUpdateCampusRequest");
+
+export function registerCampusPaths(registry: OpenAPIRegistry): void {
+  registry.registerPath({
+    method: "get",
+    path: "/campus",
+    tags: ["Campus"],
+    summary: "List all campi",
+    description:
+      "Public endpoint returning all UFPB campi. UFPB has multiple campi across the state of Paraíba.",
+    responses: {
+      200: {
+        description: "List of all campi.",
+        content: { "application/json": { schema: z.array(campusResponseSchema) } },
+      },
+      ...errorResponses([500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/campus",
+    tags: ["Campus"],
+    summary: "Create a new campus (admin only)",
+    description:
+      "Admin-only endpoint to create a new campus. Returns 409 if a campus with the same name already exists.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: createOrUpdateCampusSchema,
+            example: { nome: "Campus IV - Rio Tinto" },
+          },
+        },
+      },
+    },
+    responses: {
+      201: {
+        description: "Campus created.",
+        content: { "application/json": { schema: campusResponseSchema } },
+      },
+      ...errorResponses([400, 401, 403, 409, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "put",
+    path: "/campus/{id}",
+    tags: ["Campus"],
+    summary: "Update a campus (admin only)",
+    description: "Admin-only endpoint to rename a campus.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      params: z.object({ id: z.string().uuid() }),
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: createOrUpdateCampusSchema,
+            example: { nome: "Campus I - João Pessoa" },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Campus updated.",
+        content: { "application/json": { schema: campusResponseSchema } },
+      },
+      ...errorResponses([400, 401, 403, 404, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "delete",
+    path: "/campus/{id}",
+    tags: ["Campus"],
+    summary: "Delete a campus (admin only)",
+    description:
+      "Admin-only endpoint to delete a campus. **Returns 409 with `HAS_DEPENDENCIES` if there are academic centers linked to this campus** — you must delete/reassign linked centers first.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      params: z.object({ id: z.string().uuid() }),
+    },
+    responses: {
+      200: {
+        description: "Campus deleted.",
+        content: {
+          "application/json": {
+            schema: z.object({ success: z.literal(true) }),
+            example: { success: true },
+          },
+        },
+      },
+      ...errorResponses([401, 403, 404, 409, 500]),
+    },
+  });
+}

--- a/src/lib/server/openapi/paths/campus.ts
+++ b/src/lib/server/openapi/paths/campus.ts
@@ -20,6 +20,7 @@ const createOrUpdateCampusSchema = z
   })
   .openapi("CreateOrUpdateCampusRequest");
 
+/** Registra os paths de campus no registry OpenAPI. */
 export function registerCampusPaths(registry: OpenAPIRegistry, schemas: CommonSchemas): void {
   const { errorResponses } = schemas;
   registry.registerPath({

--- a/src/lib/server/openapi/paths/campus.ts
+++ b/src/lib/server/openapi/paths/campus.ts
@@ -14,6 +14,7 @@ const campusResponseSchema = z
   })
   .openapi("CampusResponse");
 
+/** Schema de request para criar ou atualizar um campus. */
 const createOrUpdateCampusSchema = z
   .object({
     nome: z.string().min(1).openapi({ example: "Campus I - João Pessoa" }),

--- a/src/lib/server/openapi/paths/campus.ts
+++ b/src/lib/server/openapi/paths/campus.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 
-import { errorResponses } from "../common-schemas";
+import type { CommonSchemas } from "../common-schemas";
 
 /**
  * Campus response shape. Handlers validate request bodies inline (no Zod),
@@ -20,7 +20,8 @@ const createOrUpdateCampusSchema = z
   })
   .openapi("CreateOrUpdateCampusRequest");
 
-export function registerCampusPaths(registry: OpenAPIRegistry): void {
+export function registerCampusPaths(registry: OpenAPIRegistry, schemas: CommonSchemas): void {
+  const { errorResponses } = schemas;
   registry.registerPath({
     method: "get",
     path: "/campus",

--- a/src/lib/server/openapi/paths/campus.ts
+++ b/src/lib/server/openapi/paths/campus.ts
@@ -61,7 +61,9 @@ export function registerCampusPaths(registry: OpenAPIRegistry, schemas: CommonSc
         description: "Campus criado.",
         content: { "application/json": { schema: campusResponseSchema } },
       },
-      ...errorResponses([400, 409]),
+      ...errorResponses([400, 409], {
+        409: { message: "Já existe um campus com esse nome", code: "CONFLICT" },
+      }),
     },
   });
 
@@ -89,7 +91,9 @@ export function registerCampusPaths(registry: OpenAPIRegistry, schemas: CommonSc
         description: "Campus atualizado.",
         content: { "application/json": { schema: campusResponseSchema } },
       },
-      ...errorResponses([400, 404]),
+      ...errorResponses([400, 404], {
+        404: { message: "Campus não encontrado", code: "NOT_FOUND" },
+      }),
     },
   });
 
@@ -114,7 +118,13 @@ export function registerCampusPaths(registry: OpenAPIRegistry, schemas: CommonSc
           },
         },
       },
-      ...errorResponses([404, 409]),
+      ...errorResponses([404, 409], {
+        404: { message: "Campus não encontrado", code: "NOT_FOUND" },
+        409: {
+          message: "Não é possível excluir: existem 3 centro(s) vinculado(s)",
+          code: "HAS_DEPENDENCIES",
+        },
+      }),
     },
   });
 }

--- a/src/lib/server/openapi/paths/centros.ts
+++ b/src/lib/server/openapi/paths/centros.ts
@@ -4,9 +4,9 @@ import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 import type { CommonSchemas } from "../common-schemas";
 
 /**
- * Centro (academic center, e.g., Centro de Informática) response shape.
- * Handlers validate request bodies inline rather than with Zod schemas, so
- * request/response shapes are defined here.
+ * Shape de resposta de Centro Acadêmico (ex: Centro de Informática). Os
+ * handlers validam o corpo das requisições inline, sem schemas Zod, então
+ * os shapes de request/response são definidos aqui.
  */
 const centroResponseSchema = z
   .object({
@@ -32,7 +32,7 @@ const createOrUpdateCentroSchema = z
   .openapi("CreateOrUpdateCentroRequest");
 
 /**
- * Simplified curso shape returned by GET /centros/{id}/cursos.
+ * Shape simplificado de curso retornado por GET /centros/{id}/cursos.
  */
 const centroCursoSchema = z
   .object({
@@ -47,13 +47,13 @@ export function registerCentrosPaths(registry: OpenAPIRegistry, schemas: CommonS
   registry.registerPath({
     method: "get",
     path: "/centros",
-    tags: ["Academic Centers"],
-    summary: "List all academic centers",
+    tags: ["Centros Acadêmicos"],
+    summary: "Listar todos os centros acadêmicos",
     description:
-      "Public endpoint returning all academic centers (e.g., Centro de Informática, Centro de Ciências Exatas) across all campi.",
+      "Retorna todos os centros acadêmicos (ex: Centro de Informática, Centro de Ciências Exatas) de todos os campi.",
     responses: {
       200: {
-        description: "List of all centers.",
+        description: "Lista de todos os centros.",
         content: { "application/json": { schema: z.array(centroResponseSchema) } },
       },
     },
@@ -62,9 +62,9 @@ export function registerCentrosPaths(registry: OpenAPIRegistry, schemas: CommonS
   registry.registerPath({
     method: "post",
     path: "/centros",
-    tags: ["Academic Centers"],
-    summary: "Create a new academic center (admin only)",
-    description: "Admin-only endpoint to create a new academic center.",
+    tags: ["Centros Acadêmicos"],
+    summary: "Criar um novo centro acadêmico (admin)",
+    description: "Endpoint exclusivo para administradores. Cria um novo centro acadêmico.",
     security: [{ bearerAuth: [] }],
     request: {
       body: {
@@ -85,7 +85,7 @@ export function registerCentrosPaths(registry: OpenAPIRegistry, schemas: CommonS
     },
     responses: {
       201: {
-        description: "Center created.",
+        description: "Centro criado.",
         content: { "application/json": { schema: centroResponseSchema } },
       },
       ...errorResponses([400]),
@@ -95,9 +95,9 @@ export function registerCentrosPaths(registry: OpenAPIRegistry, schemas: CommonS
   registry.registerPath({
     method: "put",
     path: "/centros/{id}",
-    tags: ["Academic Centers"],
-    summary: "Update an academic center (admin only)",
-    description: "Admin-only endpoint to update an academic center.",
+    tags: ["Centros Acadêmicos"],
+    summary: "Atualizar um centro acadêmico (admin)",
+    description: "Endpoint exclusivo para administradores. Atualiza um centro acadêmico.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({ id: z.string().uuid() }),
@@ -118,7 +118,7 @@ export function registerCentrosPaths(registry: OpenAPIRegistry, schemas: CommonS
     },
     responses: {
       200: {
-        description: "Center updated.",
+        description: "Centro atualizado.",
         content: { "application/json": { schema: centroResponseSchema } },
       },
       ...errorResponses([400, 404]),
@@ -128,17 +128,17 @@ export function registerCentrosPaths(registry: OpenAPIRegistry, schemas: CommonS
   registry.registerPath({
     method: "delete",
     path: "/centros/{id}",
-    tags: ["Academic Centers"],
-    summary: "Delete an academic center (admin only)",
+    tags: ["Centros Acadêmicos"],
+    summary: "Excluir um centro acadêmico (admin)",
     description:
-      "Admin-only endpoint to delete an academic center. **Returns 409 with `HAS_DEPENDENCIES` if there are courses linked to this center** — you must delete/reassign linked courses first.",
+      "Endpoint exclusivo para administradores. **Retorna 409 com `HAS_DEPENDENCIES` se houver cursos vinculados a este centro** — é necessário excluir/reatribuir os cursos vinculados antes.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({ id: z.string().uuid() }),
     },
     responses: {
       200: {
-        description: "Center deleted.",
+        description: "Centro excluído.",
         content: {
           "application/json": {
             schema: z.object({ success: z.literal(true) }),
@@ -153,15 +153,15 @@ export function registerCentrosPaths(registry: OpenAPIRegistry, schemas: CommonS
   registry.registerPath({
     method: "get",
     path: "/centros/{id}/cursos",
-    tags: ["Academic Centers"],
-    summary: "List courses for a specific center",
-    description: "Public endpoint returning all courses (majors) offered by the specified center.",
+    tags: ["Centros Acadêmicos"],
+    summary: "Listar cursos de um centro",
+    description: "Retorna todos os cursos oferecidos pelo centro especificado.",
     request: {
       params: z.object({ id: z.string().uuid() }),
     },
     responses: {
       200: {
-        description: "List of courses for this center.",
+        description: "Lista de cursos deste centro.",
         content: { "application/json": { schema: z.array(centroCursoSchema) } },
       },
     },

--- a/src/lib/server/openapi/paths/centros.ts
+++ b/src/lib/server/openapi/paths/centros.ts
@@ -1,0 +1,170 @@
+import { z } from "zod";
+import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
+
+import { errorResponses } from "../common-schemas";
+
+/**
+ * Centro (academic center, e.g., Centro de Informática) response shape.
+ * Handlers validate request bodies inline rather than with Zod schemas, so
+ * request/response shapes are defined here.
+ */
+const centroResponseSchema = z
+  .object({
+    id: z.string().uuid(),
+    nome: z.string().openapi({ example: "Centro de Informática" }),
+    sigla: z.string().openapi({ example: "CI" }),
+    descricao: z.string().nullable().optional(),
+    campusId: z.string().uuid(),
+  })
+  .openapi("CentroResponse");
+
+const createOrUpdateCentroSchema = z
+  .object({
+    nome: z.string().min(1).openapi({ example: "Centro de Informática" }),
+    sigla: z.string().min(1).openapi({ example: "CI" }),
+    descricao: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "Centro responsável pelos cursos de computação na UFPB." }),
+    campusId: z.string().uuid().openapi({ example: "b2c3d4e5-f6a7-8901-bcde-f23456789012" }),
+  })
+  .openapi("CreateOrUpdateCentroRequest");
+
+/**
+ * Simplified curso shape returned by GET /centros/{id}/cursos.
+ */
+const centroCursoSchema = z
+  .object({
+    id: z.string().uuid(),
+    nome: z.string(),
+    centroId: z.string().uuid(),
+  })
+  .openapi("CentroCurso");
+
+export function registerCentrosPaths(registry: OpenAPIRegistry): void {
+  registry.registerPath({
+    method: "get",
+    path: "/centros",
+    tags: ["Academic Centers"],
+    summary: "List all academic centers",
+    description:
+      "Public endpoint returning all academic centers (e.g., Centro de Informática, Centro de Ciências Exatas) across all campi.",
+    responses: {
+      200: {
+        description: "List of all centers.",
+        content: { "application/json": { schema: z.array(centroResponseSchema) } },
+      },
+      ...errorResponses([500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/centros",
+    tags: ["Academic Centers"],
+    summary: "Create a new academic center (admin only)",
+    description: "Admin-only endpoint to create a new academic center.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: createOrUpdateCentroSchema,
+            example: {
+              nome: "Centro de Informática",
+              sigla: "CI",
+              descricao:
+                "Responsável pelos cursos de Ciência da Computação e Sistemas de Informação.",
+              campusId: "b2c3d4e5-f6a7-8901-bcde-f23456789012",
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      201: {
+        description: "Center created.",
+        content: { "application/json": { schema: centroResponseSchema } },
+      },
+      ...errorResponses([400, 401, 403, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "put",
+    path: "/centros/{id}",
+    tags: ["Academic Centers"],
+    summary: "Update an academic center (admin only)",
+    description: "Admin-only endpoint to update an academic center.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      params: z.object({ id: z.string().uuid() }),
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: createOrUpdateCentroSchema,
+            example: {
+              nome: "Centro de Informática",
+              sigla: "CI",
+              descricao: "Centro atualizado.",
+              campusId: "b2c3d4e5-f6a7-8901-bcde-f23456789012",
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Center updated.",
+        content: { "application/json": { schema: centroResponseSchema } },
+      },
+      ...errorResponses([400, 401, 403, 404, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "delete",
+    path: "/centros/{id}",
+    tags: ["Academic Centers"],
+    summary: "Delete an academic center (admin only)",
+    description:
+      "Admin-only endpoint to delete an academic center. **Returns 409 with `HAS_DEPENDENCIES` if there are courses linked to this center** — you must delete/reassign linked courses first.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      params: z.object({ id: z.string().uuid() }),
+    },
+    responses: {
+      200: {
+        description: "Center deleted.",
+        content: {
+          "application/json": {
+            schema: z.object({ success: z.literal(true) }),
+            example: { success: true },
+          },
+        },
+      },
+      ...errorResponses([401, 403, 404, 409, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/centros/{id}/cursos",
+    tags: ["Academic Centers"],
+    summary: "List courses for a specific center",
+    description: "Public endpoint returning all courses (majors) offered by the specified center.",
+    request: {
+      params: z.object({ id: z.string().uuid() }),
+    },
+    responses: {
+      200: {
+        description: "List of courses for this center.",
+        content: { "application/json": { schema: z.array(centroCursoSchema) } },
+      },
+      ...errorResponses([500]),
+    },
+  });
+}

--- a/src/lib/server/openapi/paths/centros.ts
+++ b/src/lib/server/openapi/paths/centros.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 
-import { errorResponses } from "../common-schemas";
+import type { CommonSchemas } from "../common-schemas";
 
 /**
  * Centro (academic center, e.g., Centro de Informática) response shape.
@@ -42,7 +42,8 @@ const centroCursoSchema = z
   })
   .openapi("CentroCurso");
 
-export function registerCentrosPaths(registry: OpenAPIRegistry): void {
+export function registerCentrosPaths(registry: OpenAPIRegistry, schemas: CommonSchemas): void {
+  const { errorResponses } = schemas;
   registry.registerPath({
     method: "get",
     path: "/centros",

--- a/src/lib/server/openapi/paths/centros.ts
+++ b/src/lib/server/openapi/paths/centros.ts
@@ -56,7 +56,6 @@ export function registerCentrosPaths(registry: OpenAPIRegistry, schemas: CommonS
         description: "List of all centers.",
         content: { "application/json": { schema: z.array(centroResponseSchema) } },
       },
-      ...errorResponses([500]),
     },
   });
 
@@ -89,7 +88,7 @@ export function registerCentrosPaths(registry: OpenAPIRegistry, schemas: CommonS
         description: "Center created.",
         content: { "application/json": { schema: centroResponseSchema } },
       },
-      ...errorResponses([400, 401, 403, 500]),
+      ...errorResponses([400]),
     },
   });
 
@@ -122,7 +121,7 @@ export function registerCentrosPaths(registry: OpenAPIRegistry, schemas: CommonS
         description: "Center updated.",
         content: { "application/json": { schema: centroResponseSchema } },
       },
-      ...errorResponses([400, 401, 403, 404, 500]),
+      ...errorResponses([400, 404]),
     },
   });
 
@@ -147,7 +146,7 @@ export function registerCentrosPaths(registry: OpenAPIRegistry, schemas: CommonS
           },
         },
       },
-      ...errorResponses([401, 403, 404, 409, 500]),
+      ...errorResponses([404, 409]),
     },
   });
 
@@ -165,7 +164,6 @@ export function registerCentrosPaths(registry: OpenAPIRegistry, schemas: CommonS
         description: "List of courses for this center.",
         content: { "application/json": { schema: z.array(centroCursoSchema) } },
       },
-      ...errorResponses([500]),
     },
   });
 }

--- a/src/lib/server/openapi/paths/centros.ts
+++ b/src/lib/server/openapi/paths/centros.ts
@@ -121,7 +121,9 @@ export function registerCentrosPaths(registry: OpenAPIRegistry, schemas: CommonS
         description: "Centro atualizado.",
         content: { "application/json": { schema: centroResponseSchema } },
       },
-      ...errorResponses([400, 404]),
+      ...errorResponses([400, 404], {
+        404: { message: "Centro não encontrado", code: "NOT_FOUND" },
+      }),
     },
   });
 
@@ -146,7 +148,13 @@ export function registerCentrosPaths(registry: OpenAPIRegistry, schemas: CommonS
           },
         },
       },
-      ...errorResponses([404, 409]),
+      ...errorResponses([404, 409], {
+        404: { message: "Centro não encontrado", code: "NOT_FOUND" },
+        409: {
+          message: "Não é possível excluir: existem 2 curso(s) vinculado(s)",
+          code: "HAS_DEPENDENCIES",
+        },
+      }),
     },
   });
 

--- a/src/lib/server/openapi/paths/centros.ts
+++ b/src/lib/server/openapi/paths/centros.ts
@@ -42,6 +42,7 @@ const centroCursoSchema = z
   })
   .openapi("CentroCurso");
 
+/** Registra os paths de centros acadêmicos no registry OpenAPI. */
 export function registerCentrosPaths(registry: OpenAPIRegistry, schemas: CommonSchemas): void {
   const { errorResponses } = schemas;
   registry.registerPath({

--- a/src/lib/server/openapi/paths/centros.ts
+++ b/src/lib/server/openapi/paths/centros.ts
@@ -18,6 +18,7 @@ const centroResponseSchema = z
   })
   .openapi("CentroResponse");
 
+/** Schema de request para criar ou atualizar um centro acadêmico. */
 const createOrUpdateCentroSchema = z
   .object({
     nome: z.string().min(1).openapi({ example: "Centro de Informática" }),

--- a/src/lib/server/openapi/paths/curriculos.ts
+++ b/src/lib/server/openapi/paths/curriculos.ts
@@ -4,7 +4,7 @@ import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 import type { CommonSchemas } from "../common-schemas";
 
 /**
- * Discipline inside a curriculum grid — summary fields only.
+ * Disciplina dentro da grade curricular (campos de resumo).
  */
 const gradeDisciplinaSchema = z
   .object({
@@ -14,15 +14,14 @@ const gradeDisciplinaSchema = z
     cargaHoraria: z.number().int().optional(),
     creditos: z.number().int().optional(),
     natureza: z.enum(["OBRIGATORIA", "OPTATIVA", "ELETIVA", "COMPLEMENTAR"]).optional().openapi({
-      description: "Discipline nature inside this curriculum (required, optional, etc).",
+      description: "Natureza da disciplina no currículo (obrigatória, optativa, etc).",
       example: "OBRIGATORIA",
     }),
   })
   .openapi("GradeDisciplina");
 
 /**
- * A single period/semester in a curriculum grid, containing the disciplines
- * that should be taken during that period.
+ * Um período/semestre da grade, contendo as disciplinas que devem ser cursadas.
  */
 const gradePeriodoSchema = z
   .object({
@@ -32,8 +31,7 @@ const gradePeriodoSchema = z
   .openapi("GradePeriodo");
 
 /**
- * Full curriculum grid response. The shape is the one returned by
- * curriculosRepository.findActiveGradeByCursoId — an active grade per course.
+ * Resposta completa da grade curricular ativa de um curso.
  */
 const curriculoGradeResponseSchema = z
   .object({
@@ -50,21 +48,21 @@ export function registerCurriculosPaths(registry: OpenAPIRegistry, schemas: Comm
   registry.registerPath({
     method: "get",
     path: "/curriculos/grade",
-    tags: ["Curricula"],
-    summary: "Get the active curriculum grid for a course",
+    tags: ["Currículos"],
+    summary: "Obter a grade curricular ativa de um curso",
     description:
-      "Public endpoint returning the currently active curriculum grid for a specific course, organized by semester. Used by the curriculum browser page to display the discipline tree. Requires the `cursoId` query parameter — returns 400 if missing and 404 if no active grid exists for that course.",
+      "Retorna a grade curricular ativa de um curso, organizada por período. Retorna 400 se `cursoId` não for informado e 404 se o curso não tiver grade ativa.",
     request: {
       query: z.object({
         cursoId: z.string().uuid().openapi({
-          description: "Course id to fetch the active curriculum grid for.",
+          description: "ID do curso.",
           example: "550e8400-e29b-41d4-a716-446655440000",
         }),
       }),
     },
     responses: {
       200: {
-        description: "Active curriculum grid organized by period.",
+        description: "Grade curricular ativa organizada por período.",
         content: { "application/json": { schema: curriculoGradeResponseSchema } },
       },
       ...errorResponses([400, 404]),

--- a/src/lib/server/openapi/paths/curriculos.ts
+++ b/src/lib/server/openapi/paths/curriculos.ts
@@ -65,7 +65,9 @@ export function registerCurriculosPaths(registry: OpenAPIRegistry, schemas: Comm
         description: "Grade curricular ativa organizada por período.",
         content: { "application/json": { schema: curriculoGradeResponseSchema } },
       },
-      ...errorResponses([400, 404]),
+      ...errorResponses([400, 404], {
+        404: { message: "Currículo ativo não encontrado", code: "NOT_FOUND" },
+      }),
     },
   });
 }

--- a/src/lib/server/openapi/paths/curriculos.ts
+++ b/src/lib/server/openapi/paths/curriculos.ts
@@ -43,6 +43,7 @@ const curriculoGradeResponseSchema = z
   })
   .openapi("CurriculoGradeResponse");
 
+/** Registra os paths de currículos no registry OpenAPI. */
 export function registerCurriculosPaths(registry: OpenAPIRegistry, schemas: CommonSchemas): void {
   const { errorResponses } = schemas;
   registry.registerPath({

--- a/src/lib/server/openapi/paths/curriculos.ts
+++ b/src/lib/server/openapi/paths/curriculos.ts
@@ -1,0 +1,72 @@
+import { z } from "zod";
+import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
+
+import { errorResponses } from "../common-schemas";
+
+/**
+ * Discipline inside a curriculum grid — summary fields only.
+ */
+const gradeDisciplinaSchema = z
+  .object({
+    id: z.string().uuid(),
+    codigo: z.string().openapi({ example: "DCE1001" }),
+    nome: z.string().openapi({ example: "Introdução à Computação" }),
+    cargaHoraria: z.number().int().optional(),
+    creditos: z.number().int().optional(),
+    natureza: z.enum(["OBRIGATORIA", "OPTATIVA", "ELETIVA", "COMPLEMENTAR"]).optional().openapi({
+      description: "Discipline nature inside this curriculum (required, optional, etc).",
+      example: "OBRIGATORIA",
+    }),
+  })
+  .openapi("GradeDisciplina");
+
+/**
+ * A single period/semester in a curriculum grid, containing the disciplines
+ * that should be taken during that period.
+ */
+const gradePeriodoSchema = z
+  .object({
+    periodo: z.number().int().openapi({ example: 1 }),
+    disciplinas: z.array(gradeDisciplinaSchema),
+  })
+  .openapi("GradePeriodo");
+
+/**
+ * Full curriculum grid response. The shape is the one returned by
+ * curriculosRepository.findActiveGradeByCursoId — an active grade per course.
+ */
+const curriculoGradeResponseSchema = z
+  .object({
+    id: z.string().uuid(),
+    cursoId: z.string().uuid(),
+    nome: z.string().openapi({ example: "Grade 2020.1" }),
+    ativo: z.boolean().openapi({ example: true }),
+    periodos: z.array(gradePeriodoSchema),
+  })
+  .openapi("CurriculoGradeResponse");
+
+export function registerCurriculosPaths(registry: OpenAPIRegistry): void {
+  registry.registerPath({
+    method: "get",
+    path: "/curriculos/grade",
+    tags: ["Curricula"],
+    summary: "Get the active curriculum grid for a course",
+    description:
+      "Public endpoint returning the currently active curriculum grid for a specific course, organized by semester. Used by the curriculum browser page to display the discipline tree. Requires the `cursoId` query parameter — returns 400 if missing and 404 if no active grid exists for that course.",
+    request: {
+      query: z.object({
+        cursoId: z.string().uuid().openapi({
+          description: "Course id to fetch the active curriculum grid for.",
+          example: "550e8400-e29b-41d4-a716-446655440000",
+        }),
+      }),
+    },
+    responses: {
+      200: {
+        description: "Active curriculum grid organized by period.",
+        content: { "application/json": { schema: curriculoGradeResponseSchema } },
+      },
+      ...errorResponses([400, 404, 500]),
+    },
+  });
+}

--- a/src/lib/server/openapi/paths/curriculos.ts
+++ b/src/lib/server/openapi/paths/curriculos.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 
-import { errorResponses } from "../common-schemas";
+import type { CommonSchemas } from "../common-schemas";
 
 /**
  * Discipline inside a curriculum grid — summary fields only.
@@ -45,7 +45,8 @@ const curriculoGradeResponseSchema = z
   })
   .openapi("CurriculoGradeResponse");
 
-export function registerCurriculosPaths(registry: OpenAPIRegistry): void {
+export function registerCurriculosPaths(registry: OpenAPIRegistry, schemas: CommonSchemas): void {
+  const { errorResponses } = schemas;
   registry.registerPath({
     method: "get",
     path: "/curriculos/grade",

--- a/src/lib/server/openapi/paths/curriculos.ts
+++ b/src/lib/server/openapi/paths/curriculos.ts
@@ -54,7 +54,7 @@ export function registerCurriculosPaths(registry: OpenAPIRegistry, schemas: Comm
       "Retorna a grade curricular ativa de um curso, organizada por período. Retorna 400 se `cursoId` não for informado e 404 se o curso não tiver grade ativa.",
     request: {
       query: z.object({
-        cursoId: z.string().uuid().openapi({
+        cursoId: z.string().min(1).openapi({
           description: "ID do curso.",
           example: "550e8400-e29b-41d4-a716-446655440000",
         }),

--- a/src/lib/server/openapi/paths/curriculos.ts
+++ b/src/lib/server/openapi/paths/curriculos.ts
@@ -67,7 +67,7 @@ export function registerCurriculosPaths(registry: OpenAPIRegistry, schemas: Comm
         description: "Active curriculum grid organized by period.",
         content: { "application/json": { schema: curriculoGradeResponseSchema } },
       },
-      ...errorResponses([400, 404, 500]),
+      ...errorResponses([400, 404]),
     },
   });
 }

--- a/src/lib/server/openapi/paths/cursos.ts
+++ b/src/lib/server/openapi/paths/cursos.ts
@@ -4,9 +4,9 @@ import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 import type { CommonSchemas } from "../common-schemas";
 
 /**
- * Curso (course/major) response shape. The handlers do not use Zod schemas
- * for request validation (they check fields inline), so we define request
- * and response schemas here directly.
+ * Shape de resposta de Curso. Os handlers não usam Zod para validar requests
+ * (validam os campos inline), então definimos os schemas de request e response
+ * diretamente aqui.
  */
 const cursoResponseSchema = z
   .object({
@@ -28,13 +28,13 @@ export function registerCursosPaths(registry: OpenAPIRegistry, schemas: CommonSc
   registry.registerPath({
     method: "get",
     path: "/cursos",
-    tags: ["Courses"],
-    summary: "List all courses",
+    tags: ["Cursos"],
+    summary: "Listar todos os cursos",
     description:
-      "Public endpoint returning all courses (majors) across all centros. Used by the registration form, curriculum browser and search.",
+      "Retorna todos os cursos de todos os centros. Usado pelo formulário de cadastro, pelo navegador de currículo e pela busca.",
     responses: {
       200: {
-        description: "List of all courses.",
+        description: "Lista de todos os cursos.",
         content: { "application/json": { schema: z.array(cursoResponseSchema) } },
       },
     },
@@ -43,10 +43,10 @@ export function registerCursosPaths(registry: OpenAPIRegistry, schemas: CommonSc
   registry.registerPath({
     method: "post",
     path: "/cursos",
-    tags: ["Courses"],
-    summary: "Create a new course (admin only)",
+    tags: ["Cursos"],
+    summary: "Criar um novo curso (admin)",
     description:
-      "Admin-only endpoint to create a new course. Both `nome` and `centroId` are required.",
+      "Endpoint exclusivo para administradores. Tanto `nome` quanto `centroId` são obrigatórios.",
     security: [{ bearerAuth: [] }],
     request: {
       body: {
@@ -64,7 +64,7 @@ export function registerCursosPaths(registry: OpenAPIRegistry, schemas: CommonSc
     },
     responses: {
       201: {
-        description: "Course created.",
+        description: "Curso criado.",
         content: { "application/json": { schema: cursoResponseSchema } },
       },
       ...errorResponses([400]),
@@ -74,9 +74,10 @@ export function registerCursosPaths(registry: OpenAPIRegistry, schemas: CommonSc
   registry.registerPath({
     method: "put",
     path: "/cursos/{id}",
-    tags: ["Courses"],
-    summary: "Update a course (admin only)",
-    description: "Admin-only endpoint to update a course's name and/or centro.",
+    tags: ["Cursos"],
+    summary: "Atualizar um curso (admin)",
+    description:
+      "Endpoint exclusivo para administradores. Atualiza o nome e/ou o centro de um curso.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({ id: z.string().uuid() }),
@@ -95,7 +96,7 @@ export function registerCursosPaths(registry: OpenAPIRegistry, schemas: CommonSc
     },
     responses: {
       200: {
-        description: "Course updated.",
+        description: "Curso atualizado.",
         content: { "application/json": { schema: cursoResponseSchema } },
       },
       ...errorResponses([400, 404]),
@@ -105,17 +106,17 @@ export function registerCursosPaths(registry: OpenAPIRegistry, schemas: CommonSc
   registry.registerPath({
     method: "delete",
     path: "/cursos/{id}",
-    tags: ["Courses"],
-    summary: "Delete a course (admin only)",
+    tags: ["Cursos"],
+    summary: "Excluir um curso (admin)",
     description:
-      "Admin-only endpoint to delete a course. **Returns 409 with `HAS_DEPENDENCIES` if there are curriculos, guias, or usuarios linked to this course** — you must remove/reassign dependencies before deleting. The error message lists the counts.",
+      "Endpoint exclusivo para administradores. **Retorna 409 com `HAS_DEPENDENCIES` se houver currículos, guias ou usuários vinculados a este curso** — é necessário remover/reatribuir as dependências antes de excluir. A mensagem de erro lista as contagens.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({ id: z.string().uuid() }),
     },
     responses: {
       200: {
-        description: "Course deleted.",
+        description: "Curso excluído.",
         content: {
           "application/json": {
             schema: z.object({ success: z.literal(true) }),

--- a/src/lib/server/openapi/paths/cursos.ts
+++ b/src/lib/server/openapi/paths/cursos.ts
@@ -23,6 +23,7 @@ const createOrUpdateCursoSchema = z
   })
   .openapi("CreateOrUpdateCursoRequest");
 
+/** Registra os paths de cursos no registry OpenAPI. */
 export function registerCursosPaths(registry: OpenAPIRegistry, schemas: CommonSchemas): void {
   const { errorResponses } = schemas;
   registry.registerPath({

--- a/src/lib/server/openapi/paths/cursos.ts
+++ b/src/lib/server/openapi/paths/cursos.ts
@@ -16,6 +16,7 @@ const cursoResponseSchema = z
   })
   .openapi("CursoResponse");
 
+/** Schema de request para criar ou atualizar um curso. */
 const createOrUpdateCursoSchema = z
   .object({
     nome: z.string().min(1).openapi({ example: "Ciência da Computação" }),

--- a/src/lib/server/openapi/paths/cursos.ts
+++ b/src/lib/server/openapi/paths/cursos.ts
@@ -1,0 +1,129 @@
+import { z } from "zod";
+import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
+
+import { errorResponses } from "../common-schemas";
+
+/**
+ * Curso (course/major) response shape. The handlers do not use Zod schemas
+ * for request validation (they check fields inline), so we define request
+ * and response schemas here directly.
+ */
+const cursoResponseSchema = z
+  .object({
+    id: z.string().uuid(),
+    nome: z.string().openapi({ example: "Ciência da Computação" }),
+    centroId: z.string().uuid(),
+  })
+  .openapi("CursoResponse");
+
+const createOrUpdateCursoSchema = z
+  .object({
+    nome: z.string().min(1).openapi({ example: "Ciência da Computação" }),
+    centroId: z.string().uuid().openapi({ example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890" }),
+  })
+  .openapi("CreateOrUpdateCursoRequest");
+
+export function registerCursosPaths(registry: OpenAPIRegistry): void {
+  registry.registerPath({
+    method: "get",
+    path: "/cursos",
+    tags: ["Courses"],
+    summary: "List all courses",
+    description:
+      "Public endpoint returning all courses (majors) across all centros. Used by the registration form, curriculum browser and search.",
+    responses: {
+      200: {
+        description: "List of all courses.",
+        content: { "application/json": { schema: z.array(cursoResponseSchema) } },
+      },
+      ...errorResponses([500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/cursos",
+    tags: ["Courses"],
+    summary: "Create a new course (admin only)",
+    description:
+      "Admin-only endpoint to create a new course. Both `nome` and `centroId` are required.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: createOrUpdateCursoSchema,
+            example: {
+              nome: "Sistemas de Informação",
+              centroId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      201: {
+        description: "Course created.",
+        content: { "application/json": { schema: cursoResponseSchema } },
+      },
+      ...errorResponses([400, 401, 403, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "put",
+    path: "/cursos/{id}",
+    tags: ["Courses"],
+    summary: "Update a course (admin only)",
+    description: "Admin-only endpoint to update a course's name and/or centro.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      params: z.object({ id: z.string().uuid() }),
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: createOrUpdateCursoSchema,
+            example: {
+              nome: "Ciência da Computação",
+              centroId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Course updated.",
+        content: { "application/json": { schema: cursoResponseSchema } },
+      },
+      ...errorResponses([400, 401, 403, 404, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "delete",
+    path: "/cursos/{id}",
+    tags: ["Courses"],
+    summary: "Delete a course (admin only)",
+    description:
+      "Admin-only endpoint to delete a course. **Returns 409 with `HAS_DEPENDENCIES` if there are curriculos, guias, or usuarios linked to this course** — you must remove/reassign dependencies before deleting. The error message lists the counts.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      params: z.object({ id: z.string().uuid() }),
+    },
+    responses: {
+      200: {
+        description: "Course deleted.",
+        content: {
+          "application/json": {
+            schema: z.object({ success: z.literal(true) }),
+            example: { success: true },
+          },
+        },
+      },
+      ...errorResponses([401, 403, 404, 409, 500]),
+    },
+  });
+}

--- a/src/lib/server/openapi/paths/cursos.ts
+++ b/src/lib/server/openapi/paths/cursos.ts
@@ -99,7 +99,9 @@ export function registerCursosPaths(registry: OpenAPIRegistry, schemas: CommonSc
         description: "Curso atualizado.",
         content: { "application/json": { schema: cursoResponseSchema } },
       },
-      ...errorResponses([400, 404]),
+      ...errorResponses([400, 404], {
+        404: { message: "Curso não encontrado", code: "NOT_FOUND" },
+      }),
     },
   });
 
@@ -124,7 +126,13 @@ export function registerCursosPaths(registry: OpenAPIRegistry, schemas: CommonSc
           },
         },
       },
-      ...errorResponses([404, 409]),
+      ...errorResponses([404, 409], {
+        404: { message: "Curso não encontrado", code: "NOT_FOUND" },
+        409: {
+          message: "Não é possível excluir: existem 2 currículo(s), 1 guia(s) vinculado(s)",
+          code: "HAS_DEPENDENCIES",
+        },
+      }),
     },
   });
 }

--- a/src/lib/server/openapi/paths/cursos.ts
+++ b/src/lib/server/openapi/paths/cursos.ts
@@ -37,7 +37,6 @@ export function registerCursosPaths(registry: OpenAPIRegistry, schemas: CommonSc
         description: "List of all courses.",
         content: { "application/json": { schema: z.array(cursoResponseSchema) } },
       },
-      ...errorResponses([500]),
     },
   });
 
@@ -68,7 +67,7 @@ export function registerCursosPaths(registry: OpenAPIRegistry, schemas: CommonSc
         description: "Course created.",
         content: { "application/json": { schema: cursoResponseSchema } },
       },
-      ...errorResponses([400, 401, 403, 500]),
+      ...errorResponses([400]),
     },
   });
 
@@ -99,7 +98,7 @@ export function registerCursosPaths(registry: OpenAPIRegistry, schemas: CommonSc
         description: "Course updated.",
         content: { "application/json": { schema: cursoResponseSchema } },
       },
-      ...errorResponses([400, 401, 403, 404, 500]),
+      ...errorResponses([400, 404]),
     },
   });
 
@@ -124,7 +123,7 @@ export function registerCursosPaths(registry: OpenAPIRegistry, schemas: CommonSc
           },
         },
       },
-      ...errorResponses([401, 403, 404, 409, 500]),
+      ...errorResponses([404, 409]),
     },
   });
 }

--- a/src/lib/server/openapi/paths/cursos.ts
+++ b/src/lib/server/openapi/paths/cursos.ts
@@ -79,7 +79,7 @@ export function registerCursosPaths(registry: OpenAPIRegistry, schemas: CommonSc
     tags: ["Cursos"],
     summary: "Atualizar um curso (admin)",
     description:
-      "Endpoint exclusivo para administradores. Atualiza o nome e/ou o centro de um curso.",
+      "Endpoint exclusivo para administradores. Ambos os campos (`nome` e `centroId`) são obrigatórios.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({ id: z.string().uuid() }),

--- a/src/lib/server/openapi/paths/cursos.ts
+++ b/src/lib/server/openapi/paths/cursos.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 
-import { errorResponses } from "../common-schemas";
+import type { CommonSchemas } from "../common-schemas";
 
 /**
  * Curso (course/major) response shape. The handlers do not use Zod schemas
@@ -23,7 +23,8 @@ const createOrUpdateCursoSchema = z
   })
   .openapi("CreateOrUpdateCursoRequest");
 
-export function registerCursosPaths(registry: OpenAPIRegistry): void {
+export function registerCursosPaths(registry: OpenAPIRegistry, schemas: CommonSchemas): void {
+  const { errorResponses } = schemas;
   registry.registerPath({
     method: "get",
     path: "/cursos",

--- a/src/lib/server/openapi/paths/disciplinas.ts
+++ b/src/lib/server/openapi/paths/disciplinas.ts
@@ -23,8 +23,7 @@ const disciplinaSearchItemSchema = z
   })
   .openapi("DisciplinaSearchItem");
 
-export function registerDisciplinasPaths(registry: OpenAPIRegistry, schemas: CommonSchemas): void {
-  const { errorResponses } = schemas;
+export function registerDisciplinasPaths(registry: OpenAPIRegistry, _schemas: CommonSchemas): void {
   registry.registerPath({
     method: "get",
     path: "/disciplinas/search",

--- a/src/lib/server/openapi/paths/disciplinas.ts
+++ b/src/lib/server/openapi/paths/disciplinas.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
+
+import { errorResponses } from "../common-schemas";
+
+/**
+ * Discipline (course subject) summary returned by the disciplines search endpoint.
+ */
+const disciplinaSearchItemSchema = z
+  .object({
+    id: z.string().uuid(),
+    codigo: z.string().openapi({
+      description: "Official discipline code (SIGGA/PAAS format).",
+      example: "DCE1001",
+    }),
+    nome: z.string().openapi({ example: "Introdução à Computação" }),
+    cargaHoraria: z.number().int().optional().openapi({
+      description: "Workload in hours.",
+      example: 60,
+    }),
+    creditos: z.number().int().optional().openapi({ example: 4 }),
+    departamento: z.string().nullable().optional(),
+  })
+  .openapi("DisciplinaSearchItem");
+
+export function registerDisciplinasPaths(registry: OpenAPIRegistry): void {
+  registry.registerPath({
+    method: "get",
+    path: "/disciplinas/search",
+    tags: ["Disciplines"],
+    summary: "Search disciplines by code or name",
+    description:
+      "Public endpoint to search for disciplines by their official code (e.g., `DCE1001`) or by name substring. Queries shorter than 2 characters return an empty result set without hitting the database. Used by the curriculum picker during onboarding and semester discipline management.",
+    request: {
+      query: z.object({
+        q: z.string().min(2).openapi({
+          description:
+            "Search query — discipline code or name. Minimum 2 characters; shorter queries return an empty array without hitting the database.",
+          example: "DCE1001",
+        }),
+      }),
+    },
+    responses: {
+      200: {
+        description: "Disciplines matching the query. Empty array if none match.",
+        content: {
+          "application/json": {
+            schema: z.object({
+              disciplinas: z.array(disciplinaSearchItemSchema),
+            }),
+            example: {
+              disciplinas: [
+                {
+                  id: "550e8400-e29b-41d4-a716-446655440000",
+                  codigo: "DCE1001",
+                  nome: "Introdução à Computação",
+                  cargaHoraria: 60,
+                  creditos: 4,
+                  departamento: "DCE",
+                },
+              ],
+            },
+          },
+        },
+      },
+      ...errorResponses([500]),
+    },
+  });
+}

--- a/src/lib/server/openapi/paths/disciplinas.ts
+++ b/src/lib/server/openapi/paths/disciplinas.ts
@@ -33,8 +33,9 @@ export function registerDisciplinasPaths(registry: OpenAPIRegistry, _schemas: Co
       "Busca disciplinas pelo código oficial (ex: `DCE1001`) ou por parte do nome. Buscas com menos de 2 caracteres retornam array vazio sem consultar o banco.",
     request: {
       query: z.object({
-        q: z.string().min(2).openapi({
-          description: "Termo de busca — código ou nome da disciplina. Mínimo de 2 caracteres.",
+        q: z.string().optional().openapi({
+          description:
+            "Termo de busca — código ou nome da disciplina. Se ausente ou com menos de 2 caracteres, retorna lista vazia.",
           example: "DCE1001",
         }),
       }),

--- a/src/lib/server/openapi/paths/disciplinas.ts
+++ b/src/lib/server/openapi/paths/disciplinas.ts
@@ -4,18 +4,18 @@ import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 import type { CommonSchemas } from "../common-schemas";
 
 /**
- * Discipline (course subject) summary returned by the disciplines search endpoint.
+ * Resumo de disciplina retornado pelo endpoint de busca.
  */
 const disciplinaSearchItemSchema = z
   .object({
     id: z.string().uuid(),
     codigo: z.string().openapi({
-      description: "Official discipline code (SIGGA/PAAS format).",
+      description: "Código oficial da disciplina (formato SIGGA/PAAS).",
       example: "DCE1001",
     }),
     nome: z.string().openapi({ example: "Introdução à Computação" }),
     cargaHoraria: z.number().int().optional().openapi({
-      description: "Workload in hours.",
+      description: "Carga horária em horas.",
       example: 60,
     }),
     creditos: z.number().int().optional().openapi({ example: 4 }),
@@ -28,22 +28,21 @@ export function registerDisciplinasPaths(registry: OpenAPIRegistry, schemas: Com
   registry.registerPath({
     method: "get",
     path: "/disciplinas/search",
-    tags: ["Disciplines"],
-    summary: "Search disciplines by code or name",
+    tags: ["Disciplinas"],
+    summary: "Buscar disciplinas por código ou nome",
     description:
-      "Public endpoint to search for disciplines by their official code (e.g., `DCE1001`) or by name substring. Queries shorter than 2 characters return an empty result set without hitting the database. Used by the curriculum picker during onboarding and semester discipline management.",
+      "Busca disciplinas pelo código oficial (ex: `DCE1001`) ou por parte do nome. Buscas com menos de 2 caracteres retornam array vazio sem consultar o banco.",
     request: {
       query: z.object({
         q: z.string().min(2).openapi({
-          description:
-            "Search query — discipline code or name. Minimum 2 characters; shorter queries return an empty array without hitting the database.",
+          description: "Termo de busca — código ou nome da disciplina. Mínimo de 2 caracteres.",
           example: "DCE1001",
         }),
       }),
     },
     responses: {
       200: {
-        description: "Disciplines matching the query. Empty array if none match.",
+        description: "Disciplinas correspondentes à busca.",
         content: {
           "application/json": {
             schema: z.object({

--- a/src/lib/server/openapi/paths/disciplinas.ts
+++ b/src/lib/server/openapi/paths/disciplinas.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 
-import { errorResponses } from "../common-schemas";
+import type { CommonSchemas } from "../common-schemas";
 
 /**
  * Discipline (course subject) summary returned by the disciplines search endpoint.
@@ -23,7 +23,8 @@ const disciplinaSearchItemSchema = z
   })
   .openapi("DisciplinaSearchItem");
 
-export function registerDisciplinasPaths(registry: OpenAPIRegistry): void {
+export function registerDisciplinasPaths(registry: OpenAPIRegistry, schemas: CommonSchemas): void {
+  const { errorResponses } = schemas;
   registry.registerPath({
     method: "get",
     path: "/disciplinas/search",

--- a/src/lib/server/openapi/paths/disciplinas.ts
+++ b/src/lib/server/openapi/paths/disciplinas.ts
@@ -64,7 +64,6 @@ export function registerDisciplinasPaths(registry: OpenAPIRegistry, schemas: Com
           },
         },
       },
-      ...errorResponses([500]),
     },
   });
 }

--- a/src/lib/server/openapi/paths/disciplinas.ts
+++ b/src/lib/server/openapi/paths/disciplinas.ts
@@ -23,6 +23,7 @@ const disciplinaSearchItemSchema = z
   })
   .openapi("DisciplinaSearchItem");
 
+/** Registra os paths de disciplinas no registry OpenAPI. */
 export function registerDisciplinasPaths(registry: OpenAPIRegistry, _schemas: CommonSchemas): void {
   registry.registerPath({
     method: "get",

--- a/src/lib/server/openapi/paths/entidades.ts
+++ b/src/lib/server/openapi/paths/entidades.ts
@@ -1,10 +1,13 @@
 import { z } from "zod";
 import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 
-import { updateEntidadeSchema } from "@/app/api/entidades/[id]/route";
-import { addMemberSchema } from "@/app/api/entidades/[id]/membros/route";
-import { updateMemberSchema } from "@/app/api/entidades/[id]/membros/[membroId]/route";
-import { createCargoSchema, updateCargoSchema } from "@/app/api/entidades/[id]/cargos/route";
+import {
+  updateEntidadeSchema,
+  addMemberSchema,
+  updateMemberSchema,
+  createCargoSchema,
+  updateCargoSchema,
+} from "@/lib/server/api-schemas/entidades";
 
 import type { CommonSchemas } from "../common-schemas";
 

--- a/src/lib/server/openapi/paths/entidades.ts
+++ b/src/lib/server/openapi/paths/entidades.ts
@@ -323,7 +323,7 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
         },
       },
       ...errorResponses([400, 404], {
-        404: { message: "Entidade não encontrada", code: "ENTIDADE_NOT_FOUND" },
+        404: { message: "Membresia não encontrada", code: "MEMBRO_NOT_FOUND" },
       }),
     },
   });

--- a/src/lib/server/openapi/paths/entidades.ts
+++ b/src/lib/server/openapi/paths/entidades.ts
@@ -177,7 +177,9 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
         description: "Perfil da entidade com membros e cargos embutidos.",
         content: { "application/json": { schema: entidadeResponseSchema } },
       },
-      ...errorResponses([404]),
+      ...errorResponses([404], {
+        404: { message: "Entidade não encontrada", code: "ENTIDADE_NOT_FOUND" },
+      }),
     },
   });
 
@@ -215,7 +217,9 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
           },
         },
       },
-      ...errorResponses([400, 404]),
+      ...errorResponses([400, 404], {
+        404: { message: "Entidade não encontrada", code: "ENTIDADE_NOT_FOUND" },
+      }),
     },
   });
 
@@ -249,7 +253,13 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
         description: "Membro adicionado.",
         content: { "application/json": { schema: entidadeMembershipResponseSchema } },
       },
-      ...errorResponses([400, 404, 409]),
+      ...errorResponses([400, 404, 409], {
+        404: { message: "Entidade não encontrada", code: "ENTIDADE_NOT_FOUND" },
+        409: {
+          message: "Este usuário já é membro ativo desta entidade",
+          code: "ALREADY_MEMBER",
+        },
+      }),
     },
   });
 
@@ -281,7 +291,9 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
         description: "Membro atualizado.",
         content: { "application/json": { schema: entidadeMembershipResponseSchema } },
       },
-      ...errorResponses([400, 404]),
+      ...errorResponses([400, 404], {
+        404: { message: "Membresia não encontrada", code: "MEMBRO_NOT_FOUND" },
+      }),
     },
   });
 
@@ -308,7 +320,9 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
           },
         },
       },
-      ...errorResponses([400, 404]),
+      ...errorResponses([400, 404], {
+        404: { message: "Entidade não encontrada", code: "ENTIDADE_NOT_FOUND" },
+      }),
     },
   });
 
@@ -358,7 +372,9 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
         description: "Cargo criado.",
         content: { "application/json": { schema: cargoResponseSchema } },
       },
-      ...errorResponses([400, 404]),
+      ...errorResponses([400, 404], {
+        404: { message: "Entidade não encontrada", code: "ENTIDADE_NOT_FOUND" },
+      }),
     },
   });
 
@@ -387,7 +403,9 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
         description: "Cargo atualizado.",
         content: { "application/json": { schema: cargoResponseSchema } },
       },
-      ...errorResponses([400, 404]),
+      ...errorResponses([400, 404], {
+        404: { message: "Cargo não encontrado", code: "CARGO_NOT_FOUND" },
+      }),
     },
   });
 
@@ -418,7 +436,9 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
           },
         },
       },
-      ...errorResponses([400, 404]),
+      ...errorResponses([400, 404], {
+        404: { message: "Cargo não encontrado", code: "CARGO_NOT_FOUND" },
+      }),
     },
   });
 }

--- a/src/lib/server/openapi/paths/entidades.ts
+++ b/src/lib/server/openapi/paths/entidades.ts
@@ -12,8 +12,8 @@ import {
 import type { CommonSchemas } from "../common-schemas";
 
 /**
- * Enum of entity types (LABORATORIO, GRUPO, etc). Mirrors the values accepted
- * by updateEntidadeSchema's `tipo` field.
+ * Enum dos tipos de entidade (LABORATORIO, GRUPO, etc). Espelha os valores
+ * aceitos pelo campo `tipo` em updateEntidadeSchema.
  */
 const tipoEntidadeSchema = z
   .enum([
@@ -27,13 +27,14 @@ const tipoEntidadeSchema = z
   ])
   .openapi({
     description:
-      "Entity category. PET groups are modeled under 'GRUPO'. Student unions (DCEs, centros acadêmicos) use 'CENTRO_ACADEMICO'.",
+      "Categoria da entidade. Grupos PET são modelados como 'GRUPO'. DCEs e centros acadêmicos usam 'CENTRO_ACADEMICO'.",
     example: "GRUPO",
   });
 
 /**
- * Public entidade shape returned by GET /entidades, GET /entidades/slug/{slug}, etc.
- * Includes the embedded centro and — when loaded — the list of active memberships.
+ * Shape público de Entidade, retornado por GET /entidades, GET
+ * /entidades/slug/{slug}, etc. Inclui o centro embutido e — quando carregada —
+ * a lista de membros ativos.
  */
 const entidadeResponseSchema = z
   .object({
@@ -84,9 +85,9 @@ const entidadeResponseSchema = z
   .openapi("EntidadeResponse");
 
 /**
- * Response shape for entity-scoped membership endpoints (POST/PUT under
- * /entidades/{id}/membros). Differs from the user-scoped membership shape
- * in `paths/usuarios.ts` because it nests the user instead of the entity.
+ * Shape de resposta dos endpoints de membresia no escopo da entidade (POST/PUT
+ * em /entidades/{id}/membros). Difere do shape no escopo do usuário em
+ * `paths/usuarios.ts` porque aninha o usuário em vez da entidade.
  */
 const entidadeMembershipResponseSchema = z
   .object({
@@ -116,7 +117,7 @@ const entidadeMembershipResponseSchema = z
   .openapi("EntidadeMembershipResponse");
 
 /**
- * Cargo (role title) shape returned by cargos endpoints.
+ * Shape de Cargo retornado pelos endpoints de cargos.
  */
 const cargoResponseSchema = z
   .object({
@@ -131,13 +132,13 @@ const cargoResponseSchema = z
 const messageResponseSchema = z.object({ message: z.string() });
 
 /**
- * PUT cargo request body schema. Unlike POST which uses `createCargoSchema`,
- * the PUT handler expects `cargoId` in the body alongside the update fields.
+ * Schema do corpo de PUT cargo. Diferente do POST (que usa `createCargoSchema`),
+ * o handler de PUT espera `cargoId` no corpo junto com os campos de atualização.
  */
 const updateCargoRequestSchema = updateCargoSchema
   .extend({
     cargoId: z.string().uuid().openapi({
-      description: "ID of the cargo to update. Sent in the body (not the URL) on PUT requests.",
+      description: "ID do cargo a atualizar. Enviado no corpo (não na URL) em requisições PUT.",
     }),
   })
   .openapi("UpdateCargoRequest");
@@ -147,13 +148,13 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
   registry.registerPath({
     method: "get",
     path: "/entidades",
-    tags: ["Entities"],
-    summary: "List all entities",
+    tags: ["Entidades"],
+    summary: "Listar todas as entidades",
     description:
-      "Public endpoint returning all entities (labs, PET groups, student unions, companies, athletics associations) registered in the system. Results include the embedded centro but not the full member list — fetch that via GET /entidades/slug/{slug} or /entidades/{id}/membros.",
+      "Retorna todas as entidades cadastradas (laboratórios, PETs, centros acadêmicos, empresas júnior, atléticas). Os resultados incluem o centro embutido, mas não a lista completa de membros — para isso use GET /entidades/slug/{slug} ou /entidades/{id}/membros.",
     responses: {
       200: {
-        description: "List of all entities.",
+        description: "Lista de todas as entidades.",
         content: { "application/json": { schema: z.array(entidadeResponseSchema) } },
       },
     },
@@ -162,10 +163,10 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
   registry.registerPath({
     method: "get",
     path: "/entidades/slug/{slug}",
-    tags: ["Entities"],
-    summary: "Look up an entity by slug",
+    tags: ["Entidades"],
+    summary: "Buscar uma entidade pelo slug",
     description:
-      "Public endpoint to fetch an entity's full profile (with members and cargos) by its URL slug. Used by the `/entidade/[slug]` pages.",
+      "Retorna o perfil completo de uma entidade (com membros e cargos) pelo slug da URL. Usado pelas páginas `/entidade/[slug]`.",
     request: {
       params: z.object({
         slug: z.string().openapi({ example: "pet-computacao" }),
@@ -173,7 +174,7 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
     },
     responses: {
       200: {
-        description: "Entity profile with embedded members and cargos.",
+        description: "Perfil da entidade com membros e cargos embutidos.",
         content: { "application/json": { schema: entidadeResponseSchema } },
       },
       ...errorResponses([404]),
@@ -183,10 +184,10 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
   registry.registerPath({
     method: "put",
     path: "/entidades/{id}",
-    tags: ["Entities"],
-    summary: "Update an entity",
+    tags: ["Entidades"],
+    summary: "Atualizar uma entidade",
     description:
-      "Update entity fields. Requires MASTER_ADMIN or an active ADMIN membership in the entity.",
+      "Atualiza campos da entidade. Requer MASTER_ADMIN ou uma membresia ADMIN ativa na entidade.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({ id: z.string().uuid() }),
@@ -206,7 +207,7 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
     },
     responses: {
       200: {
-        description: "Entity updated.",
+        description: "Entidade atualizada.",
         content: {
           "application/json": {
             schema: messageResponseSchema,
@@ -221,10 +222,10 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
   registry.registerPath({
     method: "post",
     path: "/entidades/{id}/membros",
-    tags: ["Entities"],
-    summary: "Add a member to an entity",
+    tags: ["Entidades"],
+    summary: "Adicionar um membro à entidade",
     description:
-      "Add a user as a member. Requires MASTER_ADMIN or entity ADMIN. For self-joining, use `POST /usuarios/me/membros`.",
+      "Adiciona um usuário como membro. Requer MASTER_ADMIN ou ADMIN da entidade. Para o usuário entrar sozinho, use `POST /usuarios/me/membros`.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({ id: z.string().uuid() }),
@@ -245,7 +246,7 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
     },
     responses: {
       200: {
-        description: "Member added.",
+        description: "Membro adicionado.",
         content: { "application/json": { schema: entidadeMembershipResponseSchema } },
       },
       ...errorResponses([400, 404, 409]),
@@ -255,10 +256,10 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
   registry.registerPath({
     method: "put",
     path: "/entidades/{id}/membros/{membroId}",
-    tags: ["Entities"],
-    summary: "Update a member of an entity",
+    tags: ["Entidades"],
+    summary: "Atualizar um membro da entidade",
     description:
-      "Update a member. Requires MASTER_ADMIN or entity ADMIN. For self-management, use `PUT /usuarios/me/membros/{membroId}`.",
+      "Atualiza um membro. Requer MASTER_ADMIN ou ADMIN da entidade. Para o próprio usuário se gerenciar, use `PUT /usuarios/me/membros/{membroId}`.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({
@@ -277,7 +278,7 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
     },
     responses: {
       200: {
-        description: "Member updated.",
+        description: "Membro atualizado.",
         content: { "application/json": { schema: entidadeMembershipResponseSchema } },
       },
       ...errorResponses([400, 404]),
@@ -287,9 +288,9 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
   registry.registerPath({
     method: "delete",
     path: "/entidades/{id}/membros/{membroId}",
-    tags: ["Entities"],
-    summary: "Remove a member from an entity",
-    description: "Delete a membership. Requires MASTER_ADMIN or entity ADMIN.",
+    tags: ["Entidades"],
+    summary: "Remover um membro da entidade",
+    description: "Exclui uma membresia. Requer MASTER_ADMIN ou ADMIN da entidade.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({
@@ -299,7 +300,7 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
     },
     responses: {
       200: {
-        description: "Member removed.",
+        description: "Membro removido.",
         content: {
           "application/json": {
             schema: messageResponseSchema,
@@ -314,16 +315,16 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
   registry.registerPath({
     method: "get",
     path: "/entidades/{id}/cargos",
-    tags: ["Entities"],
-    summary: "List all cargos for an entity",
+    tags: ["Entidades"],
+    summary: "Listar cargos de uma entidade",
     description:
-      "List cargos (role titles) defined for this entity. Used as `cargoId` when creating memberships.",
+      "Lista os cargos definidos para esta entidade. Usados como `cargoId` ao criar membresias.",
     request: {
       params: z.object({ id: z.string().uuid() }),
     },
     responses: {
       200: {
-        description: "List of cargos.",
+        description: "Lista de cargos.",
         content: { "application/json": { schema: z.array(cargoResponseSchema) } },
       },
     },
@@ -332,9 +333,9 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
   registry.registerPath({
     method: "post",
     path: "/entidades/{id}/cargos",
-    tags: ["Entities"],
-    summary: "Create a new cargo for an entity",
-    description: "Create a new cargo. Requires MASTER_ADMIN or entity ADMIN.",
+    tags: ["Entidades"],
+    summary: "Criar um novo cargo para uma entidade",
+    description: "Cria um novo cargo. Requer MASTER_ADMIN ou ADMIN da entidade.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({ id: z.string().uuid() }),
@@ -354,7 +355,7 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
     },
     responses: {
       200: {
-        description: "Cargo created.",
+        description: "Cargo criado.",
         content: { "application/json": { schema: cargoResponseSchema } },
       },
       ...errorResponses([400, 404]),
@@ -364,10 +365,10 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
   registry.registerPath({
     method: "put",
     path: "/entidades/{id}/cargos",
-    tags: ["Entities"],
-    summary: "Update a cargo for an entity",
+    tags: ["Entidades"],
+    summary: "Atualizar um cargo de uma entidade",
     description:
-      "Update a cargo. **Unusual:** `cargoId` is in the body, not the URL. Requires MASTER_ADMIN or entity ADMIN.",
+      "Atualiza um cargo. **Atenção:** `cargoId` vai no corpo, não na URL. Requer MASTER_ADMIN ou ADMIN da entidade.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({ id: z.string().uuid() }),
@@ -383,7 +384,7 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
     },
     responses: {
       200: {
-        description: "Cargo updated.",
+        description: "Cargo atualizado.",
         content: { "application/json": { schema: cargoResponseSchema } },
       },
       ...errorResponses([400, 404]),
@@ -393,23 +394,23 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
   registry.registerPath({
     method: "delete",
     path: "/entidades/{id}/cargos",
-    tags: ["Entities"],
-    summary: "Delete a cargo from an entity",
+    tags: ["Entidades"],
+    summary: "Excluir um cargo de uma entidade",
     description:
-      "Delete a cargo. **Unusual:** cargo id is a `?cargoId=` query param, not in the URL. Requires MASTER_ADMIN or entity ADMIN.",
+      "Exclui um cargo. **Atenção:** o ID do cargo é passado como query param `?cargoId=`, não na URL. Requer MASTER_ADMIN ou ADMIN da entidade.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({ id: z.string().uuid() }),
       query: z.object({
         cargoId: z.string().uuid().openapi({
-          description: "ID of the cargo to delete.",
+          description: "ID do cargo a excluir.",
           example: "550e8400-e29b-41d4-a716-446655440000",
         }),
       }),
     },
     responses: {
       200: {
-        description: "Cargo deleted.",
+        description: "Cargo excluído.",
         content: {
           "application/json": {
             schema: messageResponseSchema,

--- a/src/lib/server/openapi/paths/entidades.ts
+++ b/src/lib/server/openapi/paths/entidades.ts
@@ -129,6 +129,7 @@ const cargoResponseSchema = z
   })
   .openapi("CargoResponse");
 
+/** Resposta simples com mensagem de status. */
 const messageResponseSchema = z.object({ message: z.string() });
 
 /**

--- a/src/lib/server/openapi/paths/entidades.ts
+++ b/src/lib/server/openapi/paths/entidades.ts
@@ -143,6 +143,7 @@ const updateCargoRequestSchema = updateCargoSchema
   })
   .openapi("UpdateCargoRequest");
 
+/** Registra os paths de entidades no registry OpenAPI. */
 export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: CommonSchemas): void {
   const { errorResponses } = schemas;
   registry.registerPath({

--- a/src/lib/server/openapi/paths/entidades.ts
+++ b/src/lib/server/openapi/paths/entidades.ts
@@ -156,7 +156,6 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
         description: "List of all entities.",
         content: { "application/json": { schema: z.array(entidadeResponseSchema) } },
       },
-      ...errorResponses([500]),
     },
   });
 
@@ -177,7 +176,7 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
         description: "Entity profile with embedded members and cargos.",
         content: { "application/json": { schema: entidadeResponseSchema } },
       },
-      ...errorResponses([404, 500]),
+      ...errorResponses([404]),
     },
   });
 
@@ -187,7 +186,7 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
     tags: ["Entities"],
     summary: "Update an entity",
     description:
-      "Update entity fields (name, description, social links, etc). **Requires either MASTER_ADMIN role or an active ADMIN membership in the target entity.** All fields are optional — only provided fields are updated.",
+      "Update entity fields. Requires MASTER_ADMIN or an active ADMIN membership in the entity.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({ id: z.string().uuid() }),
@@ -215,7 +214,7 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
           },
         },
       },
-      ...errorResponses([400, 401, 403, 404, 500]),
+      ...errorResponses([400, 404]),
     },
   });
 
@@ -225,7 +224,7 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
     tags: ["Entities"],
     summary: "Add a member to an entity",
     description:
-      "Add a user as a member of the entity. **Requires either MASTER_ADMIN role or an active ADMIN membership in the target entity.** Returns 409 if the user is already an active member. To let users join entities themselves, use POST /usuarios/me/membros instead.",
+      "Add a user as a member. Requires MASTER_ADMIN or entity ADMIN. For self-joining, use `POST /usuarios/me/membros`.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({ id: z.string().uuid() }),
@@ -249,7 +248,7 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
         description: "Member added.",
         content: { "application/json": { schema: entidadeMembershipResponseSchema } },
       },
-      ...errorResponses([400, 401, 403, 404, 409, 500]),
+      ...errorResponses([400, 404, 409]),
     },
   });
 
@@ -259,7 +258,7 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
     tags: ["Entities"],
     summary: "Update a member of an entity",
     description:
-      "Update a member's role, cargo, or dates inside the entity. **Requires MASTER_ADMIN or active ADMIN membership in the entity.** To update your own membership (non-admin use case), use PUT /usuarios/me/membros/{membroId} instead.",
+      "Update a member. Requires MASTER_ADMIN or entity ADMIN. For self-management, use `PUT /usuarios/me/membros/{membroId}`.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({
@@ -281,7 +280,7 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
         description: "Member updated.",
         content: { "application/json": { schema: entidadeMembershipResponseSchema } },
       },
-      ...errorResponses([400, 401, 403, 404, 500]),
+      ...errorResponses([400, 404]),
     },
   });
 
@@ -290,8 +289,7 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
     path: "/entidades/{id}/membros/{membroId}",
     tags: ["Entities"],
     summary: "Remove a member from an entity",
-    description:
-      "Permanently delete a membership from the entity. **Requires MASTER_ADMIN or active ADMIN membership in the entity.**",
+    description: "Delete a membership. Requires MASTER_ADMIN or entity ADMIN.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({
@@ -309,7 +307,7 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
           },
         },
       },
-      ...errorResponses([400, 401, 403, 404, 500]),
+      ...errorResponses([400, 404]),
     },
   });
 
@@ -319,7 +317,7 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
     tags: ["Entities"],
     summary: "List all cargos for an entity",
     description:
-      "Public endpoint returning the list of cargos (role titles) defined for this entity. Cargos are used as the `cargoId` field when creating or updating memberships.",
+      "List cargos (role titles) defined for this entity. Used as `cargoId` when creating memberships.",
     request: {
       params: z.object({ id: z.string().uuid() }),
     },
@@ -328,7 +326,6 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
         description: "List of cargos.",
         content: { "application/json": { schema: z.array(cargoResponseSchema) } },
       },
-      ...errorResponses([500]),
     },
   });
 
@@ -337,8 +334,7 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
     path: "/entidades/{id}/cargos",
     tags: ["Entities"],
     summary: "Create a new cargo for an entity",
-    description:
-      "Define a new cargo (role title) in the entity. **Requires MASTER_ADMIN or active ADMIN membership in the entity.**",
+    description: "Create a new cargo. Requires MASTER_ADMIN or entity ADMIN.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({ id: z.string().uuid() }),
@@ -361,7 +357,7 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
         description: "Cargo created.",
         content: { "application/json": { schema: cargoResponseSchema } },
       },
-      ...errorResponses([400, 401, 403, 404, 500]),
+      ...errorResponses([400, 404]),
     },
   });
 
@@ -371,7 +367,7 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
     tags: ["Entities"],
     summary: "Update a cargo for an entity",
     description:
-      "Update an existing cargo. **Unusual pattern:** the cargo id is sent in the **request body** (as `cargoId`), not in the URL. All other update fields are optional. **Requires MASTER_ADMIN or active ADMIN membership in the entity.**",
+      "Update a cargo. **Unusual:** `cargoId` is in the body, not the URL. Requires MASTER_ADMIN or entity ADMIN.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({ id: z.string().uuid() }),
@@ -390,7 +386,7 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
         description: "Cargo updated.",
         content: { "application/json": { schema: cargoResponseSchema } },
       },
-      ...errorResponses([400, 401, 403, 404, 500]),
+      ...errorResponses([400, 404]),
     },
   });
 
@@ -400,7 +396,7 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
     tags: ["Entities"],
     summary: "Delete a cargo from an entity",
     description:
-      "Delete a cargo. **Unusual pattern:** the cargo id is sent as a `?cargoId=` query parameter, not in the URL path. **Requires MASTER_ADMIN or active ADMIN membership in the entity.**",
+      "Delete a cargo. **Unusual:** cargo id is a `?cargoId=` query param, not in the URL. Requires MASTER_ADMIN or entity ADMIN.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({ id: z.string().uuid() }),
@@ -421,7 +417,7 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
           },
         },
       },
-      ...errorResponses([400, 401, 403, 404, 500]),
+      ...errorResponses([400, 404]),
     },
   });
 }

--- a/src/lib/server/openapi/paths/entidades.ts
+++ b/src/lib/server/openapi/paths/entidades.ts
@@ -166,7 +166,7 @@ export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: Commo
     tags: ["Entidades"],
     summary: "Buscar uma entidade pelo slug",
     description:
-      "Retorna o perfil completo de uma entidade (com membros e cargos) pelo slug da URL. Usado pelas páginas `/entidade/[slug]`.",
+      "Retorna o perfil completo de uma entidade (com membros) pelo slug da URL. Usado pelas páginas `/entidade/[slug]`.",
     request: {
       params: z.object({
         slug: z.string().openapi({ example: "pet-computacao" }),

--- a/src/lib/server/openapi/paths/entidades.ts
+++ b/src/lib/server/openapi/paths/entidades.ts
@@ -6,7 +6,7 @@ import { addMemberSchema } from "@/app/api/entidades/[id]/membros/route";
 import { updateMemberSchema } from "@/app/api/entidades/[id]/membros/[membroId]/route";
 import { createCargoSchema, updateCargoSchema } from "@/app/api/entidades/[id]/cargos/route";
 
-import { errorResponses } from "../common-schemas";
+import type { CommonSchemas } from "../common-schemas";
 
 /**
  * Enum of entity types (LABORATORIO, GRUPO, etc). Mirrors the values accepted
@@ -139,7 +139,8 @@ const updateCargoRequestSchema = updateCargoSchema
   })
   .openapi("UpdateCargoRequest");
 
-export function registerEntidadesPaths(registry: OpenAPIRegistry): void {
+export function registerEntidadesPaths(registry: OpenAPIRegistry, schemas: CommonSchemas): void {
+  const { errorResponses } = schemas;
   registry.registerPath({
     method: "get",
     path: "/entidades",

--- a/src/lib/server/openapi/paths/entidades.ts
+++ b/src/lib/server/openapi/paths/entidades.ts
@@ -1,0 +1,423 @@
+import { z } from "zod";
+import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
+
+import { updateEntidadeSchema } from "@/app/api/entidades/[id]/route";
+import { addMemberSchema } from "@/app/api/entidades/[id]/membros/route";
+import { updateMemberSchema } from "@/app/api/entidades/[id]/membros/[membroId]/route";
+import { createCargoSchema, updateCargoSchema } from "@/app/api/entidades/[id]/cargos/route";
+
+import { errorResponses } from "../common-schemas";
+
+/**
+ * Enum of entity types (LABORATORIO, GRUPO, etc). Mirrors the values accepted
+ * by updateEntidadeSchema's `tipo` field.
+ */
+const tipoEntidadeSchema = z
+  .enum([
+    "LABORATORIO",
+    "GRUPO",
+    "LIGA_ACADEMICA",
+    "EMPRESA",
+    "ATLETICA",
+    "CENTRO_ACADEMICO",
+    "OUTRO",
+  ])
+  .openapi({
+    description:
+      "Entity category. PET groups are modeled under 'GRUPO'. Student unions (DCEs, centros acadêmicos) use 'CENTRO_ACADEMICO'.",
+    example: "GRUPO",
+  });
+
+/**
+ * Public entidade shape returned by GET /entidades, GET /entidades/slug/{slug}, etc.
+ * Includes the embedded centro and — when loaded — the list of active memberships.
+ */
+const entidadeResponseSchema = z
+  .object({
+    id: z.string().uuid(),
+    nome: z.string().openapi({ example: "PET Computação" }),
+    slug: z.string().nullable().openapi({ example: "pet-computacao" }),
+    subtitle: z.string().nullable().optional().openapi({
+      example: "Programa de Educação Tutorial da Ciência da Computação",
+    }),
+    descricao: z.string().nullable().optional(),
+    tipo: tipoEntidadeSchema,
+    urlFoto: z.string().nullable().optional(),
+    contato: z.string().nullable().optional(),
+    instagram: z.string().nullable().optional(),
+    linkedin: z.string().nullable().optional(),
+    website: z.string().nullable().optional(),
+    location: z.string().nullable().optional(),
+    foundingDate: z.string().datetime().nullable().optional(),
+    centro: z
+      .object({
+        id: z.string().uuid(),
+        nome: z.string().openapi({ example: "Centro de Informática" }),
+        sigla: z.string().openapi({ example: "CI" }),
+      })
+      .optional(),
+    membros: z
+      .array(
+        z.object({
+          id: z.string().uuid(),
+          papel: z.enum(["ADMIN", "MEMBRO"]),
+          usuario: z.object({
+            id: z.string().uuid(),
+            nome: z.string(),
+            slug: z.string().nullable(),
+            urlFotoPerfil: z.string().nullable(),
+          }),
+          cargo: z
+            .object({
+              id: z.string().uuid(),
+              nome: z.string(),
+            })
+            .nullable()
+            .optional(),
+        })
+      )
+      .optional(),
+  })
+  .openapi("EntidadeResponse");
+
+/**
+ * Response shape for entity-scoped membership endpoints (POST/PUT under
+ * /entidades/{id}/membros). Differs from the user-scoped membership shape
+ * in `paths/usuarios.ts` because it nests the user instead of the entity.
+ */
+const entidadeMembershipResponseSchema = z
+  .object({
+    id: z.string().uuid(),
+    usuario: z.object({
+      id: z.string().uuid(),
+      nome: z.string(),
+      slug: z.string().nullable(),
+      urlFotoPerfil: z.string().nullable(),
+      eFacade: z.boolean(),
+      curso: z.object({
+        id: z.string().uuid(),
+        nome: z.string(),
+      }),
+    }),
+    papel: z.enum(["ADMIN", "MEMBRO"]),
+    cargo: z
+      .object({
+        id: z.string().uuid(),
+        nome: z.string(),
+      })
+      .nullable()
+      .optional(),
+    startedAt: z.string().datetime(),
+    endedAt: z.string().datetime().nullable(),
+  })
+  .openapi("EntidadeMembershipResponse");
+
+/**
+ * Cargo (role title) shape returned by cargos endpoints.
+ */
+const cargoResponseSchema = z
+  .object({
+    id: z.string().uuid(),
+    nome: z.string().openapi({ example: "Tutor" }),
+    descricao: z.string().nullable().optional(),
+    ordem: z.number().int().openapi({ example: 0 }),
+    entidadeId: z.string().uuid(),
+  })
+  .openapi("CargoResponse");
+
+const messageResponseSchema = z.object({ message: z.string() });
+
+/**
+ * PUT cargo request body schema. Unlike POST which uses `createCargoSchema`,
+ * the PUT handler expects `cargoId` in the body alongside the update fields.
+ */
+const updateCargoRequestSchema = updateCargoSchema
+  .extend({
+    cargoId: z.string().uuid().openapi({
+      description: "ID of the cargo to update. Sent in the body (not the URL) on PUT requests.",
+    }),
+  })
+  .openapi("UpdateCargoRequest");
+
+export function registerEntidadesPaths(registry: OpenAPIRegistry): void {
+  registry.registerPath({
+    method: "get",
+    path: "/entidades",
+    tags: ["Entities"],
+    summary: "List all entities",
+    description:
+      "Public endpoint returning all entities (labs, PET groups, student unions, companies, athletics associations) registered in the system. Results include the embedded centro but not the full member list — fetch that via GET /entidades/slug/{slug} or /entidades/{id}/membros.",
+    responses: {
+      200: {
+        description: "List of all entities.",
+        content: { "application/json": { schema: z.array(entidadeResponseSchema) } },
+      },
+      ...errorResponses([500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/entidades/slug/{slug}",
+    tags: ["Entities"],
+    summary: "Look up an entity by slug",
+    description:
+      "Public endpoint to fetch an entity's full profile (with members and cargos) by its URL slug. Used by the `/entidade/[slug]` pages.",
+    request: {
+      params: z.object({
+        slug: z.string().openapi({ example: "pet-computacao" }),
+      }),
+    },
+    responses: {
+      200: {
+        description: "Entity profile with embedded members and cargos.",
+        content: { "application/json": { schema: entidadeResponseSchema } },
+      },
+      ...errorResponses([404, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "put",
+    path: "/entidades/{id}",
+    tags: ["Entities"],
+    summary: "Update an entity",
+    description:
+      "Update entity fields (name, description, social links, etc). **Requires either MASTER_ADMIN role or an active ADMIN membership in the target entity.** All fields are optional — only provided fields are updated.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      params: z.object({ id: z.string().uuid() }),
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: updateEntidadeSchema,
+            example: {
+              descricao: "Programa de Educação Tutorial focado em Ciência da Computação.",
+              website: "https://petcomputacao.ufpb.br",
+              instagram: "@petcomputacao",
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Entity updated.",
+        content: {
+          "application/json": {
+            schema: messageResponseSchema,
+            example: { message: "Entidade atualizada com sucesso." },
+          },
+        },
+      },
+      ...errorResponses([400, 401, 403, 404, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/entidades/{id}/membros",
+    tags: ["Entities"],
+    summary: "Add a member to an entity",
+    description:
+      "Add a user as a member of the entity. **Requires either MASTER_ADMIN role or an active ADMIN membership in the target entity.** Returns 409 if the user is already an active member. To let users join entities themselves, use POST /usuarios/me/membros instead.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      params: z.object({ id: z.string().uuid() }),
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: addMemberSchema,
+            example: {
+              usuarioId: "550e8400-e29b-41d4-a716-446655440000",
+              papel: "MEMBRO",
+              cargoId: "661f9511-f30b-52e5-b827-557766551111",
+              startedAt: "2026-01-15T00:00:00.000Z",
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Member added.",
+        content: { "application/json": { schema: entidadeMembershipResponseSchema } },
+      },
+      ...errorResponses([400, 401, 403, 404, 409, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "put",
+    path: "/entidades/{id}/membros/{membroId}",
+    tags: ["Entities"],
+    summary: "Update a member of an entity",
+    description:
+      "Update a member's role, cargo, or dates inside the entity. **Requires MASTER_ADMIN or active ADMIN membership in the entity.** To update your own membership (non-admin use case), use PUT /usuarios/me/membros/{membroId} instead.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      params: z.object({
+        id: z.string().uuid(),
+        membroId: z.string().uuid(),
+      }),
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: updateMemberSchema,
+            example: { endedAt: "2026-12-31T23:59:59.000Z" },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Member updated.",
+        content: { "application/json": { schema: entidadeMembershipResponseSchema } },
+      },
+      ...errorResponses([400, 401, 403, 404, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "delete",
+    path: "/entidades/{id}/membros/{membroId}",
+    tags: ["Entities"],
+    summary: "Remove a member from an entity",
+    description:
+      "Permanently delete a membership from the entity. **Requires MASTER_ADMIN or active ADMIN membership in the entity.**",
+    security: [{ bearerAuth: [] }],
+    request: {
+      params: z.object({
+        id: z.string().uuid(),
+        membroId: z.string().uuid(),
+      }),
+    },
+    responses: {
+      200: {
+        description: "Member removed.",
+        content: {
+          "application/json": {
+            schema: messageResponseSchema,
+            example: { message: "Membresia deletada com sucesso." },
+          },
+        },
+      },
+      ...errorResponses([400, 401, 403, 404, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/entidades/{id}/cargos",
+    tags: ["Entities"],
+    summary: "List all cargos for an entity",
+    description:
+      "Public endpoint returning the list of cargos (role titles) defined for this entity. Cargos are used as the `cargoId` field when creating or updating memberships.",
+    request: {
+      params: z.object({ id: z.string().uuid() }),
+    },
+    responses: {
+      200: {
+        description: "List of cargos.",
+        content: { "application/json": { schema: z.array(cargoResponseSchema) } },
+      },
+      ...errorResponses([500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/entidades/{id}/cargos",
+    tags: ["Entities"],
+    summary: "Create a new cargo for an entity",
+    description:
+      "Define a new cargo (role title) in the entity. **Requires MASTER_ADMIN or active ADMIN membership in the entity.**",
+    security: [{ bearerAuth: [] }],
+    request: {
+      params: z.object({ id: z.string().uuid() }),
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: createCargoSchema,
+            example: {
+              nome: "Tutor",
+              descricao: "Responsável por orientar os bolsistas",
+              ordem: 0,
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Cargo created.",
+        content: { "application/json": { schema: cargoResponseSchema } },
+      },
+      ...errorResponses([400, 401, 403, 404, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "put",
+    path: "/entidades/{id}/cargos",
+    tags: ["Entities"],
+    summary: "Update a cargo for an entity",
+    description:
+      "Update an existing cargo. **Unusual pattern:** the cargo id is sent in the **request body** (as `cargoId`), not in the URL. All other update fields are optional. **Requires MASTER_ADMIN or active ADMIN membership in the entity.**",
+    security: [{ bearerAuth: [] }],
+    request: {
+      params: z.object({ id: z.string().uuid() }),
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: updateCargoRequestSchema,
+            example: { cargoId: "550e8400-e29b-41d4-a716-446655440000", nome: "Tutor Sênior" },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Cargo updated.",
+        content: { "application/json": { schema: cargoResponseSchema } },
+      },
+      ...errorResponses([400, 401, 403, 404, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "delete",
+    path: "/entidades/{id}/cargos",
+    tags: ["Entities"],
+    summary: "Delete a cargo from an entity",
+    description:
+      "Delete a cargo. **Unusual pattern:** the cargo id is sent as a `?cargoId=` query parameter, not in the URL path. **Requires MASTER_ADMIN or active ADMIN membership in the entity.**",
+    security: [{ bearerAuth: [] }],
+    request: {
+      params: z.object({ id: z.string().uuid() }),
+      query: z.object({
+        cargoId: z.string().uuid().openapi({
+          description: "ID of the cargo to delete.",
+          example: "550e8400-e29b-41d4-a716-446655440000",
+        }),
+      }),
+    },
+    responses: {
+      200: {
+        description: "Cargo deleted.",
+        content: {
+          "application/json": {
+            schema: messageResponseSchema,
+            example: { message: "Cargo deletado com sucesso." },
+          },
+        },
+      },
+      ...errorResponses([400, 401, 403, 404, 500]),
+    },
+  });
+}

--- a/src/lib/server/openapi/paths/guias.ts
+++ b/src/lib/server/openapi/paths/guias.ts
@@ -1,0 +1,112 @@
+import { z } from "zod";
+import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
+
+import { errorResponses } from "../common-schemas";
+
+/**
+ * Guia (academic guide) shape. Guides organize tutorial content for students
+ * — typically course-specific (e.g., "Guia do Calouro de Ciência da Computação").
+ * Handlers return Prisma-shaped objects without an explicit mapper, so this
+ * schema mirrors the shape returned from the repository.
+ */
+const guiaResponseSchema = z
+  .object({
+    id: z.string().uuid(),
+    titulo: z.string().openapi({ example: "Guia do Calouro de Ciência da Computação" }),
+    descricao: z.string().nullable().optional(),
+    cursoId: z.string().uuid().nullable().optional(),
+    status: z
+      .enum(["PUBLICADO", "RASCUNHO", "ARQUIVADO"])
+      .optional()
+      .openapi({ example: "PUBLICADO" }),
+    criadoEm: z.string().datetime().optional(),
+    atualizadoEm: z.string().datetime().optional(),
+  })
+  .openapi("GuiaResponse");
+
+const secaoGuiaResponseSchema = z
+  .object({
+    id: z.string().uuid(),
+    titulo: z.string().openapi({ example: "Primeiros passos no campus" }),
+    descricao: z.string().nullable().optional(),
+    ordem: z.number().int().openapi({ example: 1 }),
+    guiaId: z.string().uuid(),
+  })
+  .openapi("SecaoGuiaResponse");
+
+const subSecaoGuiaResponseSchema = z
+  .object({
+    id: z.string().uuid(),
+    titulo: z.string().openapi({ example: "Onde fica o Centro de Informática" }),
+    conteudo: z.string().openapi({
+      description: "Markdown content of the subsection.",
+      example: "O CI fica localizado no Campus I, próximo ao bloco de engenharias...",
+    }),
+    ordem: z.number().int().openapi({ example: 1 }),
+    secaoId: z.string().uuid(),
+  })
+  .openapi("SubSecaoGuiaResponse");
+
+export function registerGuiasPaths(registry: OpenAPIRegistry): void {
+  registry.registerPath({
+    method: "get",
+    path: "/guias",
+    tags: ["Guides"],
+    summary: "List all guides (optionally filtered by course)",
+    description:
+      "Public endpoint returning all academic guides. Optionally filter by `cursoId` to get only guides associated with a specific course.",
+    request: {
+      query: z.object({
+        cursoId: z.string().uuid().optional().openapi({
+          description: "Filter guides by course id.",
+          example: "550e8400-e29b-41d4-a716-446655440000",
+        }),
+      }),
+    },
+    responses: {
+      200: {
+        description: "List of guides.",
+        content: { "application/json": { schema: z.array(guiaResponseSchema) } },
+      },
+      ...errorResponses([500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/guias/{id}/secoes",
+    tags: ["Guides"],
+    summary: "List sections for a guide",
+    description:
+      "Public endpoint returning all top-level sections of a guide, ordered by the `ordem` field. Sections group related subsections within a guide.",
+    request: {
+      params: z.object({ id: z.string().uuid() }),
+    },
+    responses: {
+      200: {
+        description: "List of sections ordered by the 'ordem' field.",
+        content: { "application/json": { schema: z.array(secaoGuiaResponseSchema) } },
+      },
+      ...errorResponses([500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/guias/secoes/{id}/subsecoes",
+    tags: ["Guides"],
+    summary: "List subsections for a section",
+    description:
+      "Public endpoint returning all subsections within a section, ordered by `ordem`. Subsection content is Markdown.",
+    request: {
+      params: z.object({ id: z.string().uuid() }),
+    },
+    responses: {
+      200: {
+        description: "List of subsections ordered by the 'ordem' field.",
+        content: { "application/json": { schema: z.array(subSecaoGuiaResponseSchema) } },
+      },
+      ...errorResponses([500]),
+    },
+  });
+}

--- a/src/lib/server/openapi/paths/guias.ts
+++ b/src/lib/server/openapi/paths/guias.ts
@@ -4,10 +4,10 @@ import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 import type { CommonSchemas } from "../common-schemas";
 
 /**
- * Guia (academic guide) shape. Guides organize tutorial content for students
- * — typically course-specific (e.g., "Guia do Calouro de Ciência da Computação").
- * Handlers return Prisma-shaped objects without an explicit mapper, so this
- * schema mirrors the shape returned from the repository.
+ * Shape de Guia. Guias organizam conteúdo tutorial para estudantes —
+ * tipicamente associados a um curso (ex: "Guia do Calouro de Ciência da
+ * Computação"). Os handlers retornam objetos no formato do Prisma sem mapper
+ * explícito, então o schema espelha o shape vindo do repositório.
  */
 const guiaResponseSchema = z
   .object({
@@ -39,7 +39,7 @@ const subSecaoGuiaResponseSchema = z
     id: z.string().uuid(),
     titulo: z.string().openapi({ example: "Onde fica o Centro de Informática" }),
     conteudo: z.string().openapi({
-      description: "Markdown content of the subsection.",
+      description: "Conteúdo da subseção em Markdown.",
       example: "O CI fica localizado no Campus I, próximo ao bloco de engenharias...",
     }),
     ordem: z.number().int().openapi({ example: 1 }),
@@ -52,21 +52,21 @@ export function registerGuiasPaths(registry: OpenAPIRegistry, schemas: CommonSch
   registry.registerPath({
     method: "get",
     path: "/guias",
-    tags: ["Guides"],
-    summary: "List all guides (optionally filtered by course)",
+    tags: ["Guias"],
+    summary: "Listar guias (opcionalmente filtrados por curso)",
     description:
-      "Public endpoint returning all academic guides. Optionally filter by `cursoId` to get only guides associated with a specific course.",
+      "Retorna todos os guias acadêmicos. Use `cursoId` para filtrar apenas os guias associados a um curso específico.",
     request: {
       query: z.object({
         cursoId: z.string().uuid().optional().openapi({
-          description: "Filter guides by course id.",
+          description: "Filtra guias pelo ID do curso.",
           example: "550e8400-e29b-41d4-a716-446655440000",
         }),
       }),
     },
     responses: {
       200: {
-        description: "List of guides.",
+        description: "Lista de guias.",
         content: { "application/json": { schema: z.array(guiaResponseSchema) } },
       },
     },
@@ -75,16 +75,16 @@ export function registerGuiasPaths(registry: OpenAPIRegistry, schemas: CommonSch
   registry.registerPath({
     method: "get",
     path: "/guias/{id}/secoes",
-    tags: ["Guides"],
-    summary: "List sections for a guide",
+    tags: ["Guias"],
+    summary: "Listar seções de um guia",
     description:
-      "Public endpoint returning all top-level sections of a guide, ordered by the `ordem` field. Sections group related subsections within a guide.",
+      "Retorna todas as seções de nível superior de um guia, ordenadas pelo campo `ordem`. Seções agrupam subseções relacionadas dentro de um guia.",
     request: {
       params: z.object({ id: z.string().uuid() }),
     },
     responses: {
       200: {
-        description: "List of sections ordered by the 'ordem' field.",
+        description: "Lista de seções ordenadas pelo campo `ordem`.",
         content: { "application/json": { schema: z.array(secaoGuiaResponseSchema) } },
       },
     },
@@ -93,16 +93,16 @@ export function registerGuiasPaths(registry: OpenAPIRegistry, schemas: CommonSch
   registry.registerPath({
     method: "get",
     path: "/guias/secoes/{id}/subsecoes",
-    tags: ["Guides"],
-    summary: "List subsections for a section",
+    tags: ["Guias"],
+    summary: "Listar subseções de uma seção",
     description:
-      "Public endpoint returning all subsections within a section, ordered by `ordem`. Subsection content is Markdown.",
+      "Retorna todas as subseções de uma seção, ordenadas pelo campo `ordem`. O conteúdo das subseções é Markdown.",
     request: {
       params: z.object({ id: z.string().uuid() }),
     },
     responses: {
       200: {
-        description: "List of subsections ordered by the 'ordem' field.",
+        description: "Lista de subseções ordenadas pelo campo `ordem`.",
         content: { "application/json": { schema: z.array(subSecaoGuiaResponseSchema) } },
       },
     },

--- a/src/lib/server/openapi/paths/guias.ts
+++ b/src/lib/server/openapi/paths/guias.ts
@@ -47,8 +47,7 @@ const subSecaoGuiaResponseSchema = z
   })
   .openapi("SubSecaoGuiaResponse");
 
-export function registerGuiasPaths(registry: OpenAPIRegistry, schemas: CommonSchemas): void {
-  const { errorResponses } = schemas;
+export function registerGuiasPaths(registry: OpenAPIRegistry, _schemas: CommonSchemas): void {
   registry.registerPath({
     method: "get",
     path: "/guias",

--- a/src/lib/server/openapi/paths/guias.ts
+++ b/src/lib/server/openapi/paths/guias.ts
@@ -24,6 +24,7 @@ const guiaResponseSchema = z
   })
   .openapi("GuiaResponse");
 
+/** Shape de resposta de seção de guia. */
 const secaoGuiaResponseSchema = z
   .object({
     id: z.string().uuid(),
@@ -34,6 +35,7 @@ const secaoGuiaResponseSchema = z
   })
   .openapi("SecaoGuiaResponse");
 
+/** Shape de resposta de subseção de guia. */
 const subSecaoGuiaResponseSchema = z
   .object({
     id: z.string().uuid(),

--- a/src/lib/server/openapi/paths/guias.ts
+++ b/src/lib/server/openapi/paths/guias.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 
-import { errorResponses } from "../common-schemas";
+import type { CommonSchemas } from "../common-schemas";
 
 /**
  * Guia (academic guide) shape. Guides organize tutorial content for students
@@ -47,7 +47,8 @@ const subSecaoGuiaResponseSchema = z
   })
   .openapi("SubSecaoGuiaResponse");
 
-export function registerGuiasPaths(registry: OpenAPIRegistry): void {
+export function registerGuiasPaths(registry: OpenAPIRegistry, schemas: CommonSchemas): void {
+  const { errorResponses } = schemas;
   registry.registerPath({
     method: "get",
     path: "/guias",

--- a/src/lib/server/openapi/paths/guias.ts
+++ b/src/lib/server/openapi/paths/guias.ts
@@ -47,6 +47,7 @@ const subSecaoGuiaResponseSchema = z
   })
   .openapi("SubSecaoGuiaResponse");
 
+/** Registra os paths de guias no registry OpenAPI. */
 export function registerGuiasPaths(registry: OpenAPIRegistry, _schemas: CommonSchemas): void {
   registry.registerPath({
     method: "get",

--- a/src/lib/server/openapi/paths/guias.ts
+++ b/src/lib/server/openapi/paths/guias.ts
@@ -69,7 +69,6 @@ export function registerGuiasPaths(registry: OpenAPIRegistry, schemas: CommonSch
         description: "List of guides.",
         content: { "application/json": { schema: z.array(guiaResponseSchema) } },
       },
-      ...errorResponses([500]),
     },
   });
 
@@ -88,7 +87,6 @@ export function registerGuiasPaths(registry: OpenAPIRegistry, schemas: CommonSch
         description: "List of sections ordered by the 'ordem' field.",
         content: { "application/json": { schema: z.array(secaoGuiaResponseSchema) } },
       },
-      ...errorResponses([500]),
     },
   });
 
@@ -107,7 +105,6 @@ export function registerGuiasPaths(registry: OpenAPIRegistry, schemas: CommonSch
         description: "List of subsections ordered by the 'ordem' field.",
         content: { "application/json": { schema: z.array(subSecaoGuiaResponseSchema) } },
       },
-      ...errorResponses([500]),
     },
   });
 }

--- a/src/lib/server/openapi/paths/index.ts
+++ b/src/lib/server/openapi/paths/index.ts
@@ -1,0 +1,14 @@
+import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
+
+/**
+ * Register every path in the OpenAPI registry. Called once by the generator
+ * during lazy document creation. Keep the calls ordered by resource group
+ * so the resulting paths object matches the tag order in registry.ts.
+ *
+ * As each resource group is documented, its `register*Paths` function will
+ * be added here (see src/lib/server/openapi/paths/auth.ts, usuarios.ts, etc).
+ */
+export function registerAllPaths(_registry: OpenAPIRegistry): void {
+  // Intentionally empty for now. Each resource group is registered
+  // incrementally across subsequent commits in this PR.
+}

--- a/src/lib/server/openapi/paths/index.ts
+++ b/src/lib/server/openapi/paths/index.ts
@@ -1,5 +1,9 @@
 import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 
+import { registerAuthPaths } from "./auth";
+import { registerMiscPaths } from "./misc";
+import { registerSearchPaths } from "./search";
+
 /**
  * Register every path in the OpenAPI registry. Called once by the generator
  * during lazy document creation. Keep the calls ordered by resource group
@@ -8,7 +12,8 @@ import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
  * As each resource group is documented, its `register*Paths` function will
  * be added here (see src/lib/server/openapi/paths/auth.ts, usuarios.ts, etc).
  */
-export function registerAllPaths(_registry: OpenAPIRegistry): void {
-  // Intentionally empty for now. Each resource group is registered
-  // incrementally across subsequent commits in this PR.
+export function registerAllPaths(registry: OpenAPIRegistry): void {
+  registerAuthPaths(registry);
+  registerSearchPaths(registry);
+  registerMiscPaths(registry);
 }

--- a/src/lib/server/openapi/paths/index.ts
+++ b/src/lib/server/openapi/paths/index.ts
@@ -1,10 +1,14 @@
 import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 
 import { registerAuthPaths } from "./auth";
+import { registerCalendarioPaths } from "./calendario";
 import { registerCampusPaths } from "./campus";
 import { registerCentrosPaths } from "./centros";
+import { registerCurriculosPaths } from "./curriculos";
 import { registerCursosPaths } from "./cursos";
+import { registerDisciplinasPaths } from "./disciplinas";
 import { registerEntidadesPaths } from "./entidades";
+import { registerGuiasPaths } from "./guias";
 import { registerMiscPaths } from "./misc";
 import { registerSearchPaths } from "./search";
 import { registerUsuariosPaths } from "./usuarios";
@@ -23,9 +27,13 @@ export function registerAllPaths(registry: OpenAPIRegistry): void {
   registerUsuariosPaths(registry);
   registerEntidadesPaths(registry);
   registerVagasPaths(registry);
+  registerGuiasPaths(registry);
   registerCursosPaths(registry);
   registerCentrosPaths(registry);
   registerCampusPaths(registry);
+  registerDisciplinasPaths(registry);
+  registerCurriculosPaths(registry);
+  registerCalendarioPaths(registry);
   registerSearchPaths(registry);
   registerMiscPaths(registry);
 }

--- a/src/lib/server/openapi/paths/index.ts
+++ b/src/lib/server/openapi/paths/index.ts
@@ -3,6 +3,7 @@ import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 import { registerAuthPaths } from "./auth";
 import { registerMiscPaths } from "./misc";
 import { registerSearchPaths } from "./search";
+import { registerUsuariosPaths } from "./usuarios";
 
 /**
  * Register every path in the OpenAPI registry. Called once by the generator
@@ -14,6 +15,7 @@ import { registerSearchPaths } from "./search";
  */
 export function registerAllPaths(registry: OpenAPIRegistry): void {
   registerAuthPaths(registry);
+  registerUsuariosPaths(registry);
   registerSearchPaths(registry);
   registerMiscPaths(registry);
 }

--- a/src/lib/server/openapi/paths/index.ts
+++ b/src/lib/server/openapi/paths/index.ts
@@ -1,9 +1,14 @@
 import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 
 import { registerAuthPaths } from "./auth";
+import { registerCampusPaths } from "./campus";
+import { registerCentrosPaths } from "./centros";
+import { registerCursosPaths } from "./cursos";
+import { registerEntidadesPaths } from "./entidades";
 import { registerMiscPaths } from "./misc";
 import { registerSearchPaths } from "./search";
 import { registerUsuariosPaths } from "./usuarios";
+import { registerVagasPaths } from "./vagas";
 
 /**
  * Register every path in the OpenAPI registry. Called once by the generator
@@ -16,6 +21,11 @@ import { registerUsuariosPaths } from "./usuarios";
 export function registerAllPaths(registry: OpenAPIRegistry): void {
   registerAuthPaths(registry);
   registerUsuariosPaths(registry);
+  registerEntidadesPaths(registry);
+  registerVagasPaths(registry);
+  registerCursosPaths(registry);
+  registerCentrosPaths(registry);
+  registerCampusPaths(registry);
   registerSearchPaths(registry);
   registerMiscPaths(registry);
 }

--- a/src/lib/server/openapi/paths/index.ts
+++ b/src/lib/server/openapi/paths/index.ts
@@ -1,5 +1,6 @@
 import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 
+import type { CommonSchemas } from "../common-schemas";
 import { registerAuthPaths } from "./auth";
 import { registerCalendarioPaths } from "./calendario";
 import { registerCampusPaths } from "./campus";
@@ -19,21 +20,24 @@ import { registerVagasPaths } from "./vagas";
  * during lazy document creation. Keep the calls ordered by resource group
  * so the resulting paths object matches the tag order in registry.ts.
  *
- * As each resource group is documented, its `register*Paths` function will
- * be added here (see src/lib/server/openapi/paths/auth.ts, usuarios.ts, etc).
+ * The `schemas` argument is the set of shared component schemas (ErrorCode,
+ * ApiErrorBody, PaginationMeta, the `errorResponses` helper) created by
+ * `registerCommonSchemas` on the same registry. Path modules receive it as
+ * a second argument so they can reference the shared error envelope without
+ * importing module-level singletons.
  */
-export function registerAllPaths(registry: OpenAPIRegistry): void {
-  registerAuthPaths(registry);
-  registerUsuariosPaths(registry);
-  registerEntidadesPaths(registry);
-  registerVagasPaths(registry);
-  registerGuiasPaths(registry);
-  registerCursosPaths(registry);
-  registerCentrosPaths(registry);
-  registerCampusPaths(registry);
-  registerDisciplinasPaths(registry);
-  registerCurriculosPaths(registry);
-  registerCalendarioPaths(registry);
-  registerSearchPaths(registry);
-  registerMiscPaths(registry);
+export function registerAllPaths(registry: OpenAPIRegistry, schemas: CommonSchemas): void {
+  registerAuthPaths(registry, schemas);
+  registerUsuariosPaths(registry, schemas);
+  registerEntidadesPaths(registry, schemas);
+  registerVagasPaths(registry, schemas);
+  registerGuiasPaths(registry, schemas);
+  registerCursosPaths(registry, schemas);
+  registerCentrosPaths(registry, schemas);
+  registerCampusPaths(registry, schemas);
+  registerDisciplinasPaths(registry, schemas);
+  registerCurriculosPaths(registry, schemas);
+  registerCalendarioPaths(registry, schemas);
+  registerSearchPaths(registry, schemas);
+  registerMiscPaths(registry, schemas);
 }

--- a/src/lib/server/openapi/paths/misc.ts
+++ b/src/lib/server/openapi/paths/misc.ts
@@ -77,7 +77,6 @@ export function registerMiscPaths(registry: OpenAPIRegistry, schemas: CommonSche
           },
         },
       },
-      ...errorResponses([500]),
     },
   });
 
@@ -87,7 +86,7 @@ export function registerMiscPaths(registry: OpenAPIRegistry, schemas: CommonSche
     tags: ["Upload"],
     summary: "Upload a profile photo for the current user",
     description:
-      "Atomically upload a profile photo and update the user's `urlFotoPerfil` field. The previous photo (if hosted on blob storage) is deleted as part of the operation. On any failure after upload, the newly-uploaded file is cleaned up to keep storage and database in sync.\n\n**File constraints:**\n- Max size: **5 MB**\n- Allowed MIME types: `image/jpeg`, `image/jpg`, `image/png`, `image/webp`, `image/gif`\n- The filename is ignored server-side — a safe extension is derived from the MIME type.\n\nReturns the updated user profile on success.",
+      "Upload a photo (max 5 MB, JPEG/PNG/WebP/GIF) and atomically update the user's profile. Returns the updated user.",
     security: [{ bearerAuth: [] }],
     request: {
       body: {
@@ -104,7 +103,7 @@ export function registerMiscPaths(registry: OpenAPIRegistry, schemas: CommonSche
         description: "Photo uploaded and user profile updated.",
         content: { "application/json": { schema: uploadPhotoResponseSchema } },
       },
-      ...errorResponses([400, 401, 500]),
+      ...errorResponses([400]),
     },
   });
 
@@ -114,30 +113,18 @@ export function registerMiscPaths(registry: OpenAPIRegistry, schemas: CommonSche
     tags: ["Content Images"],
     summary: "Serve a static image from the content submodules",
     description:
-      "Public endpoint that serves static images (illustrations, entity logos, map assets) from the `content/` git submodules. The path is **resolved using slug matching**, so you can reference folders/files by their lowercased, accent-stripped, hyphen-joined names rather than the actual filesystem paths (which may include priority prefixes like `'1 - Componentes Curriculares'`).\n\n**Supported path roots (the first segment chooses the content submodule):**\n- `entidades/<file>` — serves from `content/aquario-entidades/centro-de-informatica`\n- `assets/entidades/<file>` — serves from `content/aquario-entidades/centro-de-informatica/assets`\n- `mapas/<path>` — serves from `content/aquario-mapas`\n- (anything else) — serves from `content/aquario-guias/centro-de-informatica` (default)\n\n**Unlike every other endpoint in this API, error responses for this endpoint are plain text (`'Image not found'`, `'Forbidden'`, `'Internal Server Error'`) — NOT the standard `ApiErrorBody` JSON shape.** This keeps the endpoint compatible with `<img>` tags and avoids any JSON parsing on the client side.\n\nResponses include `Cache-Control: public, max-age=31536000, immutable` — the browser can cache the image permanently.",
+      "Serve a static image from `content/` git submodules. Path uses slug matching (accent-stripped, priority prefixes ignored). Supported roots: `entidades/*`, `assets/entidades/*`, `mapas/*`, or default (guias). **Errors return plain text**, not JSON — compatible with `<img>` tags.",
     request: {
       params: z.object({
         path: z.string().openapi({
-          description:
-            "Slash-joined path segments. Next.js catch-all route — any number of segments is accepted. Slugs are matched case-insensitively against folder/file names with priority prefixes stripped.",
+          description: "Slash-joined path segments (catch-all).",
           example: "entidades/pet-computacao.png",
         }),
       }),
     },
     responses: {
       200: {
-        description:
-          "Image file served as binary data. The `Content-Type` header reflects the actual file format; `application/octet-stream` is used as a fallback for unknown extensions.",
-        headers: {
-          "Content-Type": {
-            description: "MIME type of the served image, derived from the file extension.",
-            schema: { type: "string", example: "image/png" },
-          },
-          "Cache-Control": {
-            description: "Long-lived immutable cache directive (1 year).",
-            schema: { type: "string", example: "public, max-age=31536000, immutable" },
-          },
-        },
+        description: "Image binary. Cached for 1 year (`Cache-Control: immutable`).",
         content: {
           "image/png": { schema: { type: "string", format: "binary" } },
           "image/jpeg": { schema: { type: "string", format: "binary" } },
@@ -147,30 +134,11 @@ export function registerMiscPaths(registry: OpenAPIRegistry, schemas: CommonSche
           "application/octet-stream": { schema: { type: "string", format: "binary" } },
         },
       },
-      403: {
-        description:
-          "Forbidden — the resolved path is outside the allowed content directory. Body is the plain text string 'Forbidden', NOT the standard JSON error shape.",
-        content: {
-          "text/plain": {
-            schema: { type: "string", example: "Forbidden" },
-          },
-        },
-      },
       404: {
-        description:
-          "Image not found at the resolved path. Body is the plain text string 'Image not found', NOT the standard JSON error shape.",
+        description: "Image not found (plain text body).",
         content: {
           "text/plain": {
             schema: { type: "string", example: "Image not found" },
-          },
-        },
-      },
-      500: {
-        description:
-          "Internal error while reading the image. Body is the plain text string 'Internal Server Error', NOT the standard JSON error shape.",
-        content: {
-          "text/plain": {
-            schema: { type: "string", example: "Internal Server Error" },
           },
         },
       },

--- a/src/lib/server/openapi/paths/misc.ts
+++ b/src/lib/server/openapi/paths/misc.ts
@@ -8,8 +8,7 @@ import { errorResponses } from "../common-schemas";
  * health check, file upload, and static content image serving.
  *
  * These are registered together to avoid creating three separate files for
- * one endpoint each. Upload and content-images will be added in later commits
- * of this PR.
+ * one endpoint each. Content-images is added in a later commit of this PR.
  */
 
 const healthResponseSchema = z
@@ -20,6 +19,44 @@ const healthResponseSchema = z
     }),
   })
   .openapi("HealthResponse");
+
+/**
+ * Multipart form body schema for POST /upload/photo. The file must be sent
+ * as a multipart/form-data field named `file`. Zod doesn't have a native
+ * binary primitive, so we use `z.unknown()` with an explicit openapi override.
+ */
+const uploadPhotoBodySchema = z
+  .object({
+    file: z.unknown().openapi({
+      type: "string",
+      format: "binary",
+      description: "Image file to upload. Max 5MB. Allowed MIME types: JPEG, PNG, WebP, GIF.",
+    }),
+  })
+  .openapi("UploadPhotoBody");
+
+/**
+ * Reuses the same user profile shape returned by /auth/me and /usuarios/slug/{slug}.
+ * Kept minimal here since the full profile schema lives in paths/usuarios.ts.
+ */
+const uploadPhotoResponseSchema = z
+  .object({
+    id: z.string().uuid(),
+    nome: z.string(),
+    email: z.string().nullable(),
+    slug: z.string().nullable(),
+    papelPlataforma: z.enum(["USER", "MASTER_ADMIN"]),
+    eVerificado: z.boolean(),
+    urlFotoPerfil: z.string().nullable().openapi({
+      description: "URL of the newly uploaded photo in blob storage.",
+      example: "https://blob.vercel-storage.com/photos/550e8400-1712668800.webp",
+    }),
+    periodoAtual: z.string().nullable().optional(),
+    centro: z.object({ id: z.string().uuid(), nome: z.string(), sigla: z.string() }),
+    curso: z.object({ id: z.string().uuid(), nome: z.string() }),
+    permissoes: z.array(z.string()),
+  })
+  .openapi("UploadPhotoResponse");
 
 export function registerMiscPaths(registry: OpenAPIRegistry): void {
   registry.registerPath({
@@ -40,6 +77,33 @@ export function registerMiscPaths(registry: OpenAPIRegistry): void {
         },
       },
       ...errorResponses([500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/upload/photo",
+    tags: ["Upload"],
+    summary: "Upload a profile photo for the current user",
+    description:
+      "Atomically upload a profile photo and update the user's `urlFotoPerfil` field. The previous photo (if hosted on blob storage) is deleted as part of the operation. On any failure after upload, the newly-uploaded file is cleaned up to keep storage and database in sync.\n\n**File constraints:**\n- Max size: **5 MB**\n- Allowed MIME types: `image/jpeg`, `image/jpg`, `image/png`, `image/webp`, `image/gif`\n- The filename is ignored server-side — a safe extension is derived from the MIME type.\n\nReturns the updated user profile on success.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      body: {
+        required: true,
+        content: {
+          "multipart/form-data": {
+            schema: uploadPhotoBodySchema,
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Photo uploaded and user profile updated.",
+        content: { "application/json": { schema: uploadPhotoResponseSchema } },
+      },
+      ...errorResponses([400, 401, 500]),
     },
   });
 }

--- a/src/lib/server/openapi/paths/misc.ts
+++ b/src/lib/server/openapi/paths/misc.ts
@@ -8,7 +8,7 @@ import { errorResponses } from "../common-schemas";
  * health check, file upload, and static content image serving.
  *
  * These are registered together to avoid creating three separate files for
- * one endpoint each. Content-images is added in a later commit of this PR.
+ * one endpoint each.
  */
 
 const healthResponseSchema = z
@@ -104,6 +104,75 @@ export function registerMiscPaths(registry: OpenAPIRegistry): void {
         content: { "application/json": { schema: uploadPhotoResponseSchema } },
       },
       ...errorResponses([400, 401, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/content-images/{path}",
+    tags: ["Content Images"],
+    summary: "Serve a static image from the content submodules",
+    description:
+      "Public endpoint that serves static images (illustrations, entity logos, map assets) from the `content/` git submodules. The path is **resolved using slug matching**, so you can reference folders/files by their lowercased, accent-stripped, hyphen-joined names rather than the actual filesystem paths (which may include priority prefixes like `'1 - Componentes Curriculares'`).\n\n**Supported path roots (the first segment chooses the content submodule):**\n- `entidades/<file>` — serves from `content/aquario-entidades/centro-de-informatica`\n- `assets/entidades/<file>` — serves from `content/aquario-entidades/centro-de-informatica/assets`\n- `mapas/<path>` — serves from `content/aquario-mapas`\n- (anything else) — serves from `content/aquario-guias/centro-de-informatica` (default)\n\n**Unlike every other endpoint in this API, error responses for this endpoint are plain text (`'Image not found'`, `'Forbidden'`, `'Internal Server Error'`) — NOT the standard `ApiErrorBody` JSON shape.** This keeps the endpoint compatible with `<img>` tags and avoids any JSON parsing on the client side.\n\nResponses include `Cache-Control: public, max-age=31536000, immutable` — the browser can cache the image permanently.",
+    request: {
+      params: z.object({
+        path: z.string().openapi({
+          description:
+            "Slash-joined path segments. Next.js catch-all route — any number of segments is accepted. Slugs are matched case-insensitively against folder/file names with priority prefixes stripped.",
+          example: "entidades/pet-computacao.png",
+        }),
+      }),
+    },
+    responses: {
+      200: {
+        description:
+          "Image file served as binary data. The `Content-Type` header reflects the actual file format; `application/octet-stream` is used as a fallback for unknown extensions.",
+        headers: {
+          "Content-Type": {
+            description: "MIME type of the served image, derived from the file extension.",
+            schema: { type: "string", example: "image/png" },
+          },
+          "Cache-Control": {
+            description: "Long-lived immutable cache directive (1 year).",
+            schema: { type: "string", example: "public, max-age=31536000, immutable" },
+          },
+        },
+        content: {
+          "image/png": { schema: { type: "string", format: "binary" } },
+          "image/jpeg": { schema: { type: "string", format: "binary" } },
+          "image/gif": { schema: { type: "string", format: "binary" } },
+          "image/webp": { schema: { type: "string", format: "binary" } },
+          "image/svg+xml": { schema: { type: "string", format: "binary" } },
+          "application/octet-stream": { schema: { type: "string", format: "binary" } },
+        },
+      },
+      403: {
+        description:
+          "Forbidden — the resolved path is outside the allowed content directory. Body is the plain text string 'Forbidden', NOT the standard JSON error shape.",
+        content: {
+          "text/plain": {
+            schema: { type: "string", example: "Forbidden" },
+          },
+        },
+      },
+      404: {
+        description:
+          "Image not found at the resolved path. Body is the plain text string 'Image not found', NOT the standard JSON error shape.",
+        content: {
+          "text/plain": {
+            schema: { type: "string", example: "Image not found" },
+          },
+        },
+      },
+      500: {
+        description:
+          "Internal error while reading the image. Body is the plain text string 'Internal Server Error', NOT the standard JSON error shape.",
+        content: {
+          "text/plain": {
+            schema: { type: "string", example: "Internal Server Error" },
+          },
+        },
+      },
     },
   });
 }

--- a/src/lib/server/openapi/paths/misc.ts
+++ b/src/lib/server/openapi/paths/misc.ts
@@ -59,6 +59,7 @@ const uploadPhotoResponseSchema = z
   })
   .openapi("UploadPhotoResponse");
 
+/** Registra os paths diversos (health, upload, imagens de conteúdo) no registry OpenAPI. */
 export function registerMiscPaths(registry: OpenAPIRegistry, schemas: CommonSchemas): void {
   const { errorResponses } = schemas;
   registry.registerPath({

--- a/src/lib/server/openapi/paths/misc.ts
+++ b/src/lib/server/openapi/paths/misc.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
+
+import { errorResponses } from "../common-schemas";
+
+/**
+ * Miscellaneous endpoints that don't fit into any specific resource group:
+ * health check, file upload, and static content image serving.
+ *
+ * These are registered together to avoid creating three separate files for
+ * one endpoint each. Upload and content-images will be added in later commits
+ * of this PR.
+ */
+
+const healthResponseSchema = z
+  .object({
+    status: z.literal("ok").openapi({
+      description: "Service health indicator. Always 'ok' when the service is reachable.",
+      example: "ok",
+    }),
+  })
+  .openapi("HealthResponse");
+
+export function registerMiscPaths(registry: OpenAPIRegistry): void {
+  registry.registerPath({
+    method: "get",
+    path: "/health",
+    tags: ["Health"],
+    summary: "Service health check",
+    description:
+      "Simple liveness probe for the API service. Returns HTTP 200 with `{ status: 'ok' }` when the service is reachable. Use this for uptime monitoring and load balancer health checks.",
+    responses: {
+      200: {
+        description: "Service is healthy.",
+        content: {
+          "application/json": {
+            schema: healthResponseSchema,
+            example: { status: "ok" },
+          },
+        },
+      },
+      ...errorResponses([500]),
+    },
+  });
+}

--- a/src/lib/server/openapi/paths/misc.ts
+++ b/src/lib/server/openapi/paths/misc.ts
@@ -11,6 +11,7 @@ import type { CommonSchemas } from "../common-schemas";
  * Registrados juntos para evitar criar três arquivos separados de 1 endpoint cada.
  */
 
+/** Shape de resposta do health check. */
 const healthResponseSchema = z
   .object({
     status: z.literal("ok").openapi({

--- a/src/lib/server/openapi/paths/misc.ts
+++ b/src/lib/server/openapi/paths/misc.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 
-import { errorResponses } from "../common-schemas";
+import type { CommonSchemas } from "../common-schemas";
 
 /**
  * Miscellaneous endpoints that don't fit into any specific resource group:
@@ -58,7 +58,8 @@ const uploadPhotoResponseSchema = z
   })
   .openapi("UploadPhotoResponse");
 
-export function registerMiscPaths(registry: OpenAPIRegistry): void {
+export function registerMiscPaths(registry: OpenAPIRegistry, schemas: CommonSchemas): void {
+  const { errorResponses } = schemas;
   registry.registerPath({
     method: "get",
     path: "/health",

--- a/src/lib/server/openapi/paths/misc.ts
+++ b/src/lib/server/openapi/paths/misc.ts
@@ -4,40 +4,41 @@ import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 import type { CommonSchemas } from "../common-schemas";
 
 /**
- * Miscellaneous endpoints that don't fit into any specific resource group:
- * health check, file upload, and static content image serving.
+ * Endpoints diversos que não se encaixam em nenhum grupo de recurso específico:
+ * health check, upload de arquivos e serviço de imagens estáticas dos
+ * submódulos de conteúdo.
  *
- * These are registered together to avoid creating three separate files for
- * one endpoint each.
+ * Registrados juntos para evitar criar três arquivos separados de 1 endpoint cada.
  */
 
 const healthResponseSchema = z
   .object({
     status: z.literal("ok").openapi({
-      description: "Service health indicator. Always 'ok' when the service is reachable.",
+      description: "Indicador de saúde do serviço. Sempre 'ok' quando o serviço está acessível.",
       example: "ok",
     }),
   })
   .openapi("HealthResponse");
 
 /**
- * Multipart form body schema for POST /upload/photo. The file must be sent
- * as a multipart/form-data field named `file`. Zod doesn't have a native
- * binary primitive, so we use `z.unknown()` with an explicit openapi override.
+ * Schema do corpo multipart para POST /upload/photo. O arquivo deve ser enviado
+ * como campo `file` em multipart/form-data. Zod não tem primitivo binário
+ * nativo, então usamos `z.unknown()` com override explícito do openapi.
  */
 const uploadPhotoBodySchema = z
   .object({
     file: z.unknown().openapi({
       type: "string",
       format: "binary",
-      description: "Image file to upload. Max 5MB. Allowed MIME types: JPEG, PNG, WebP, GIF.",
+      description:
+        "Arquivo de imagem para upload. Máximo 5MB. MIME types aceitos: JPEG, PNG, WebP, GIF.",
     }),
   })
   .openapi("UploadPhotoBody");
 
 /**
- * Reuses the same user profile shape returned by /auth/me and /usuarios/slug/{slug}.
- * Kept minimal here since the full profile schema lives in paths/usuarios.ts.
+ * Reusa o mesmo shape de perfil retornado por /auth/me e /usuarios/slug/{slug}.
+ * Mantido mínimo aqui — o schema completo de perfil vive em paths/usuarios.ts.
  */
 const uploadPhotoResponseSchema = z
   .object({
@@ -48,7 +49,7 @@ const uploadPhotoResponseSchema = z
     papelPlataforma: z.enum(["USER", "MASTER_ADMIN"]),
     eVerificado: z.boolean(),
     urlFotoPerfil: z.string().nullable().openapi({
-      description: "URL of the newly uploaded photo in blob storage.",
+      description: "URL da foto recém-enviada no blob storage.",
       example: "https://blob.vercel-storage.com/photos/550e8400-1712668800.webp",
     }),
     periodoAtual: z.string().nullable().optional(),
@@ -64,12 +65,12 @@ export function registerMiscPaths(registry: OpenAPIRegistry, schemas: CommonSche
     method: "get",
     path: "/health",
     tags: ["Health"],
-    summary: "Service health check",
+    summary: "Health check do serviço",
     description:
-      "Simple liveness probe for the API service. Returns HTTP 200 with `{ status: 'ok' }` when the service is reachable. Use this for uptime monitoring and load balancer health checks.",
+      "Liveness probe simples da API. Retorna HTTP 200 com `{ status: 'ok' }` quando o serviço está acessível. Útil para monitoramento de uptime e health checks de load balancer.",
     responses: {
       200: {
-        description: "Service is healthy.",
+        description: "Serviço saudável.",
         content: {
           "application/json": {
             schema: healthResponseSchema,
@@ -84,9 +85,9 @@ export function registerMiscPaths(registry: OpenAPIRegistry, schemas: CommonSche
     method: "post",
     path: "/upload/photo",
     tags: ["Upload"],
-    summary: "Upload a profile photo for the current user",
+    summary: "Enviar foto de perfil do usuário atual",
     description:
-      "Upload a photo (max 5 MB, JPEG/PNG/WebP/GIF) and atomically update the user's profile. Returns the updated user.",
+      "Faz upload de uma foto (máximo 5MB, JPEG/PNG/WebP/GIF) e atualiza o perfil do usuário atomicamente. Retorna o usuário atualizado.",
     security: [{ bearerAuth: [] }],
     request: {
       body: {
@@ -100,7 +101,7 @@ export function registerMiscPaths(registry: OpenAPIRegistry, schemas: CommonSche
     },
     responses: {
       200: {
-        description: "Photo uploaded and user profile updated.",
+        description: "Foto enviada e perfil atualizado.",
         content: { "application/json": { schema: uploadPhotoResponseSchema } },
       },
       ...errorResponses([400]),
@@ -110,21 +111,21 @@ export function registerMiscPaths(registry: OpenAPIRegistry, schemas: CommonSche
   registry.registerPath({
     method: "get",
     path: "/content-images/{path}",
-    tags: ["Content Images"],
-    summary: "Serve a static image from the content submodules",
+    tags: ["Imagens de Conteúdo"],
+    summary: "Servir imagem estática dos submódulos de conteúdo",
     description:
-      "Serve a static image from `content/` git submodules. Path uses slug matching (accent-stripped, priority prefixes ignored). Supported roots: `entidades/*`, `assets/entidades/*`, `mapas/*`, or default (guias). **Errors return plain text**, not JSON — compatible with `<img>` tags.",
+      "Serve uma imagem estática dos submódulos git em `content/`. O path usa slug matching (sem acentos, prefixos de prioridade ignorados). Roots suportados: `entidades/*`, `assets/entidades/*`, `mapas/*`, ou padrão (guias). **Erros retornam texto plano**, não JSON — compatível com tags `<img>`.",
     request: {
       params: z.object({
         path: z.string().openapi({
-          description: "Slash-joined path segments (catch-all).",
+          description: "Segmentos de path concatenados por barra (catch-all).",
           example: "entidades/pet-computacao.png",
         }),
       }),
     },
     responses: {
       200: {
-        description: "Image binary. Cached for 1 year (`Cache-Control: immutable`).",
+        description: "Imagem binária. Cacheada por 1 ano (`Cache-Control: immutable`).",
         content: {
           "image/png": { schema: { type: "string", format: "binary" } },
           "image/jpeg": { schema: { type: "string", format: "binary" } },
@@ -135,7 +136,7 @@ export function registerMiscPaths(registry: OpenAPIRegistry, schemas: CommonSche
         },
       },
       404: {
-        description: "Image not found (plain text body).",
+        description: "Imagem não encontrada (corpo em texto plano).",
         content: {
           "text/plain": {
             schema: { type: "string", example: "Image not found" },

--- a/src/lib/server/openapi/paths/search.ts
+++ b/src/lib/server/openapi/paths/search.ts
@@ -69,7 +69,7 @@ export function registerSearchPaths(registry: OpenAPIRegistry, schemas: CommonSc
     tags: ["Search"],
     summary: "Unified full-text search across all entity categories",
     description:
-      "Execute a unified full-text search across all major entity categories (static pages, guides, entities, jobs, disciplines, courses, users). Uses PostgreSQL full-text search with the `unaccent` extension, so queries match Brazilian Portuguese accents transparently. Results are ranked by relevance using `ts_rank`. Queries shorter than 3 characters return an empty result set without hitting the database.",
+      "Full-text search across pages, guides, entities, vagas, disciplines, courses and users. Accent-insensitive (Brazilian Portuguese). Queries shorter than 3 characters return empty results.",
     request: {
       query: z.object({
         q: z.string().min(3).openapi({
@@ -85,7 +85,7 @@ export function registerSearchPaths(registry: OpenAPIRegistry, schemas: CommonSc
     responses: {
       200: {
         description:
-          "Search results grouped by category. Categories with no matches return empty arrays instead of being omitted.",
+          "Search results grouped by category (empty arrays where there are no matches).",
         content: {
           "application/json": {
             schema: searchResponseSchema,
@@ -143,7 +143,6 @@ export function registerSearchPaths(registry: OpenAPIRegistry, schemas: CommonSc
           },
         },
       },
-      ...errorResponses([500]),
     },
   });
 }

--- a/src/lib/server/openapi/paths/search.ts
+++ b/src/lib/server/openapi/paths/search.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 
-import { errorResponses } from "../common-schemas";
+import type { CommonSchemas } from "../common-schemas";
 
 /**
  * Shared minimal shape for search result items. Each result category has
@@ -61,7 +61,8 @@ const searchResponseSchema = z
   })
   .openapi("SearchResponse");
 
-export function registerSearchPaths(registry: OpenAPIRegistry): void {
+export function registerSearchPaths(registry: OpenAPIRegistry, schemas: CommonSchemas): void {
+  const { errorResponses } = schemas;
   registry.registerPath({
     method: "get",
     path: "/search",

--- a/src/lib/server/openapi/paths/search.ts
+++ b/src/lib/server/openapi/paths/search.ts
@@ -71,9 +71,9 @@ export function registerSearchPaths(registry: OpenAPIRegistry, _schemas: CommonS
       "Full-text search em páginas, guias, entidades, vagas, disciplinas, cursos e usuários. Acento-insensível (português). Queries com menos de 3 caracteres retornam resultados vazios.",
     request: {
       query: z.object({
-        q: z.string().min(3).openapi({
+        q: z.string().optional().openapi({
           description:
-            "Termo de busca. Mínimo de 3 caracteres; queries menores retornam resultados vazios.",
+            "Termo de busca. Se ausente ou com menos de 3 caracteres, retorna resultados vazios.",
           example: "computação",
         }),
         limit: z.coerce.number().int().min(1).max(20).default(5).openapi({

--- a/src/lib/server/openapi/paths/search.ts
+++ b/src/lib/server/openapi/paths/search.ts
@@ -4,44 +4,44 @@ import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 import type { CommonSchemas } from "../common-schemas";
 
 /**
- * Shared minimal shape for search result items. Each result category has
- * slightly different fields (entities have sigla, disciplines have codigo, etc),
- * but all include at least `id`, `title` and `url` for the Scalar UI to render
- * meaningful examples.
+ * Shape mínimo compartilhado pelos itens de resultado da busca. Cada categoria
+ * tem campos ligeiramente diferentes (entidades têm sigla, disciplinas têm
+ * código, etc), mas todos incluem pelo menos `id`, `title` e `url`.
  */
 const searchResultItemSchema = z
   .object({
     id: z.string().openapi({
-      description: "Entity identifier (UUID for DB-backed items, slug for static pages).",
+      description: "Identificador do item (UUID para itens do banco, slug para páginas estáticas).",
       example: "550e8400-e29b-41d4-a716-446655440000",
     }),
     title: z.string().openapi({
-      description: "Primary display text for the result item.",
+      description: "Texto principal exibido para o item.",
       example: "Centro de Informática",
     }),
     subtitle: z.string().nullable().optional().openapi({
-      description: "Secondary display text (sigla, category, etc).",
+      description: "Texto secundário (sigla, categoria, etc).",
       example: "CI",
     }),
     url: z.string().openapi({
-      description: "In-app URL to navigate to the full item.",
+      description: "URL interna para navegar até o item completo.",
       example: "/entidade/centro-de-informatica",
     }),
     rank: z.number().optional().openapi({
-      description: "PostgreSQL full-text search rank score (higher is more relevant).",
+      description:
+        "Score de relevância do full-text search do PostgreSQL (quanto maior, mais relevante).",
       example: 0.87,
     }),
   })
   .openapi("SearchResultItem");
 
 /**
- * Unified search response. Results are grouped by entity category so the
- * command palette UI can render them in separate sections.
+ * Resposta unificada da busca. Resultados são agrupados por categoria para que
+ * a UI do command palette possa renderizá-los em seções separadas.
  */
 const searchResponseSchema = z
   .object({
     query: z.string().openapi({
-      description: "The normalized search query that was executed.",
+      description: "Query de busca normalizada que foi executada.",
       example: "computação",
     }),
     results: z
@@ -56,7 +56,7 @@ const searchResponseSchema = z
       })
       .openapi({
         description:
-          "Results grouped by category. Empty arrays are returned for categories with no matches.",
+          "Resultados agrupados por categoria. Categorias sem resultados retornam array vazio.",
       }),
   })
   .openapi("SearchResponse");
@@ -66,18 +66,19 @@ export function registerSearchPaths(registry: OpenAPIRegistry, schemas: CommonSc
   registry.registerPath({
     method: "get",
     path: "/search",
-    tags: ["Search"],
-    summary: "Unified full-text search across all entity categories",
+    tags: ["Busca"],
+    summary: "Busca unificada em todas as categorias",
     description:
-      "Full-text search across pages, guides, entities, vagas, disciplines, courses and users. Accent-insensitive (Brazilian Portuguese). Queries shorter than 3 characters return empty results.",
+      "Full-text search em páginas, guias, entidades, vagas, disciplinas, cursos e usuários. Acento-insensível (português). Queries com menos de 3 caracteres retornam resultados vazios.",
     request: {
       query: z.object({
         q: z.string().min(3).openapi({
-          description: "Search query. Minimum 3 characters; shorter queries return empty results.",
+          description:
+            "Termo de busca. Mínimo de 3 caracteres; queries menores retornam resultados vazios.",
           example: "computação",
         }),
         limit: z.coerce.number().int().min(1).max(20).default(5).openapi({
-          description: "Maximum results per category (1-20, default 5).",
+          description: "Número máximo de resultados por categoria (1-20, padrão 5).",
           example: 5,
         }),
       }),
@@ -85,7 +86,7 @@ export function registerSearchPaths(registry: OpenAPIRegistry, schemas: CommonSc
     responses: {
       200: {
         description:
-          "Search results grouped by category (empty arrays where there are no matches).",
+          "Resultados da busca agrupados por categoria (arrays vazios onde não há matches).",
         content: {
           "application/json": {
             schema: searchResponseSchema,

--- a/src/lib/server/openapi/paths/search.ts
+++ b/src/lib/server/openapi/paths/search.ts
@@ -61,8 +61,7 @@ const searchResponseSchema = z
   })
   .openapi("SearchResponse");
 
-export function registerSearchPaths(registry: OpenAPIRegistry, schemas: CommonSchemas): void {
-  const { errorResponses } = schemas;
+export function registerSearchPaths(registry: OpenAPIRegistry, _schemas: CommonSchemas): void {
   registry.registerPath({
     method: "get",
     path: "/search",

--- a/src/lib/server/openapi/paths/search.ts
+++ b/src/lib/server/openapi/paths/search.ts
@@ -1,0 +1,148 @@
+import { z } from "zod";
+import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
+
+import { errorResponses } from "../common-schemas";
+
+/**
+ * Shared minimal shape for search result items. Each result category has
+ * slightly different fields (entities have sigla, disciplines have codigo, etc),
+ * but all include at least `id`, `title` and `url` for the Scalar UI to render
+ * meaningful examples.
+ */
+const searchResultItemSchema = z
+  .object({
+    id: z.string().openapi({
+      description: "Entity identifier (UUID for DB-backed items, slug for static pages).",
+      example: "550e8400-e29b-41d4-a716-446655440000",
+    }),
+    title: z.string().openapi({
+      description: "Primary display text for the result item.",
+      example: "Centro de Informática",
+    }),
+    subtitle: z.string().nullable().optional().openapi({
+      description: "Secondary display text (sigla, category, etc).",
+      example: "CI",
+    }),
+    url: z.string().openapi({
+      description: "In-app URL to navigate to the full item.",
+      example: "/entidade/centro-de-informatica",
+    }),
+    rank: z.number().optional().openapi({
+      description: "PostgreSQL full-text search rank score (higher is more relevant).",
+      example: 0.87,
+    }),
+  })
+  .openapi("SearchResultItem");
+
+/**
+ * Unified search response. Results are grouped by entity category so the
+ * command palette UI can render them in separate sections.
+ */
+const searchResponseSchema = z
+  .object({
+    query: z.string().openapi({
+      description: "The normalized search query that was executed.",
+      example: "computação",
+    }),
+    results: z
+      .object({
+        paginas: z.array(searchResultItemSchema),
+        guias: z.array(searchResultItemSchema),
+        entidades: z.array(searchResultItemSchema),
+        vagas: z.array(searchResultItemSchema),
+        disciplinas: z.array(searchResultItemSchema),
+        cursos: z.array(searchResultItemSchema),
+        usuarios: z.array(searchResultItemSchema),
+      })
+      .openapi({
+        description:
+          "Results grouped by category. Empty arrays are returned for categories with no matches.",
+      }),
+  })
+  .openapi("SearchResponse");
+
+export function registerSearchPaths(registry: OpenAPIRegistry): void {
+  registry.registerPath({
+    method: "get",
+    path: "/search",
+    tags: ["Search"],
+    summary: "Unified full-text search across all entity categories",
+    description:
+      "Execute a unified full-text search across all major entity categories (static pages, guides, entities, jobs, disciplines, courses, users). Uses PostgreSQL full-text search with the `unaccent` extension, so queries match Brazilian Portuguese accents transparently. Results are ranked by relevance using `ts_rank`. Queries shorter than 3 characters return an empty result set without hitting the database.",
+    request: {
+      query: z.object({
+        q: z.string().min(3).openapi({
+          description: "Search query. Minimum 3 characters; shorter queries return empty results.",
+          example: "computação",
+        }),
+        limit: z.coerce.number().int().min(1).max(20).default(5).openapi({
+          description: "Maximum results per category (1-20, default 5).",
+          example: 5,
+        }),
+      }),
+    },
+    responses: {
+      200: {
+        description:
+          "Search results grouped by category. Categories with no matches return empty arrays instead of being omitted.",
+        content: {
+          "application/json": {
+            schema: searchResponseSchema,
+            example: {
+              query: "computação",
+              results: {
+                paginas: [
+                  {
+                    id: "curriculos",
+                    title: "Currículos",
+                    subtitle: "Grades curriculares dos cursos",
+                    url: "/curriculos",
+                  },
+                ],
+                guias: [
+                  {
+                    id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                    title: "Guia do Calouro de Ciência da Computação",
+                    subtitle: "Guia",
+                    url: "/guias/a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                    rank: 0.92,
+                  },
+                ],
+                entidades: [
+                  {
+                    id: "b2c3d4e5-f6a7-8901-bcde-f23456789012",
+                    title: "Centro de Informática",
+                    subtitle: "CI",
+                    url: "/entidade/centro-de-informatica",
+                    rank: 0.87,
+                  },
+                ],
+                vagas: [],
+                disciplinas: [
+                  {
+                    id: "c3d4e5f6-a7b8-9012-cdef-345678901234",
+                    title: "Introdução à Computação",
+                    subtitle: "DCE1001",
+                    url: "/disciplinas/dce1001",
+                    rank: 0.81,
+                  },
+                ],
+                cursos: [
+                  {
+                    id: "d4e5f6a7-b8c9-0123-defa-456789012345",
+                    title: "Ciência da Computação",
+                    subtitle: "Bacharelado",
+                    url: "/curso/ciencia-da-computacao",
+                    rank: 0.95,
+                  },
+                ],
+                usuarios: [],
+              },
+            },
+          },
+        },
+      },
+      ...errorResponses([500]),
+    },
+  });
+}

--- a/src/lib/server/openapi/paths/search.ts
+++ b/src/lib/server/openapi/paths/search.ts
@@ -61,6 +61,7 @@ const searchResponseSchema = z
   })
   .openapi("SearchResponse");
 
+/** Registra os paths de busca unificada no registry OpenAPI. */
 export function registerSearchPaths(registry: OpenAPIRegistry, _schemas: CommonSchemas): void {
   registry.registerPath({
     method: "get",

--- a/src/lib/server/openapi/paths/usuarios.ts
+++ b/src/lib/server/openapi/paths/usuarios.ts
@@ -1,20 +1,22 @@
 import { z } from "zod";
 import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 
-import { updateUserInfoSchema } from "@/app/api/usuarios/[id]/info/route";
-import { updateRoleSchema } from "@/app/api/usuarios/[id]/role/route";
-import { updateSlugSchema } from "@/app/api/usuarios/[id]/slug/route";
-import { createFacadeUserSchema } from "@/app/api/usuarios/facade/route";
-import { mergeFacadeUserSchema } from "@/app/api/usuarios/merge-facade/route";
-import { updateCompletedDisciplinasSchema } from "@/app/api/usuarios/me/disciplinas/route";
-import { marcarDisciplinasSchema } from "@/app/api/usuarios/me/disciplinas/marcar/route";
-import { createOwnMembershipSchema } from "@/app/api/usuarios/me/membros/route";
-import { updateOwnMembershipSchema } from "@/app/api/usuarios/me/membros/[membroId]/route";
-import { patchSchema as onboardingPatchSchema } from "@/app/api/usuarios/me/onboarding/route";
-import { patchSchema as updatePeriodoSchema } from "@/app/api/usuarios/me/periodo/route";
-import { updatePhotoSchema } from "@/app/api/usuarios/me/photo/route";
-import { saveSchema as saveSemestreDisciplinasSchema } from "@/app/api/usuarios/me/semestres/[semestreId]/disciplinas/route";
-import { patchSchema as updateDisciplinaSemestreSchema } from "@/app/api/usuarios/me/semestres/[semestreId]/disciplinas/[disciplinaSemestreId]/route";
+import {
+  updateUserInfoSchema,
+  updateRoleSchema,
+  updateSlugSchema,
+  createFacadeUserSchema,
+  mergeFacadeUserSchema,
+  updateCompletedDisciplinasSchema,
+  marcarDisciplinasSchema,
+  createOwnMembershipSchema,
+  updateOwnMembershipSchema,
+  onboardingPatchSchema,
+  updatePeriodoSchema,
+  updatePhotoSchema,
+  saveSemestreDisciplinasSchema,
+  updateDisciplinaSemestreSchema,
+} from "@/lib/server/api-schemas/usuarios";
 
 import type { CommonSchemas } from "../common-schemas";
 

--- a/src/lib/server/openapi/paths/usuarios.ts
+++ b/src/lib/server/openapi/paths/usuarios.ts
@@ -214,7 +214,12 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
           },
         },
       },
-      ...errorResponses([403]),
+      ...errorResponses([403], {
+        403: {
+          message: "Acesso negado. Permissão de administrador necessária.",
+          code: "FORBIDDEN",
+        },
+      }),
     },
   });
 
@@ -243,7 +248,9 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
           },
         },
       },
-      ...errorResponses([400, 404]),
+      ...errorResponses([400, 404], {
+        404: { message: "Usuário não encontrado", code: "USER_NOT_FOUND" },
+      }),
     },
   });
 
@@ -278,7 +285,9 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
         description: "Dados do usuário atualizados.",
         content: { "application/json": { schema: adminUserResponseSchema } },
       },
-      ...errorResponses([400, 404]),
+      ...errorResponses([400, 404], {
+        404: { message: "Usuário não encontrado", code: "USER_NOT_FOUND" },
+      }),
     },
   });
 
@@ -356,7 +365,9 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
         description: "Papel atualizado com sucesso.",
         content: { "application/json": { schema: adminUserResponseSchema } },
       },
-      ...errorResponses([400, 404]),
+      ...errorResponses([400, 404], {
+        404: { message: "Usuário não encontrado", code: "USER_NOT_FOUND" },
+      }),
     },
   });
 
@@ -388,7 +399,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
         description: "Slug atualizado.",
         content: { "application/json": { schema: adminUserResponseSchema } },
       },
-      ...errorResponses([400, 409]),
+      ...errorResponses([400]),
     },
   });
 
@@ -412,7 +423,9 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
         description: "Perfil do usuário.",
         content: { "application/json": { schema: userProfileSchema } },
       },
-      ...errorResponses([404]),
+      ...errorResponses([404], {
+        404: { message: "Usuário não encontrado", code: "USER_NOT_FOUND" },
+      }),
     },
   });
 
@@ -447,7 +460,9 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
         description: "Usuário facade criado.",
         content: { "application/json": { schema: adminUserResponseSchema } },
       },
-      ...errorResponses([400, 404]),
+      ...errorResponses([400, 404], {
+        404: { message: "Centro não encontrado", code: "NOT_FOUND" },
+      }),
     },
   });
 
@@ -653,7 +668,10 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
         description: "Membresia criada.",
         content: { "application/json": { schema: membershipResponseSchema } },
       },
-      ...errorResponses([400, 404, 409]),
+      ...errorResponses([400, 404, 409], {
+        404: { message: "Entidade não encontrada", code: "ENTIDADE_NOT_FOUND" },
+        409: { message: "Este usuário já é membro ativo desta entidade", code: "ALREADY_MEMBER" },
+      }),
     },
   });
 
@@ -685,7 +703,9 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
         description: "Membresia atualizada.",
         content: { "application/json": { schema: membershipResponseSchema } },
       },
-      ...errorResponses([400, 404]),
+      ...errorResponses([400, 404], {
+        404: { message: "Membresia não encontrada", code: "MEMBRO_NOT_FOUND" },
+      }),
     },
   });
 
@@ -710,7 +730,9 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
           },
         },
       },
-      ...errorResponses([404]),
+      ...errorResponses([404], {
+        404: { message: "Membresia não encontrada", code: "MEMBRO_NOT_FOUND" },
+      }),
     },
   });
 
@@ -921,7 +943,9 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
         description: "Disciplinas matriculadas substituídas.",
         content: { "application/json": { schema: semestreDisciplinasResponseSchema } },
       },
-      ...errorResponses([400, 404]),
+      ...errorResponses([400, 404], {
+        404: { message: "Semestre ativo não encontrado", code: "NOT_FOUND" },
+      }),
     },
   });
 
@@ -956,7 +980,9 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
         description: "Disciplina atualizada.",
         content: { "application/json": { schema: disciplinaSemestreResponseSchema } },
       },
-      ...errorResponses([400, 404]),
+      ...errorResponses([400, 404], {
+        404: { message: "Disciplina do semestre não encontrada", code: "NOT_FOUND" },
+      }),
     },
   });
 }

--- a/src/lib/server/openapi/paths/usuarios.ts
+++ b/src/lib/server/openapi/paths/usuarios.ts
@@ -16,7 +16,7 @@ import { updatePhotoSchema } from "@/app/api/usuarios/me/photo/route";
 import { saveSchema as saveSemestreDisciplinasSchema } from "@/app/api/usuarios/me/semestres/[semestreId]/disciplinas/route";
 import { patchSchema as updateDisciplinaSemestreSchema } from "@/app/api/usuarios/me/semestres/[semestreId]/disciplinas/[disciplinaSemestreId]/route";
 
-import { errorResponses, PaginationMetaSchema } from "../common-schemas";
+import type { CommonSchemas } from "../common-schemas";
 
 /**
  * User profile shape returned by the `formatUserResponse` mapper. Mirrors the
@@ -73,16 +73,6 @@ const adminUserResponseSchema = userProfileSchema
     }),
   })
   .openapi("AdminUserResponse");
-
-/**
- * Paginated user list envelope for GET /usuarios (with ?page and ?limit).
- */
-const paginatedUsersResponseSchema = z
-  .object({
-    users: z.array(adminUserResponseSchema),
-    pagination: PaginationMetaSchema,
-  })
-  .openapi("PaginatedUsersResponse");
 
 /**
  * Simplified entity summary embedded in membership responses.
@@ -168,7 +158,21 @@ const messageResponseSchema = z
   .object({ message: z.string() })
   .openapi({ description: "Simple status message response." });
 
-export function registerUsuariosPaths(registry: OpenAPIRegistry): void {
+export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: CommonSchemas): void {
+  const { errorResponses, PaginationMetaSchema } = schemas;
+
+  /**
+   * Paginated user list envelope for GET /usuarios (with ?page and ?limit).
+   * Defined inside the register function so it can reference the shared
+   * PaginationMetaSchema from the current registry — building it at module
+   * level would capture a stale reference across multiple document generations.
+   */
+  const paginatedUsersResponseSchema = z
+    .object({
+      users: z.array(adminUserResponseSchema),
+      pagination: PaginationMetaSchema,
+    })
+    .openapi("PaginatedUsersResponse");
   // ============================================================================
   // GET /usuarios — three-mode listing (see edge case documentation)
   // ============================================================================

--- a/src/lib/server/openapi/paths/usuarios.ts
+++ b/src/lib/server/openapi/paths/usuarios.ts
@@ -162,6 +162,7 @@ const messageResponseSchema = z
   .object({ message: z.string() })
   .openapi({ description: "Resposta simples com mensagem de status." });
 
+/** Registra os paths de usuários no registry OpenAPI. */
 export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: CommonSchemas): void {
   const { errorResponses, PaginationMetaSchema } = schemas;
 

--- a/src/lib/server/openapi/paths/usuarios.ts
+++ b/src/lib/server/openapi/paths/usuarios.ts
@@ -182,9 +182,9 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
     method: "get",
     path: "/usuarios",
     tags: ["Users"],
-    summary: "List users (three modes: search, paginated, or all)",
+    summary: "List users (search, paginated, or all)",
     description:
-      "This endpoint has **three distinct modes** depending on the query parameters supplied, each with different authentication requirements:\n\n- **Search mode** (`?search=term` without `?page`): returns an envelope with users matching the query. Requires any authenticated user (`bearerAuth`).\n- **Paginated mode** (`?page=N` and/or `?limit=N`): returns a paginated envelope `{ users, pagination }`. Requires MASTER_ADMIN role.\n- **Full dump mode** (no query params): returns an array of ALL users (legacy backward-compatibility mode). Requires MASTER_ADMIN role.\n\nThe response shape differs across modes — consumers should check for the presence of the `pagination` key to distinguish the envelope form from the raw array form.",
+      "Three modes:\n- `?search=X`: envelope of matching users (any authenticated user)\n- `?page=N`: paginated envelope (admin only)\n- no params: raw array of all users (admin only)\n\nCheck for `pagination` key to distinguish envelope from array.",
     security: [{ bearerAuth: [] }],
     request: {
       query: z.object({
@@ -203,15 +203,14 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
     },
     responses: {
       200: {
-        description:
-          "Users matching the query. Response shape depends on the mode: paginated envelope `{ users, pagination }` for search/pagination modes, bare array for full dump mode.",
+        description: "Users (envelope in search/paginated modes, array in full-dump mode).",
         content: {
           "application/json": {
             schema: z.union([paginatedUsersResponseSchema, z.array(adminUserResponseSchema)]),
           },
         },
       },
-      ...errorResponses([401, 403, 500]),
+      ...errorResponses([403]),
     },
   });
 
@@ -223,8 +222,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
     path: "/usuarios/{id}",
     tags: ["Users"],
     summary: "Delete a user (admin only)",
-    description:
-      "Permanently delete a user account. Admins cannot delete their own account through this endpoint — a 400 is returned in that case to prevent accidental lockout.",
+    description: "Delete a user account. Admins cannot delete themselves (returns 400).",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({
@@ -241,7 +239,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
           },
         },
       },
-      ...errorResponses([400, 401, 403, 404, 500]),
+      ...errorResponses([400, 404]),
     },
   });
 
@@ -276,7 +274,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
         description: "User info updated.",
         content: { "application/json": { schema: adminUserResponseSchema } },
       },
-      ...errorResponses([400, 401, 403, 404, 500]),
+      ...errorResponses([400, 404]),
     },
   });
 
@@ -323,7 +321,6 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
           },
         },
       },
-      ...errorResponses([500]),
     },
   });
 
@@ -355,7 +352,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
         description: "Role updated successfully.",
         content: { "application/json": { schema: adminUserResponseSchema } },
       },
-      ...errorResponses([400, 401, 403, 404, 500]),
+      ...errorResponses([400, 404]),
     },
   });
 
@@ -387,7 +384,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
         description: "Slug updated.",
         content: { "application/json": { schema: adminUserResponseSchema } },
       },
-      ...errorResponses([400, 401, 403, 409, 500]),
+      ...errorResponses([400, 409]),
     },
   });
 
@@ -411,7 +408,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
         description: "User profile.",
         content: { "application/json": { schema: userProfileSchema } },
       },
-      ...errorResponses([404, 500]),
+      ...errorResponses([404]),
     },
   });
 
@@ -446,7 +443,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
         description: "Facade user created.",
         content: { "application/json": { schema: adminUserResponseSchema } },
       },
-      ...errorResponses([400, 401, 403, 404, 500]),
+      ...errorResponses([400, 404]),
     },
   });
 
@@ -496,7 +493,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
           },
         },
       },
-      ...errorResponses([400, 401, 403, 500]),
+      ...errorResponses([400]),
     },
   });
 
@@ -526,7 +523,6 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
           },
         },
       },
-      ...errorResponses([401, 500]),
     },
   });
 
@@ -563,7 +559,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
           },
         },
       },
-      ...errorResponses([400, 401, 500]),
+      ...errorResponses([400]),
     },
   });
 
@@ -602,7 +598,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
           },
         },
       },
-      ...errorResponses([400, 401, 500]),
+      ...errorResponses([400]),
     },
   });
 
@@ -622,7 +618,6 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
         description: "List of memberships for the authenticated user.",
         content: { "application/json": { schema: z.array(membershipResponseSchema) } },
       },
-      ...errorResponses([401, 500]),
     },
   });
 
@@ -655,7 +650,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
         description: "Membership created.",
         content: { "application/json": { schema: membershipResponseSchema } },
       },
-      ...errorResponses([400, 401, 404, 409, 500]),
+      ...errorResponses([400, 404, 409]),
     },
   });
 
@@ -687,7 +682,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
         description: "Membership updated.",
         content: { "application/json": { schema: membershipResponseSchema } },
       },
-      ...errorResponses([400, 401, 403, 404, 500]),
+      ...errorResponses([400, 404]),
     },
   });
 
@@ -712,7 +707,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
           },
         },
       },
-      ...errorResponses([401, 403, 404, 500]),
+      ...errorResponses([404]),
     },
   });
 
@@ -741,7 +736,6 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
           },
         },
       },
-      ...errorResponses([401, 500]),
     },
   });
 
@@ -771,7 +765,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
         description: "Onboarding metadata updated.",
         content: { "application/json": { schema: onboardingPatchSchema } },
       },
-      ...errorResponses([400, 401, 500]),
+      ...errorResponses([400]),
     },
   });
 
@@ -807,7 +801,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
           },
         },
       },
-      ...errorResponses([400, 401, 500]),
+      ...errorResponses([400]),
     },
   });
 
@@ -840,7 +834,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
         description: "Photo updated.",
         content: { "application/json": { schema: userProfileSchema } },
       },
-      ...errorResponses([400, 401, 500]),
+      ...errorResponses([400]),
     },
   });
 
@@ -857,7 +851,6 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
         description: "Photo deleted.",
         content: { "application/json": { schema: userProfileSchema } },
       },
-      ...errorResponses([401, 500]),
     },
   });
 
@@ -887,7 +880,6 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
           "Enrolled disciplines for the semester. Returns `{ semestreLetivoId: null, disciplinas: [] }` when `semestreId='ativo'` but no semester is currently active.",
         content: { "application/json": { schema: semestreDisciplinasResponseSchema } },
       },
-      ...errorResponses([401, 500]),
     },
   });
 
@@ -926,7 +918,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
         description: "Enrolled disciplines replaced.",
         content: { "application/json": { schema: semestreDisciplinasResponseSchema } },
       },
-      ...errorResponses([400, 401, 404, 500]),
+      ...errorResponses([400, 404]),
     },
   });
 
@@ -961,7 +953,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
         description: "Discipline updated.",
         content: { "application/json": { schema: disciplinaSemestreResponseSchema } },
       },
-      ...errorResponses([400, 401, 404, 500]),
+      ...errorResponses([400, 404]),
     },
   });
 }

--- a/src/lib/server/openapi/paths/usuarios.ts
+++ b/src/lib/server/openapi/paths/usuarios.ts
@@ -883,6 +883,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
   // ============================================================================
   // GET/PUT /usuarios/me/semestres/{semestreId}/disciplinas — semestreId pode ser UUID ou "ativo"
   // ============================================================================
+  /** Parâmetro de path que aceita UUID ou a string literal 'ativo'. */
   const semestreIdParam = z.object({
     semestreId: z.union([z.string().uuid(), z.literal("ativo")]).openapi({
       description:

--- a/src/lib/server/openapi/paths/usuarios.ts
+++ b/src/lib/server/openapi/paths/usuarios.ts
@@ -21,19 +21,19 @@ import {
 import type { CommonSchemas } from "../common-schemas";
 
 /**
- * User profile shape returned by the `formatUserResponse` mapper. Mirrors the
- * output of src/lib/server/utils/format-user-response.ts — do NOT substitute
- * with the raw Prisma `Usuario` type (it includes sensitive fields).
+ * Shape de perfil de usuário retornado pelo mapper `formatUserResponse`.
+ * Espelha a saída de src/lib/server/utils/format-user-response.ts — NÃO usar
+ * o tipo Prisma `Usuario` direto (ele inclui campos sensíveis).
  *
- * Also used by other endpoints that return a user (PATCH /photo, PATCH /slug,
- * PATCH /info, POST /facade, etc).
+ * Também usado por outros endpoints que retornam um usuário (PATCH /photo,
+ * PATCH /slug, PATCH /info, POST /facade, etc).
  */
 const userProfileSchema = z
   .object({
     id: z.string().uuid().openapi({ example: "550e8400-e29b-41d4-a716-446655440000" }),
     nome: z.string().openapi({ example: "João Silva" }),
     email: z.string().nullable().openapi({
-      description: "Email address. Null for facade users (placeholders created by admins).",
+      description: "Email do usuário. Null para usuários facade (placeholders criados por admins).",
       example: "joao.silva@academico.ufpb.br",
     }),
     slug: z.string().nullable().openapi({ example: "joao-silva" }),
@@ -44,7 +44,7 @@ const userProfileSchema = z
       .nullable()
       .openapi({ example: "https://blob.vercel-storage.com/photos/550e8400-1712668800.webp" }),
     periodoAtual: z.string().nullable().optional().openapi({
-      description: "Current semester (1–12, '12+', or 'graduado'). Null until set by the user.",
+      description: "Período atual (1–12, '12+' ou 'graduado'). Null até o usuário definir.",
       example: "5",
     }),
     centro: z.object({
@@ -63,21 +63,21 @@ const userProfileSchema = z
   .openapi("UserProfile");
 
 /**
- * Extended user shape that includes the `eFacade` flag. Returned by admin-only
- * endpoints (GET /usuarios, POST /facade) so admins can distinguish real users
- * from facade placeholders.
+ * Shape estendido de usuário que inclui o flag `eFacade`. Retornado pelos
+ * endpoints exclusivos de admin (GET /usuarios, POST /facade) para que admins
+ * possam distinguir usuários reais de placeholders facade.
  */
 const adminUserResponseSchema = userProfileSchema
   .extend({
     eFacade: z.boolean().openapi({
-      description: "Whether this is a facade user (placeholder created by an admin, no login).",
+      description: "Indica se este é um usuário facade (placeholder criado por admin, sem login).",
       example: false,
     }),
   })
   .openapi("AdminUserResponse");
 
 /**
- * Simplified entity summary embedded in membership responses.
+ * Resumo simplificado de entidade embutido nas respostas de membresia.
  */
 const membershipEntidadeSchema = z
   .object({
@@ -97,7 +97,7 @@ const membershipEntidadeSchema = z
   .openapi("MembershipEntidade");
 
 /**
- * Cargo (role title) inside an entity membership.
+ * Cargo dentro de uma membresia de entidade.
  */
 const cargoSchema = z
   .object({
@@ -108,8 +108,8 @@ const cargoSchema = z
   .openapi("Cargo");
 
 /**
- * Membership response shape returned by endpoints that list or return
- * memberships (/usuarios/{id}/membros, /usuarios/me/membros, etc).
+ * Shape de resposta de Membresia retornado pelos endpoints que listam ou
+ * retornam membresias (/usuarios/{id}/membros, /usuarios/me/membros, etc).
  */
 const membershipResponseSchema = z
   .object({
@@ -123,7 +123,8 @@ const membershipResponseSchema = z
   .openapi("MembershipResponse");
 
 /**
- * DisciplinaSemestre response shape returned by semester discipline endpoints.
+ * Shape de resposta de DisciplinaSemestre retornado pelos endpoints de
+ * disciplinas por semestre.
  */
 const disciplinaSemestreResponseSchema = z
   .object({
@@ -140,7 +141,7 @@ const disciplinaSemestreResponseSchema = z
   .openapi("DisciplinaSemestreResponse");
 
 /**
- * Envelope for GET/PUT /usuarios/me/semestres/{semestreId}/disciplinas.
+ * Envelope de GET/PUT /usuarios/me/semestres/{semestreId}/disciplinas.
  */
 const semestreDisciplinasResponseSchema = z
   .object({
@@ -148,26 +149,28 @@ const semestreDisciplinasResponseSchema = z
     disciplinas: z.array(disciplinaSemestreResponseSchema),
     skippedCodigos: z.array(z.string()).optional().openapi({
       description:
-        "Discipline codes that could not be resolved to a valid record and were skipped (only present on PUT responses when applicable).",
+        "Códigos de disciplina que não puderam ser resolvidos para um registro válido e foram pulados (presente apenas em respostas de PUT quando aplicável).",
     }),
   })
   .openapi("SemestreDisciplinasResponse");
 
 /**
- * Simple message response used by DELETE endpoints and other success confirmations.
+ * Resposta simples com mensagem usada por endpoints DELETE e outras
+ * confirmações de sucesso.
  */
 const messageResponseSchema = z
   .object({ message: z.string() })
-  .openapi({ description: "Simple status message response." });
+  .openapi({ description: "Resposta simples com mensagem de status." });
 
 export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: CommonSchemas): void {
   const { errorResponses, PaginationMetaSchema } = schemas;
 
   /**
-   * Paginated user list envelope for GET /usuarios (with ?page and ?limit).
-   * Defined inside the register function so it can reference the shared
-   * PaginationMetaSchema from the current registry — building it at module
-   * level would capture a stale reference across multiple document generations.
+   * Envelope de listagem paginada de usuários para GET /usuarios (com `?page`
+   * e `?limit`). Definido dentro da função de registro para que possa
+   * referenciar o `PaginationMetaSchema` compartilhado do registry atual —
+   * construir no nível do módulo capturaria uma referência stale entre
+   * múltiplas gerações de documento.
    */
   const paginatedUsersResponseSchema = z
     .object({
@@ -176,34 +179,35 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
     })
     .openapi("PaginatedUsersResponse");
   // ============================================================================
-  // GET /usuarios — three-mode listing (see edge case documentation)
+  // GET /usuarios — listagem em três modos (ver documentação de edge cases)
   // ============================================================================
   registry.registerPath({
     method: "get",
     path: "/usuarios",
-    tags: ["Users"],
-    summary: "List users (search, paginated, or all)",
+    tags: ["Usuários"],
+    summary: "Listar usuários (busca, paginado ou todos)",
     description:
-      "Three modes:\n- `?search=X`: envelope of matching users (any authenticated user)\n- `?page=N`: paginated envelope (admin only)\n- no params: raw array of all users (admin only)\n\nCheck for `pagination` key to distinguish envelope from array.",
+      "Três modos:\n- `?search=X`: envelope com usuários que combinam (qualquer usuário autenticado)\n- `?page=N`: envelope paginado (apenas admin)\n- sem parâmetros: array bruto com todos os usuários (apenas admin)\n\nVerifique a presença da chave `pagination` para distinguir envelope de array.",
     security: [{ bearerAuth: [] }],
     request: {
       query: z.object({
         search: z.string().optional().openapi({
-          description: "Search term (used in search and paginated modes).",
+          description: "Termo de busca (usado nos modos search e paginado).",
           example: "joão",
         }),
         page: z.coerce.number().int().positive().optional().openapi({ example: 1 }),
         limit: z.coerce.number().int().positive().max(100).optional().openapi({ example: 25 }),
         filter: z.enum(["all", "facade", "real"]).optional().openapi({
           description:
-            "Filter by user type: 'all' (default), 'facade' (placeholder users), or 'real' (normal users with email).",
+            "Filtra por tipo de usuário: 'all' (padrão), 'facade' (usuários placeholder) ou 'real' (usuários normais com email).",
           example: "all",
         }),
       }),
     },
     responses: {
       200: {
-        description: "Users (envelope in search/paginated modes, array in full-dump mode).",
+        description:
+          "Usuários (envelope nos modos search/paginado, array no modo de listagem completa).",
         content: {
           "application/json": {
             schema: z.union([paginatedUsersResponseSchema, z.array(adminUserResponseSchema)]),
@@ -215,14 +219,14 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
   });
 
   // ============================================================================
-  // DELETE /usuarios/{id} — admin-only, prevents self-delete
+  // DELETE /usuarios/{id} — apenas admin, impede auto-exclusão
   // ============================================================================
   registry.registerPath({
     method: "delete",
     path: "/usuarios/{id}",
-    tags: ["Users"],
-    summary: "Delete a user (admin only)",
-    description: "Delete a user account. Admins cannot delete themselves (returns 400).",
+    tags: ["Usuários"],
+    summary: "Excluir um usuário (admin)",
+    description: "Exclui uma conta de usuário. Admins não podem se auto-excluir (retorna 400).",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({
@@ -231,7 +235,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
     },
     responses: {
       200: {
-        description: "User deleted successfully.",
+        description: "Usuário excluído com sucesso.",
         content: {
           "application/json": {
             schema: messageResponseSchema,
@@ -244,15 +248,15 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
   });
 
   // ============================================================================
-  // PATCH /usuarios/{id}/info — admin-only (update centro/curso)
+  // PATCH /usuarios/{id}/info — apenas admin (atualiza centro/curso)
   // ============================================================================
   registry.registerPath({
     method: "patch",
     path: "/usuarios/{id}/info",
-    tags: ["Users"],
-    summary: "Update a user's academic center and/or course (admin only)",
+    tags: ["Usuários"],
+    summary: "Atualizar centro e/ou curso de um usuário (admin)",
     description:
-      "Admin-only endpoint to correct a user's centro and/or curso. Both fields are optional — omit a field to leave it unchanged. Used when users are incorrectly assigned during registration.",
+      "Endpoint exclusivo para administradores. Corrige o centro e/ou curso de um usuário. Ambos os campos são opcionais — omita um campo para mantê-lo inalterado. Útil para corrigir cadastros feitos com dados errados.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({ id: z.string().uuid() }),
@@ -271,7 +275,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
     },
     responses: {
       200: {
-        description: "User info updated.",
+        description: "Dados do usuário atualizados.",
         content: { "application/json": { schema: adminUserResponseSchema } },
       },
       ...errorResponses([400, 404]),
@@ -279,21 +283,21 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
   });
 
   // ============================================================================
-  // GET /usuarios/{id}/membros — list memberships for a user (public)
+  // GET /usuarios/{id}/membros — lista membresias de um usuário (público)
   // ============================================================================
   registry.registerPath({
     method: "get",
     path: "/usuarios/{id}/membros",
-    tags: ["Users"],
-    summary: "List memberships for a specific user",
+    tags: ["Usuários"],
+    summary: "Listar membresias de um usuário",
     description:
-      "Return all entity memberships (active and historical) for the specified user. Public endpoint — useful for displaying a user's affiliations on their profile page.",
+      "Retorna todas as membresias (ativas e históricas) do usuário especificado. Útil para exibir os vínculos de um usuário na página de perfil.",
     request: {
       params: z.object({ id: z.string().uuid() }),
     },
     responses: {
       200: {
-        description: "List of memberships for the user.",
+        description: "Lista de membresias do usuário.",
         content: {
           "application/json": {
             schema: z.array(membershipResponseSchema),
@@ -325,15 +329,15 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
   });
 
   // ============================================================================
-  // PATCH /usuarios/{id}/role — admin-only, prevents self-demotion
+  // PATCH /usuarios/{id}/role — apenas admin, impede auto-rebaixamento
   // ============================================================================
   registry.registerPath({
     method: "patch",
     path: "/usuarios/{id}/role",
-    tags: ["Users"],
-    summary: "Update a user's platform role (admin only)",
+    tags: ["Usuários"],
+    summary: "Atualizar o papel de um usuário na plataforma (admin)",
     description:
-      "Admin-only endpoint to promote or demote users between USER and MASTER_ADMIN. Admins cannot change their own role through this endpoint to prevent accidental lockout.",
+      "Endpoint exclusivo para administradores. Promove ou rebaixa usuários entre USER e MASTER_ADMIN. Admins não podem alterar o próprio papel por este endpoint, para evitar lockout acidental.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({ id: z.string().uuid() }),
@@ -349,7 +353,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
     },
     responses: {
       200: {
-        description: "Role updated successfully.",
+        description: "Papel atualizado com sucesso.",
         content: { "application/json": { schema: adminUserResponseSchema } },
       },
       ...errorResponses([400, 404]),
@@ -357,15 +361,15 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
   });
 
   // ============================================================================
-  // PATCH /usuarios/{id}/slug — admin-only
+  // PATCH /usuarios/{id}/slug — apenas admin
   // ============================================================================
   registry.registerPath({
     method: "patch",
     path: "/usuarios/{id}/slug",
-    tags: ["Users"],
-    summary: "Update a user's slug (admin only)",
+    tags: ["Usuários"],
+    summary: "Atualizar o slug de um usuário (admin)",
     description:
-      "Admin-only endpoint to change a user's URL slug. The slug is normalized (trimmed, lowercased) server-side. Pass null to remove the slug. Slugs must be unique across all users — 409 is returned on collision.",
+      "Endpoint exclusivo para administradores. Altera o slug de URL do usuário. O slug é normalizado (trim e lowercase) no servidor. Envie null para remover o slug. Slugs precisam ser únicos — retorna 409 em caso de colisão.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({ id: z.string().uuid() }),
@@ -381,7 +385,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
     },
     responses: {
       200: {
-        description: "Slug updated.",
+        description: "Slug atualizado.",
         content: { "application/json": { schema: adminUserResponseSchema } },
       },
       ...errorResponses([400, 409]),
@@ -389,15 +393,15 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
   });
 
   // ============================================================================
-  // GET /usuarios/slug/{slug} — public lookup by slug
+  // GET /usuarios/slug/{slug} — busca pública pelo slug
   // ============================================================================
   registry.registerPath({
     method: "get",
     path: "/usuarios/slug/{slug}",
-    tags: ["Users"],
-    summary: "Look up a user by URL slug",
+    tags: ["Usuários"],
+    summary: "Buscar um usuário pelo slug",
     description:
-      "Public endpoint to fetch a user's profile by their slug. Returns the sanitized user profile (no sensitive fields). Used by `/usuarios/[slug]` pages.",
+      "Retorna o perfil de um usuário pelo slug. Devolve o perfil sanitizado (sem campos sensíveis). Usado pelas páginas `/usuarios/[slug]`.",
     request: {
       params: z.object({
         slug: z.string().openapi({ example: "joao-silva" }),
@@ -405,7 +409,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
     },
     responses: {
       200: {
-        description: "User profile.",
+        description: "Perfil do usuário.",
         content: { "application/json": { schema: userProfileSchema } },
       },
       ...errorResponses([404]),
@@ -413,15 +417,15 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
   });
 
   // ============================================================================
-  // POST /usuarios/facade — admin-only, create placeholder user
+  // POST /usuarios/facade — apenas admin, cria usuário placeholder
   // ============================================================================
   registry.registerPath({
     method: "post",
     path: "/usuarios/facade",
-    tags: ["Users"],
-    summary: "Create a facade user (admin only)",
+    tags: ["Usuários"],
+    summary: "Criar um usuário facade (admin)",
     description:
-      "Admin-only endpoint to create a placeholder ('facade') user — a user record without email or password, used to represent non-registered people (historical members, guest speakers, etc) in entity memberships. Facade users can later be merged into real users via POST /usuarios/merge-facade.",
+      "Endpoint exclusivo para administradores. Cria um usuário placeholder ('facade') — um registro sem email nem senha, usado para representar pessoas não cadastradas (membros antigos, palestrantes convidados, etc) em membresias de entidades. Usuários facade podem ser posteriormente mesclados em usuários reais via POST /usuarios/merge-facade.",
     security: [{ bearerAuth: [] }],
     request: {
       body: {
@@ -440,7 +444,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
     },
     responses: {
       200: {
-        description: "Facade user created.",
+        description: "Usuário facade criado.",
         content: { "application/json": { schema: adminUserResponseSchema } },
       },
       ...errorResponses([400, 404]),
@@ -448,15 +452,15 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
   });
 
   // ============================================================================
-  // POST /usuarios/merge-facade — admin-only
+  // POST /usuarios/merge-facade — apenas admin
   // ============================================================================
   registry.registerPath({
     method: "post",
     path: "/usuarios/merge-facade",
-    tags: ["Users"],
-    summary: "Merge a facade user into a real user (admin only)",
+    tags: ["Usuários"],
+    summary: "Mesclar usuário facade em usuário real (admin)",
     description:
-      "Admin-only endpoint to merge a facade user's memberships into a real user account. Membership conflicts (same user already in the same entity) are returned in the response. By default the facade user is deleted after merging — pass `deleteFacade: false` to retain the facade record.",
+      "Endpoint exclusivo para administradores. Mescla as membresias de um usuário facade em uma conta de usuário real. Conflitos de membresia (mesmo usuário já em mesma entidade) são retornados na resposta. Por padrão, o usuário facade é excluído após a mesclagem — envie `deleteFacade: false` para manter o registro facade.",
     security: [{ bearerAuth: [] }],
     request: {
       body: {
@@ -475,7 +479,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
     },
     responses: {
       200: {
-        description: "Merge completed successfully.",
+        description: "Mesclagem realizada com sucesso.",
         content: {
           "application/json": {
             schema: z.object({
@@ -498,19 +502,19 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
   });
 
   // ============================================================================
-  // GET/PUT /usuarios/me/disciplinas — completed disciplines
+  // GET/PUT /usuarios/me/disciplinas — disciplinas concluídas
   // ============================================================================
   registry.registerPath({
     method: "get",
     path: "/usuarios/me/disciplinas",
-    tags: ["Users"],
-    summary: "List completed disciplines for the current user",
+    tags: ["Usuários"],
+    summary: "Listar disciplinas concluídas do usuário atual",
     description:
-      "Return the list of discipline IDs the authenticated user has marked as completed.",
+      "Retorna a lista de IDs das disciplinas que o usuário autenticado marcou como concluídas.",
     security: [{ bearerAuth: [] }],
     responses: {
       200: {
-        description: "List of completed discipline IDs.",
+        description: "Lista de IDs de disciplinas concluídas.",
         content: {
           "application/json": {
             schema: z.object({ disciplinaIds: z.array(z.string().uuid()) }),
@@ -529,10 +533,10 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
   registry.registerPath({
     method: "put",
     path: "/usuarios/me/disciplinas",
-    tags: ["Users"],
-    summary: "Replace the set of completed disciplines for the current user",
+    tags: ["Usuários"],
+    summary: "Substituir o conjunto de disciplinas concluídas do usuário atual",
     description:
-      "Replace the authenticated user's full set of completed disciplines in one request. Any disciplines not in the provided list will be removed from the completed set.",
+      "Substitui o conjunto completo de disciplinas concluídas do usuário autenticado em uma única requisição. Disciplinas não incluídas na lista enviada serão removidas do conjunto.",
     security: [{ bearerAuth: [] }],
     request: {
       body: {
@@ -552,7 +556,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
     },
     responses: {
       200: {
-        description: "Completed disciplines updated.",
+        description: "Disciplinas concluídas atualizadas.",
         content: {
           "application/json": {
             schema: z.object({ disciplinaIds: z.array(z.string().uuid()) }),
@@ -564,15 +568,15 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
   });
 
   // ============================================================================
-  // POST /usuarios/me/disciplinas/marcar — mark with status
+  // POST /usuarios/me/disciplinas/marcar — marca com status
   // ============================================================================
   registry.registerPath({
     method: "post",
     path: "/usuarios/me/disciplinas/marcar",
-    tags: ["Users"],
-    summary: "Mark disciplines with a status (concluida, cursando, or none)",
+    tags: ["Usuários"],
+    summary: "Marcar disciplinas com um status (concluida, cursando ou none)",
     description:
-      "Atomically mark a set of disciplines with a specific status. Uses the currently active semester as the context for the 'cursando' (in progress) status. Marking as 'cursando' removes a previous 'concluida' status on the same disciplines and vice versa. Status 'none' clears any existing marking.",
+      "Marca atomicamente um conjunto de disciplinas com um status específico. Usa o semestre ativo como contexto para o status 'cursando'. Marcar como 'cursando' remove um status 'concluida' anterior nas mesmas disciplinas e vice-versa. O status 'none' limpa qualquer marcação existente.",
     security: [{ bearerAuth: [] }],
     request: {
       body: {
@@ -590,7 +594,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
     },
     responses: {
       200: {
-        description: "Disciplines marked successfully.",
+        description: "Disciplinas marcadas com sucesso.",
         content: {
           "application/json": {
             schema: z.object({ ok: z.literal(true) }),
@@ -603,19 +607,18 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
   });
 
   // ============================================================================
-  // GET/POST /usuarios/me/membros — current user's memberships
+  // GET/POST /usuarios/me/membros — membresias do usuário atual
   // ============================================================================
   registry.registerPath({
     method: "get",
     path: "/usuarios/me/membros",
-    tags: ["Users"],
-    summary: "List the current user's memberships",
-    description:
-      "Return all entity memberships (active and historical) for the authenticated user.",
+    tags: ["Usuários"],
+    summary: "Listar as membresias do usuário atual",
+    description: "Retorna todas as membresias (ativas e históricas) do usuário autenticado.",
     security: [{ bearerAuth: [] }],
     responses: {
       200: {
-        description: "List of memberships for the authenticated user.",
+        description: "Lista de membresias do usuário autenticado.",
         content: { "application/json": { schema: z.array(membershipResponseSchema) } },
       },
     },
@@ -624,10 +627,10 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
   registry.registerPath({
     method: "post",
     path: "/usuarios/me/membros",
-    tags: ["Users"],
-    summary: "Join an entity as a member",
+    tags: ["Usuários"],
+    summary: "Entrar em uma entidade como membro",
     description:
-      "Create a new membership linking the authenticated user to an entity. Regular users can only join as `MEMBRO` — attempting to set `papel: 'ADMIN'` silently downgrades to `MEMBRO` unless the caller is a MASTER_ADMIN. Returns 409 if the user is already an active member of the target entity.",
+      "Cria uma nova membresia vinculando o usuário autenticado a uma entidade. Usuários comuns só podem entrar como `MEMBRO` — tentar definir `papel: 'ADMIN'` é silenciosamente rebaixado para `MEMBRO`, exceto se quem chama for MASTER_ADMIN. Retorna 409 se o usuário já é membro ativo da entidade alvo.",
     security: [{ bearerAuth: [] }],
     request: {
       body: {
@@ -647,7 +650,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
     },
     responses: {
       200: {
-        description: "Membership created.",
+        description: "Membresia criada.",
         content: { "application/json": { schema: membershipResponseSchema } },
       },
       ...errorResponses([400, 404, 409]),
@@ -660,10 +663,10 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
   registry.registerPath({
     method: "put",
     path: "/usuarios/me/membros/{membroId}",
-    tags: ["Users"],
-    summary: "Update one of the current user's memberships",
+    tags: ["Usuários"],
+    summary: "Atualizar uma membresia do usuário atual",
     description:
-      "Update dates, cargo or papel on a membership. The membership must belong to the authenticated user — returns 403 otherwise. Non-admins cannot set `papel: 'ADMIN'` (silently ignored).",
+      "Atualiza datas, cargo ou papel de uma membresia. A membresia deve pertencer ao usuário autenticado — retorna 403 caso contrário. Não-admins não podem definir `papel: 'ADMIN'` (silenciosamente ignorado).",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({ membroId: z.string().uuid() }),
@@ -679,7 +682,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
     },
     responses: {
       200: {
-        description: "Membership updated.",
+        description: "Membresia atualizada.",
         content: { "application/json": { schema: membershipResponseSchema } },
       },
       ...errorResponses([400, 404]),
@@ -689,17 +692,17 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
   registry.registerPath({
     method: "delete",
     path: "/usuarios/me/membros/{membroId}",
-    tags: ["Users"],
-    summary: "Delete one of the current user's memberships",
+    tags: ["Usuários"],
+    summary: "Excluir uma membresia do usuário atual",
     description:
-      "Permanently delete a membership. The membership must belong to the authenticated user — returns 403 otherwise.",
+      "Exclui uma membresia permanentemente. A membresia deve pertencer ao usuário autenticado — retorna 403 caso contrário.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({ membroId: z.string().uuid() }),
     },
     responses: {
       200: {
-        description: "Membership deleted.",
+        description: "Membresia excluída.",
         content: {
           "application/json": {
             schema: messageResponseSchema,
@@ -717,14 +720,14 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
   registry.registerPath({
     method: "get",
     path: "/usuarios/me/onboarding",
-    tags: ["Users"],
-    summary: "Get the current user's onboarding progress",
+    tags: ["Usuários"],
+    summary: "Obter o progresso de onboarding do usuário atual",
     description:
-      "Return the onboarding metadata object tracking which onboarding steps the user has completed or skipped. Returns an empty object if no onboarding has been started.",
+      "Retorna o objeto de metadata do onboarding, rastreando quais etapas o usuário já completou ou pulou. Retorna objeto vazio se nenhum onboarding foi iniciado.",
     security: [{ bearerAuth: [] }],
     responses: {
       200: {
-        description: "Onboarding metadata (may be empty).",
+        description: "Metadata do onboarding (pode estar vazio).",
         content: {
           "application/json": {
             schema: onboardingPatchSchema,
@@ -742,10 +745,10 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
   registry.registerPath({
     method: "patch",
     path: "/usuarios/me/onboarding",
-    tags: ["Users"],
-    summary: "Update the current user's onboarding progress",
+    tags: ["Usuários"],
+    summary: "Atualizar o progresso de onboarding do usuário atual",
     description:
-      "Partial update of onboarding metadata. The request body is deep-merged with the existing metadata — only provided keys are updated. The `semesters` field is a map keyed by semester id, allowing per-semester tracking of 'cursando' and 'turmas' steps.",
+      "Atualização parcial dos metadados de onboarding. O corpo da requisição é mesclado em profundidade (deep merge) com o existente — apenas as chaves enviadas são atualizadas. O campo `semesters` é um mapa indexado por ID de semestre, permitindo rastrear as etapas de 'cursando' e 'turmas' por semestre.",
     security: [{ bearerAuth: [] }],
     request: {
       body: {
@@ -762,7 +765,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
     },
     responses: {
       200: {
-        description: "Onboarding metadata updated.",
+        description: "Metadata do onboarding atualizado.",
         content: { "application/json": { schema: onboardingPatchSchema } },
       },
       ...errorResponses([400]),
@@ -775,10 +778,10 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
   registry.registerPath({
     method: "patch",
     path: "/usuarios/me/periodo",
-    tags: ["Users"],
-    summary: "Update the current user's academic period",
+    tags: ["Usuários"],
+    summary: "Atualizar o período acadêmico do usuário atual",
     description:
-      "Update the user's current semester (e.g., '5' for 5th semester, '12+' for 12+ semesters, 'graduado' for graduated). Pass null to clear the field.",
+      "Atualiza o período atual do usuário (ex: '5' para o 5º período, '12+' para 12 ou mais, 'graduado' para já formado). Envie null para limpar o campo.",
     security: [{ bearerAuth: [] }],
     request: {
       body: {
@@ -793,7 +796,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
     },
     responses: {
       200: {
-        description: "Period updated.",
+        description: "Período atualizado.",
         content: {
           "application/json": {
             schema: z.object({ periodoAtual: z.string().nullable() }),
@@ -811,10 +814,10 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
   registry.registerPath({
     method: "patch",
     path: "/usuarios/me/photo",
-    tags: ["Users"],
-    summary: "Update the current user's profile photo URL",
+    tags: ["Usuários"],
+    summary: "Atualizar a URL da foto de perfil do usuário atual",
     description:
-      "Update the profile photo URL for the authenticated user. The URL must point to an already-uploaded image — to upload a new image file, use POST /upload/photo instead (which handles upload + DB update atomically). The old photo is deleted from blob storage if it was hosted there.",
+      "Atualiza a URL da foto de perfil do usuário autenticado. A URL deve apontar para uma imagem já enviada — para fazer upload de um novo arquivo, use POST /upload/photo (que cuida do upload + atualização do banco atomicamente). A foto antiga é excluída do blob storage se estivesse hospedada lá.",
     security: [{ bearerAuth: [] }],
     request: {
       body: {
@@ -831,7 +834,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
     },
     responses: {
       200: {
-        description: "Photo updated.",
+        description: "Foto atualizada.",
         content: { "application/json": { schema: userProfileSchema } },
       },
       ...errorResponses([400]),
@@ -841,26 +844,26 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
   registry.registerPath({
     method: "delete",
     path: "/usuarios/me/photo",
-    tags: ["Users"],
-    summary: "Delete the current user's profile photo",
+    tags: ["Usuários"],
+    summary: "Excluir a foto de perfil do usuário atual",
     description:
-      "Remove the authenticated user's profile photo and delete the file from blob storage if it was hosted there.",
+      "Remove a foto de perfil do usuário autenticado e exclui o arquivo do blob storage se estivesse hospedada lá.",
     security: [{ bearerAuth: [] }],
     responses: {
       200: {
-        description: "Photo deleted.",
+        description: "Foto excluída.",
         content: { "application/json": { schema: userProfileSchema } },
       },
     },
   });
 
   // ============================================================================
-  // GET/PUT /usuarios/me/semestres/{semestreId}/disciplinas — semestreId can be UUID or "ativo"
+  // GET/PUT /usuarios/me/semestres/{semestreId}/disciplinas — semestreId pode ser UUID ou "ativo"
   // ============================================================================
   const semestreIdParam = z.object({
     semestreId: z.union([z.string().uuid(), z.literal("ativo")]).openapi({
       description:
-        "Either a specific semester UUID, or the literal string 'ativo' to target the currently active semester.",
+        "Um UUID de semestre específico ou a string literal 'ativo' para mirar o semestre atualmente ativo.",
       example: "ativo",
     }),
   });
@@ -868,16 +871,16 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
   registry.registerPath({
     method: "get",
     path: "/usuarios/me/semestres/{semestreId}/disciplinas",
-    tags: ["Users"],
-    summary: "List the current user's enrolled disciplines for a semester",
+    tags: ["Usuários"],
+    summary: "Listar disciplinas matriculadas no semestre (usuário atual)",
     description:
-      "Return the disciplines the authenticated user is currently enrolled in for the specified semester. The `semestreId` path parameter accepts either a UUID (for a specific semester) or the literal string `'ativo'`, which auto-resolves to the currently active semester.",
+      "Retorna as disciplinas em que o usuário autenticado está matriculado no semestre especificado. O parâmetro `semestreId` aceita um UUID (para um semestre específico) ou a string literal `'ativo'`, que resolve automaticamente para o semestre ativo.",
     security: [{ bearerAuth: [] }],
     request: { params: semestreIdParam },
     responses: {
       200: {
         description:
-          "Enrolled disciplines for the semester. Returns `{ semestreLetivoId: null, disciplinas: [] }` when `semestreId='ativo'` but no semester is currently active.",
+          "Disciplinas matriculadas no semestre. Retorna `{ semestreLetivoId: null, disciplinas: [] }` quando `semestreId='ativo'` mas nenhum semestre está ativo.",
         content: { "application/json": { schema: semestreDisciplinasResponseSchema } },
       },
     },
@@ -886,10 +889,10 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
   registry.registerPath({
     method: "put",
     path: "/usuarios/me/semestres/{semestreId}/disciplinas",
-    tags: ["Users"],
-    summary: "Replace enrolled disciplines for a semester",
+    tags: ["Usuários"],
+    summary: "Substituir disciplinas matriculadas em um semestre",
     description:
-      "Replace the authenticated user's full set of enrolled disciplines for the specified semester. Disciplines are referenced by their PAAS `codigoDisciplina` and resolved to internal IDs server-side. Any codes that cannot be resolved are listed in `skippedCodigos` in the response. `semestreId` accepts a UUID or the literal 'ativo'.",
+      "Substitui o conjunto completo de disciplinas matriculadas do usuário autenticado para o semestre especificado. As disciplinas são referenciadas pelo `codigoDisciplina` do PAAS e resolvidas para IDs internos no servidor. Códigos que não puderem ser resolvidos aparecem em `skippedCodigos` na resposta. `semestreId` aceita um UUID ou a string 'ativo'.",
     security: [{ bearerAuth: [] }],
     request: {
       params: semestreIdParam,
@@ -915,7 +918,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
     },
     responses: {
       200: {
-        description: "Enrolled disciplines replaced.",
+        description: "Disciplinas matriculadas substituídas.",
         content: { "application/json": { schema: semestreDisciplinasResponseSchema } },
       },
       ...errorResponses([400, 404]),
@@ -928,10 +931,10 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
   registry.registerPath({
     method: "patch",
     path: "/usuarios/me/semestres/{semestreId}/disciplinas/{disciplinaSemestreId}",
-    tags: ["Users"],
-    summary: "Update one of the user's enrolled disciplines for a semester",
+    tags: ["Usuários"],
+    summary: "Atualizar uma disciplina matriculada do usuário no semestre",
     description:
-      "Update the turma, docente, horario or codigoPaas fields on a specific enrolled discipline. The discipline must belong to the authenticated user and the specified semester. `semestreId` accepts a UUID or 'ativo'.",
+      "Atualiza os campos turma, docente, horario ou codigoPaas de uma disciplina matriculada específica. A disciplina deve pertencer ao usuário autenticado e ao semestre informado. `semestreId` aceita um UUID ou 'ativo'.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({
@@ -950,7 +953,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
     },
     responses: {
       200: {
-        description: "Discipline updated.",
+        description: "Disciplina atualizada.",
         content: { "application/json": { schema: disciplinaSemestreResponseSchema } },
       },
       ...errorResponses([400, 404]),

--- a/src/lib/server/openapi/paths/usuarios.ts
+++ b/src/lib/server/openapi/paths/usuarios.ts
@@ -381,7 +381,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
     tags: ["Usuários"],
     summary: "Atualizar o slug de um usuário (admin)",
     description:
-      "Endpoint exclusivo para administradores. Altera o slug de URL do usuário. O slug é normalizado (trim e lowercase) no servidor. Envie null para remover o slug. Slugs precisam ser únicos — retorna 409 em caso de colisão.",
+      "Endpoint exclusivo para administradores. Altera o slug de URL do usuário. O slug é normalizado (trim e lowercase) no servidor. Envie null para remover o slug. Slugs são garantidos únicos (auto-resolve colisões).",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({ id: z.string().uuid() }),
@@ -704,7 +704,11 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
         description: "Membresia atualizada.",
         content: { "application/json": { schema: membershipResponseSchema } },
       },
-      ...errorResponses([400, 404], {
+      ...errorResponses([400, 403, 404], {
+        403: {
+          message: "Você só pode editar suas próprias membresias.",
+          code: "FORBIDDEN",
+        },
         404: { message: "Membresia não encontrada", code: "MEMBRO_NOT_FOUND" },
       }),
     },
@@ -731,7 +735,11 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
           },
         },
       },
-      ...errorResponses([404], {
+      ...errorResponses([403, 404], {
+        403: {
+          message: "Você só pode deletar suas próprias membresias.",
+          code: "FORBIDDEN",
+        },
         404: { message: "Membresia não encontrada", code: "MEMBRO_NOT_FOUND" },
       }),
     },

--- a/src/lib/server/openapi/paths/usuarios.ts
+++ b/src/lib/server/openapi/paths/usuarios.ts
@@ -1,0 +1,961 @@
+import { z } from "zod";
+import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
+
+import { updateUserInfoSchema } from "@/app/api/usuarios/[id]/info/route";
+import { updateRoleSchema } from "@/app/api/usuarios/[id]/role/route";
+import { updateSlugSchema } from "@/app/api/usuarios/[id]/slug/route";
+import { createFacadeUserSchema } from "@/app/api/usuarios/facade/route";
+import { mergeFacadeUserSchema } from "@/app/api/usuarios/merge-facade/route";
+import { updateCompletedDisciplinasSchema } from "@/app/api/usuarios/me/disciplinas/route";
+import { marcarDisciplinasSchema } from "@/app/api/usuarios/me/disciplinas/marcar/route";
+import { createOwnMembershipSchema } from "@/app/api/usuarios/me/membros/route";
+import { updateOwnMembershipSchema } from "@/app/api/usuarios/me/membros/[membroId]/route";
+import { patchSchema as onboardingPatchSchema } from "@/app/api/usuarios/me/onboarding/route";
+import { patchSchema as updatePeriodoSchema } from "@/app/api/usuarios/me/periodo/route";
+import { updatePhotoSchema } from "@/app/api/usuarios/me/photo/route";
+import { saveSchema as saveSemestreDisciplinasSchema } from "@/app/api/usuarios/me/semestres/[semestreId]/disciplinas/route";
+import { patchSchema as updateDisciplinaSemestreSchema } from "@/app/api/usuarios/me/semestres/[semestreId]/disciplinas/[disciplinaSemestreId]/route";
+
+import { errorResponses, PaginationMetaSchema } from "../common-schemas";
+
+/**
+ * User profile shape returned by the `formatUserResponse` mapper. Mirrors the
+ * output of src/lib/server/utils/format-user-response.ts — do NOT substitute
+ * with the raw Prisma `Usuario` type (it includes sensitive fields).
+ *
+ * Also used by other endpoints that return a user (PATCH /photo, PATCH /slug,
+ * PATCH /info, POST /facade, etc).
+ */
+const userProfileSchema = z
+  .object({
+    id: z.string().uuid().openapi({ example: "550e8400-e29b-41d4-a716-446655440000" }),
+    nome: z.string().openapi({ example: "João Silva" }),
+    email: z.string().nullable().openapi({
+      description: "Email address. Null for facade users (placeholders created by admins).",
+      example: "joao.silva@academico.ufpb.br",
+    }),
+    slug: z.string().nullable().openapi({ example: "joao-silva" }),
+    papelPlataforma: z.enum(["USER", "MASTER_ADMIN"]).openapi({ example: "USER" }),
+    eVerificado: z.boolean().openapi({ example: true }),
+    urlFotoPerfil: z
+      .string()
+      .nullable()
+      .openapi({ example: "https://blob.vercel-storage.com/photos/550e8400-1712668800.webp" }),
+    periodoAtual: z.string().nullable().optional().openapi({
+      description: "Current semester (1–12, '12+', or 'graduado'). Null until set by the user.",
+      example: "5",
+    }),
+    centro: z.object({
+      id: z.string().uuid(),
+      nome: z.string().openapi({ example: "Centro de Informática" }),
+      sigla: z.string().openapi({ example: "CI" }),
+    }),
+    curso: z.object({
+      id: z.string().uuid(),
+      nome: z.string().openapi({ example: "Ciência da Computação" }),
+    }),
+    permissoes: z.array(z.string()).openapi({
+      example: ["entidade:admin:a1b2c3d4-e5f6-7890-abcd-ef1234567890"],
+    }),
+  })
+  .openapi("UserProfile");
+
+/**
+ * Extended user shape that includes the `eFacade` flag. Returned by admin-only
+ * endpoints (GET /usuarios, POST /facade) so admins can distinguish real users
+ * from facade placeholders.
+ */
+const adminUserResponseSchema = userProfileSchema
+  .extend({
+    eFacade: z.boolean().openapi({
+      description: "Whether this is a facade user (placeholder created by an admin, no login).",
+      example: false,
+    }),
+  })
+  .openapi("AdminUserResponse");
+
+/**
+ * Paginated user list envelope for GET /usuarios (with ?page and ?limit).
+ */
+const paginatedUsersResponseSchema = z
+  .object({
+    users: z.array(adminUserResponseSchema),
+    pagination: PaginationMetaSchema,
+  })
+  .openapi("PaginatedUsersResponse");
+
+/**
+ * Simplified entity summary embedded in membership responses.
+ */
+const membershipEntidadeSchema = z
+  .object({
+    id: z.string().uuid(),
+    nome: z.string().openapi({ example: "PET Computação" }),
+    slug: z.string().nullable().openapi({ example: "pet-computacao" }),
+    tipo: z.string().openapi({ example: "PET" }),
+    urlFoto: z.string().nullable(),
+    centro: z
+      .object({
+        id: z.string().uuid(),
+        nome: z.string(),
+        sigla: z.string(),
+      })
+      .optional(),
+  })
+  .openapi("MembershipEntidade");
+
+/**
+ * Cargo (role title) inside an entity membership.
+ */
+const cargoSchema = z
+  .object({
+    id: z.string().uuid(),
+    nome: z.string().openapi({ example: "Tutor" }),
+    descricao: z.string().nullable().optional(),
+  })
+  .openapi("Cargo");
+
+/**
+ * Membership response shape returned by endpoints that list or return
+ * memberships (/usuarios/{id}/membros, /usuarios/me/membros, etc).
+ */
+const membershipResponseSchema = z
+  .object({
+    id: z.string().uuid(),
+    entidade: membershipEntidadeSchema,
+    papel: z.enum(["ADMIN", "MEMBRO"]).openapi({ example: "MEMBRO" }),
+    cargo: cargoSchema.nullable().optional(),
+    startedAt: z.string().datetime().openapi({ example: "2026-01-15T00:00:00.000Z" }),
+    endedAt: z.string().datetime().nullable().openapi({ example: null }),
+  })
+  .openapi("MembershipResponse");
+
+/**
+ * DisciplinaSemestre response shape returned by semester discipline endpoints.
+ */
+const disciplinaSemestreResponseSchema = z
+  .object({
+    id: z.string().uuid(),
+    disciplinaId: z.string().uuid(),
+    disciplinaCodigo: z.string().openapi({ example: "DCE1001" }),
+    disciplinaNome: z.string().openapi({ example: "Introdução à Computação" }),
+    turma: z.string().nullable().openapi({ example: "01" }),
+    docente: z.string().nullable().openapi({ example: "Prof. Maria Santos" }),
+    horario: z.string().nullable().openapi({ example: "24T34" }),
+    codigoPaas: z.number().int().nullable().openapi({ example: 12345 }),
+    criadoEm: z.string().datetime(),
+  })
+  .openapi("DisciplinaSemestreResponse");
+
+/**
+ * Envelope for GET/PUT /usuarios/me/semestres/{semestreId}/disciplinas.
+ */
+const semestreDisciplinasResponseSchema = z
+  .object({
+    semestreLetivoId: z.string().uuid().nullable(),
+    disciplinas: z.array(disciplinaSemestreResponseSchema),
+    skippedCodigos: z.array(z.string()).optional().openapi({
+      description:
+        "Discipline codes that could not be resolved to a valid record and were skipped (only present on PUT responses when applicable).",
+    }),
+  })
+  .openapi("SemestreDisciplinasResponse");
+
+/**
+ * Simple message response used by DELETE endpoints and other success confirmations.
+ */
+const messageResponseSchema = z
+  .object({ message: z.string() })
+  .openapi({ description: "Simple status message response." });
+
+export function registerUsuariosPaths(registry: OpenAPIRegistry): void {
+  // ============================================================================
+  // GET /usuarios — three-mode listing (see edge case documentation)
+  // ============================================================================
+  registry.registerPath({
+    method: "get",
+    path: "/usuarios",
+    tags: ["Users"],
+    summary: "List users (three modes: search, paginated, or all)",
+    description:
+      "This endpoint has **three distinct modes** depending on the query parameters supplied, each with different authentication requirements:\n\n- **Search mode** (`?search=term` without `?page`): returns an envelope with users matching the query. Requires any authenticated user (`bearerAuth`).\n- **Paginated mode** (`?page=N` and/or `?limit=N`): returns a paginated envelope `{ users, pagination }`. Requires MASTER_ADMIN role.\n- **Full dump mode** (no query params): returns an array of ALL users (legacy backward-compatibility mode). Requires MASTER_ADMIN role.\n\nThe response shape differs across modes — consumers should check for the presence of the `pagination` key to distinguish the envelope form from the raw array form.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      query: z.object({
+        search: z.string().optional().openapi({
+          description: "Search term (used in search and paginated modes).",
+          example: "joão",
+        }),
+        page: z.coerce.number().int().positive().optional().openapi({ example: 1 }),
+        limit: z.coerce.number().int().positive().max(100).optional().openapi({ example: 25 }),
+        filter: z.enum(["all", "facade", "real"]).optional().openapi({
+          description:
+            "Filter by user type: 'all' (default), 'facade' (placeholder users), or 'real' (normal users with email).",
+          example: "all",
+        }),
+      }),
+    },
+    responses: {
+      200: {
+        description:
+          "Users matching the query. Response shape depends on the mode: paginated envelope `{ users, pagination }` for search/pagination modes, bare array for full dump mode.",
+        content: {
+          "application/json": {
+            schema: z.union([paginatedUsersResponseSchema, z.array(adminUserResponseSchema)]),
+          },
+        },
+      },
+      ...errorResponses([401, 403, 500]),
+    },
+  });
+
+  // ============================================================================
+  // DELETE /usuarios/{id} — admin-only, prevents self-delete
+  // ============================================================================
+  registry.registerPath({
+    method: "delete",
+    path: "/usuarios/{id}",
+    tags: ["Users"],
+    summary: "Delete a user (admin only)",
+    description:
+      "Permanently delete a user account. Admins cannot delete their own account through this endpoint — a 400 is returned in that case to prevent accidental lockout.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      params: z.object({
+        id: z.string().uuid().openapi({ example: "550e8400-e29b-41d4-a716-446655440000" }),
+      }),
+    },
+    responses: {
+      200: {
+        description: "User deleted successfully.",
+        content: {
+          "application/json": {
+            schema: messageResponseSchema,
+            example: { message: "Usuário deletado com sucesso." },
+          },
+        },
+      },
+      ...errorResponses([400, 401, 403, 404, 500]),
+    },
+  });
+
+  // ============================================================================
+  // PATCH /usuarios/{id}/info — admin-only (update centro/curso)
+  // ============================================================================
+  registry.registerPath({
+    method: "patch",
+    path: "/usuarios/{id}/info",
+    tags: ["Users"],
+    summary: "Update a user's academic center and/or course (admin only)",
+    description:
+      "Admin-only endpoint to correct a user's centro and/or curso. Both fields are optional — omit a field to leave it unchanged. Used when users are incorrectly assigned during registration.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      params: z.object({ id: z.string().uuid() }),
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: updateUserInfoSchema,
+            example: {
+              centroId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+              cursoId: "b2c3d4e5-f6a7-8901-bcde-f23456789012",
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "User info updated.",
+        content: { "application/json": { schema: adminUserResponseSchema } },
+      },
+      ...errorResponses([400, 401, 403, 404, 500]),
+    },
+  });
+
+  // ============================================================================
+  // GET /usuarios/{id}/membros — list memberships for a user (public)
+  // ============================================================================
+  registry.registerPath({
+    method: "get",
+    path: "/usuarios/{id}/membros",
+    tags: ["Users"],
+    summary: "List memberships for a specific user",
+    description:
+      "Return all entity memberships (active and historical) for the specified user. Public endpoint — useful for displaying a user's affiliations on their profile page.",
+    request: {
+      params: z.object({ id: z.string().uuid() }),
+    },
+    responses: {
+      200: {
+        description: "List of memberships for the user.",
+        content: {
+          "application/json": {
+            schema: z.array(membershipResponseSchema),
+            example: [
+              {
+                id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                entidade: {
+                  id: "b2c3d4e5-f6a7-8901-bcde-f23456789012",
+                  nome: "PET Computação",
+                  slug: "pet-computacao",
+                  tipo: "PET",
+                  urlFoto: null,
+                  centro: {
+                    id: "c3d4e5f6-a7b8-9012-cdef-345678901234",
+                    nome: "Centro de Informática",
+                    sigla: "CI",
+                  },
+                },
+                papel: "MEMBRO",
+                cargo: { id: "d4e5f6a7-b8c9-0123-defa-456789012345", nome: "Tutor" },
+                startedAt: "2026-01-15T00:00:00.000Z",
+                endedAt: null,
+              },
+            ],
+          },
+        },
+      },
+      ...errorResponses([500]),
+    },
+  });
+
+  // ============================================================================
+  // PATCH /usuarios/{id}/role — admin-only, prevents self-demotion
+  // ============================================================================
+  registry.registerPath({
+    method: "patch",
+    path: "/usuarios/{id}/role",
+    tags: ["Users"],
+    summary: "Update a user's platform role (admin only)",
+    description:
+      "Admin-only endpoint to promote or demote users between USER and MASTER_ADMIN. Admins cannot change their own role through this endpoint to prevent accidental lockout.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      params: z.object({ id: z.string().uuid() }),
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: updateRoleSchema,
+            example: { papelPlataforma: "MASTER_ADMIN" },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Role updated successfully.",
+        content: { "application/json": { schema: adminUserResponseSchema } },
+      },
+      ...errorResponses([400, 401, 403, 404, 500]),
+    },
+  });
+
+  // ============================================================================
+  // PATCH /usuarios/{id}/slug — admin-only
+  // ============================================================================
+  registry.registerPath({
+    method: "patch",
+    path: "/usuarios/{id}/slug",
+    tags: ["Users"],
+    summary: "Update a user's slug (admin only)",
+    description:
+      "Admin-only endpoint to change a user's URL slug. The slug is normalized (trimmed, lowercased) server-side. Pass null to remove the slug. Slugs must be unique across all users — 409 is returned on collision.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      params: z.object({ id: z.string().uuid() }),
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: updateSlugSchema,
+            example: { slug: "joao-silva" },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Slug updated.",
+        content: { "application/json": { schema: adminUserResponseSchema } },
+      },
+      ...errorResponses([400, 401, 403, 409, 500]),
+    },
+  });
+
+  // ============================================================================
+  // GET /usuarios/slug/{slug} — public lookup by slug
+  // ============================================================================
+  registry.registerPath({
+    method: "get",
+    path: "/usuarios/slug/{slug}",
+    tags: ["Users"],
+    summary: "Look up a user by URL slug",
+    description:
+      "Public endpoint to fetch a user's profile by their slug. Returns the sanitized user profile (no sensitive fields). Used by `/usuarios/[slug]` pages.",
+    request: {
+      params: z.object({
+        slug: z.string().openapi({ example: "joao-silva" }),
+      }),
+    },
+    responses: {
+      200: {
+        description: "User profile.",
+        content: { "application/json": { schema: userProfileSchema } },
+      },
+      ...errorResponses([404, 500]),
+    },
+  });
+
+  // ============================================================================
+  // POST /usuarios/facade — admin-only, create placeholder user
+  // ============================================================================
+  registry.registerPath({
+    method: "post",
+    path: "/usuarios/facade",
+    tags: ["Users"],
+    summary: "Create a facade user (admin only)",
+    description:
+      "Admin-only endpoint to create a placeholder ('facade') user — a user record without email or password, used to represent non-registered people (historical members, guest speakers, etc) in entity memberships. Facade users can later be merged into real users via POST /usuarios/merge-facade.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: createFacadeUserSchema,
+            example: {
+              nome: "Maria Fictícia",
+              centroId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+              cursoId: "b2c3d4e5-f6a7-8901-bcde-f23456789012",
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Facade user created.",
+        content: { "application/json": { schema: adminUserResponseSchema } },
+      },
+      ...errorResponses([400, 401, 403, 404, 500]),
+    },
+  });
+
+  // ============================================================================
+  // POST /usuarios/merge-facade — admin-only
+  // ============================================================================
+  registry.registerPath({
+    method: "post",
+    path: "/usuarios/merge-facade",
+    tags: ["Users"],
+    summary: "Merge a facade user into a real user (admin only)",
+    description:
+      "Admin-only endpoint to merge a facade user's memberships into a real user account. Membership conflicts (same user already in the same entity) are returned in the response. By default the facade user is deleted after merging — pass `deleteFacade: false` to retain the facade record.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: mergeFacadeUserSchema,
+            example: {
+              facadeUserId: "550e8400-e29b-41d4-a716-446655440000",
+              realUserId: "661f9511-f30b-52e5-b827-557766551111",
+              deleteFacade: true,
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Merge completed successfully.",
+        content: {
+          "application/json": {
+            schema: z.object({
+              success: z.literal(true),
+              membershipsCopied: z.number().int(),
+              conflicts: z.array(z.string()),
+              facadeUserDeleted: z.boolean(),
+            }),
+            example: {
+              success: true,
+              membershipsCopied: 3,
+              conflicts: [],
+              facadeUserDeleted: true,
+            },
+          },
+        },
+      },
+      ...errorResponses([400, 401, 403, 500]),
+    },
+  });
+
+  // ============================================================================
+  // GET/PUT /usuarios/me/disciplinas — completed disciplines
+  // ============================================================================
+  registry.registerPath({
+    method: "get",
+    path: "/usuarios/me/disciplinas",
+    tags: ["Users"],
+    summary: "List completed disciplines for the current user",
+    description:
+      "Return the list of discipline IDs the authenticated user has marked as completed.",
+    security: [{ bearerAuth: [] }],
+    responses: {
+      200: {
+        description: "List of completed discipline IDs.",
+        content: {
+          "application/json": {
+            schema: z.object({ disciplinaIds: z.array(z.string().uuid()) }),
+            example: {
+              disciplinaIds: [
+                "550e8400-e29b-41d4-a716-446655440000",
+                "661f9511-f30b-52e5-b827-557766551111",
+              ],
+            },
+          },
+        },
+      },
+      ...errorResponses([401, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "put",
+    path: "/usuarios/me/disciplinas",
+    tags: ["Users"],
+    summary: "Replace the set of completed disciplines for the current user",
+    description:
+      "Replace the authenticated user's full set of completed disciplines in one request. Any disciplines not in the provided list will be removed from the completed set.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: updateCompletedDisciplinasSchema,
+            example: {
+              disciplinaIds: [
+                "550e8400-e29b-41d4-a716-446655440000",
+                "661f9511-f30b-52e5-b827-557766551111",
+              ],
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Completed disciplines updated.",
+        content: {
+          "application/json": {
+            schema: z.object({ disciplinaIds: z.array(z.string().uuid()) }),
+          },
+        },
+      },
+      ...errorResponses([400, 401, 500]),
+    },
+  });
+
+  // ============================================================================
+  // POST /usuarios/me/disciplinas/marcar — mark with status
+  // ============================================================================
+  registry.registerPath({
+    method: "post",
+    path: "/usuarios/me/disciplinas/marcar",
+    tags: ["Users"],
+    summary: "Mark disciplines with a status (concluida, cursando, or none)",
+    description:
+      "Atomically mark a set of disciplines with a specific status. Uses the currently active semester as the context for the 'cursando' (in progress) status. Marking as 'cursando' removes a previous 'concluida' status on the same disciplines and vice versa. Status 'none' clears any existing marking.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: marcarDisciplinasSchema,
+            example: {
+              disciplinaIds: ["550e8400-e29b-41d4-a716-446655440000"],
+              status: "cursando",
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Disciplines marked successfully.",
+        content: {
+          "application/json": {
+            schema: z.object({ ok: z.literal(true) }),
+            example: { ok: true },
+          },
+        },
+      },
+      ...errorResponses([400, 401, 500]),
+    },
+  });
+
+  // ============================================================================
+  // GET/POST /usuarios/me/membros — current user's memberships
+  // ============================================================================
+  registry.registerPath({
+    method: "get",
+    path: "/usuarios/me/membros",
+    tags: ["Users"],
+    summary: "List the current user's memberships",
+    description:
+      "Return all entity memberships (active and historical) for the authenticated user.",
+    security: [{ bearerAuth: [] }],
+    responses: {
+      200: {
+        description: "List of memberships for the authenticated user.",
+        content: { "application/json": { schema: z.array(membershipResponseSchema) } },
+      },
+      ...errorResponses([401, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/usuarios/me/membros",
+    tags: ["Users"],
+    summary: "Join an entity as a member",
+    description:
+      "Create a new membership linking the authenticated user to an entity. Regular users can only join as `MEMBRO` — attempting to set `papel: 'ADMIN'` silently downgrades to `MEMBRO` unless the caller is a MASTER_ADMIN. Returns 409 if the user is already an active member of the target entity.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: createOwnMembershipSchema,
+            example: {
+              entidadeId: "550e8400-e29b-41d4-a716-446655440000",
+              papel: "MEMBRO",
+              cargoId: "661f9511-f30b-52e5-b827-557766551111",
+              startedAt: "2026-01-15T00:00:00.000Z",
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Membership created.",
+        content: { "application/json": { schema: membershipResponseSchema } },
+      },
+      ...errorResponses([400, 401, 404, 409, 500]),
+    },
+  });
+
+  // ============================================================================
+  // PUT/DELETE /usuarios/me/membros/{membroId}
+  // ============================================================================
+  registry.registerPath({
+    method: "put",
+    path: "/usuarios/me/membros/{membroId}",
+    tags: ["Users"],
+    summary: "Update one of the current user's memberships",
+    description:
+      "Update dates, cargo or papel on a membership. The membership must belong to the authenticated user — returns 403 otherwise. Non-admins cannot set `papel: 'ADMIN'` (silently ignored).",
+    security: [{ bearerAuth: [] }],
+    request: {
+      params: z.object({ membroId: z.string().uuid() }),
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: updateOwnMembershipSchema,
+            example: { endedAt: "2026-12-31T23:59:59.000Z" },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Membership updated.",
+        content: { "application/json": { schema: membershipResponseSchema } },
+      },
+      ...errorResponses([400, 401, 403, 404, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "delete",
+    path: "/usuarios/me/membros/{membroId}",
+    tags: ["Users"],
+    summary: "Delete one of the current user's memberships",
+    description:
+      "Permanently delete a membership. The membership must belong to the authenticated user — returns 403 otherwise.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      params: z.object({ membroId: z.string().uuid() }),
+    },
+    responses: {
+      200: {
+        description: "Membership deleted.",
+        content: {
+          "application/json": {
+            schema: messageResponseSchema,
+            example: { message: "Membresia deletada com sucesso." },
+          },
+        },
+      },
+      ...errorResponses([401, 403, 404, 500]),
+    },
+  });
+
+  // ============================================================================
+  // GET/PATCH /usuarios/me/onboarding
+  // ============================================================================
+  registry.registerPath({
+    method: "get",
+    path: "/usuarios/me/onboarding",
+    tags: ["Users"],
+    summary: "Get the current user's onboarding progress",
+    description:
+      "Return the onboarding metadata object tracking which onboarding steps the user has completed or skipped. Returns an empty object if no onboarding has been started.",
+    security: [{ bearerAuth: [] }],
+    responses: {
+      200: {
+        description: "Onboarding metadata (may be empty).",
+        content: {
+          "application/json": {
+            schema: onboardingPatchSchema,
+            example: {
+              welcome: { completedAt: "2026-01-15T12:00:00.000Z" },
+              periodo: { completedAt: "2026-01-15T12:01:00.000Z" },
+              concluidas: { skippedAt: "2026-01-15T12:02:00.000Z" },
+            },
+          },
+        },
+      },
+      ...errorResponses([401, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "patch",
+    path: "/usuarios/me/onboarding",
+    tags: ["Users"],
+    summary: "Update the current user's onboarding progress",
+    description:
+      "Partial update of onboarding metadata. The request body is deep-merged with the existing metadata — only provided keys are updated. The `semesters` field is a map keyed by semester id, allowing per-semester tracking of 'cursando' and 'turmas' steps.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: onboardingPatchSchema,
+            example: {
+              concluidas: { completedAt: "2026-01-15T12:10:00.000Z" },
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Onboarding metadata updated.",
+        content: { "application/json": { schema: onboardingPatchSchema } },
+      },
+      ...errorResponses([400, 401, 500]),
+    },
+  });
+
+  // ============================================================================
+  // PATCH /usuarios/me/periodo
+  // ============================================================================
+  registry.registerPath({
+    method: "patch",
+    path: "/usuarios/me/periodo",
+    tags: ["Users"],
+    summary: "Update the current user's academic period",
+    description:
+      "Update the user's current semester (e.g., '5' for 5th semester, '12+' for 12+ semesters, 'graduado' for graduated). Pass null to clear the field.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: updatePeriodoSchema,
+            example: { periodoAtual: "5" },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Period updated.",
+        content: {
+          "application/json": {
+            schema: z.object({ periodoAtual: z.string().nullable() }),
+            example: { periodoAtual: "5" },
+          },
+        },
+      },
+      ...errorResponses([400, 401, 500]),
+    },
+  });
+
+  // ============================================================================
+  // PATCH/DELETE /usuarios/me/photo
+  // ============================================================================
+  registry.registerPath({
+    method: "patch",
+    path: "/usuarios/me/photo",
+    tags: ["Users"],
+    summary: "Update the current user's profile photo URL",
+    description:
+      "Update the profile photo URL for the authenticated user. The URL must point to an already-uploaded image — to upload a new image file, use POST /upload/photo instead (which handles upload + DB update atomically). The old photo is deleted from blob storage if it was hosted there.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: updatePhotoSchema,
+            example: {
+              urlFotoPerfil: "https://blob.vercel-storage.com/photos/550e8400-1712668800.webp",
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Photo updated.",
+        content: { "application/json": { schema: userProfileSchema } },
+      },
+      ...errorResponses([400, 401, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "delete",
+    path: "/usuarios/me/photo",
+    tags: ["Users"],
+    summary: "Delete the current user's profile photo",
+    description:
+      "Remove the authenticated user's profile photo and delete the file from blob storage if it was hosted there.",
+    security: [{ bearerAuth: [] }],
+    responses: {
+      200: {
+        description: "Photo deleted.",
+        content: { "application/json": { schema: userProfileSchema } },
+      },
+      ...errorResponses([401, 500]),
+    },
+  });
+
+  // ============================================================================
+  // GET/PUT /usuarios/me/semestres/{semestreId}/disciplinas — semestreId can be UUID or "ativo"
+  // ============================================================================
+  const semestreIdParam = z.object({
+    semestreId: z.union([z.string().uuid(), z.literal("ativo")]).openapi({
+      description:
+        "Either a specific semester UUID, or the literal string 'ativo' to target the currently active semester.",
+      example: "ativo",
+    }),
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/usuarios/me/semestres/{semestreId}/disciplinas",
+    tags: ["Users"],
+    summary: "List the current user's enrolled disciplines for a semester",
+    description:
+      "Return the disciplines the authenticated user is currently enrolled in for the specified semester. The `semestreId` path parameter accepts either a UUID (for a specific semester) or the literal string `'ativo'`, which auto-resolves to the currently active semester.",
+    security: [{ bearerAuth: [] }],
+    request: { params: semestreIdParam },
+    responses: {
+      200: {
+        description:
+          "Enrolled disciplines for the semester. Returns `{ semestreLetivoId: null, disciplinas: [] }` when `semestreId='ativo'` but no semester is currently active.",
+        content: { "application/json": { schema: semestreDisciplinasResponseSchema } },
+      },
+      ...errorResponses([401, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "put",
+    path: "/usuarios/me/semestres/{semestreId}/disciplinas",
+    tags: ["Users"],
+    summary: "Replace enrolled disciplines for a semester",
+    description:
+      "Replace the authenticated user's full set of enrolled disciplines for the specified semester. Disciplines are referenced by their PAAS `codigoDisciplina` and resolved to internal IDs server-side. Any codes that cannot be resolved are listed in `skippedCodigos` in the response. `semestreId` accepts a UUID or the literal 'ativo'.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      params: semestreIdParam,
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: saveSemestreDisciplinasSchema,
+            example: {
+              disciplinas: [
+                {
+                  codigoDisciplina: "DCE1001",
+                  turma: "01",
+                  docente: "Prof. Maria Santos",
+                  horario: "24T34",
+                  codigoPaas: 12345,
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Enrolled disciplines replaced.",
+        content: { "application/json": { schema: semestreDisciplinasResponseSchema } },
+      },
+      ...errorResponses([400, 401, 404, 500]),
+    },
+  });
+
+  // ============================================================================
+  // PATCH /usuarios/me/semestres/{semestreId}/disciplinas/{disciplinaSemestreId}
+  // ============================================================================
+  registry.registerPath({
+    method: "patch",
+    path: "/usuarios/me/semestres/{semestreId}/disciplinas/{disciplinaSemestreId}",
+    tags: ["Users"],
+    summary: "Update one of the user's enrolled disciplines for a semester",
+    description:
+      "Update the turma, docente, horario or codigoPaas fields on a specific enrolled discipline. The discipline must belong to the authenticated user and the specified semester. `semestreId` accepts a UUID or 'ativo'.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      params: z.object({
+        semestreId: z.union([z.string().uuid(), z.literal("ativo")]),
+        disciplinaSemestreId: z.string().uuid(),
+      }),
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: updateDisciplinaSemestreSchema,
+            example: { turma: "02", docente: "Prof. João Costa" },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Discipline updated.",
+        content: { "application/json": { schema: disciplinaSemestreResponseSchema } },
+      },
+      ...errorResponses([400, 401, 404, 500]),
+    },
+  });
+}

--- a/src/lib/server/openapi/paths/vagas.ts
+++ b/src/lib/server/openapi/paths/vagas.ts
@@ -139,7 +139,9 @@ export function registerVagasPaths(registry: OpenAPIRegistry, schemas: CommonSch
         description: "Vaga criada com sucesso.",
         content: { "application/json": { schema: vagaResponseSchema } },
       },
-      ...errorResponses([400, 404]),
+      ...errorResponses([400, 404], {
+        404: { message: "Entidade não encontrada", code: "ENTIDADE_NOT_FOUND" },
+      }),
     },
   });
 
@@ -157,7 +159,9 @@ export function registerVagasPaths(registry: OpenAPIRegistry, schemas: CommonSch
         description: "Detalhes da vaga.",
         content: { "application/json": { schema: vagaDetailResponseSchema } },
       },
-      ...errorResponses([404]),
+      ...errorResponses([404], {
+        404: { message: "Vaga não encontrado", code: "NOT_FOUND" },
+      }),
     },
   });
 
@@ -176,7 +180,9 @@ export function registerVagasPaths(registry: OpenAPIRegistry, schemas: CommonSch
       204: {
         description: "Vaga excluída com sucesso. Sem corpo de resposta.",
       },
-      ...errorResponses([404]),
+      ...errorResponses([404], {
+        404: { message: "Vaga não encontrado", code: "NOT_FOUND" },
+      }),
     },
   });
 }

--- a/src/lib/server/openapi/paths/vagas.ts
+++ b/src/lib/server/openapi/paths/vagas.ts
@@ -3,7 +3,7 @@ import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 
 import { createVagaSchema } from "@/app/api/vagas/route";
 
-import { errorResponses } from "../common-schemas";
+import type { CommonSchemas } from "../common-schemas";
 
 /**
  * Enum of supported job/opportunity types. Mirrors TIPO_VAGA_VALUES in
@@ -75,7 +75,8 @@ const vagaDetailResponseSchema = vagaResponseSchema
   })
   .openapi("VagaDetailResponse");
 
-export function registerVagasPaths(registry: OpenAPIRegistry): void {
+export function registerVagasPaths(registry: OpenAPIRegistry, schemas: CommonSchemas): void {
+  const { errorResponses } = schemas;
   registry.registerPath({
     method: "get",
     path: "/vagas",

--- a/src/lib/server/openapi/paths/vagas.ts
+++ b/src/lib/server/openapi/paths/vagas.ts
@@ -6,18 +6,18 @@ import { createVagaSchema } from "@/lib/server/api-schemas/vagas";
 import type { CommonSchemas } from "../common-schemas";
 
 /**
- * Enum of supported job/opportunity types. Mirrors TIPO_VAGA_VALUES in
- * src/app/api/vagas/route.ts — keep in sync.
+ * Enum dos tipos de vaga suportados. Espelha TIPO_VAGA_VALUES em
+ * src/app/api/vagas/route.ts — manter em sincronia.
  */
 const tipoVagaSchema = z
   .enum(["ESTAGIO", "TRAINEE", "VOLUNTARIO", "PESQUISA", "CLT", "PJ", "OUTRO"])
   .openapi({
-    description: "Type of job opportunity.",
+    description: "Tipo da oportunidade de vaga.",
     example: "ESTAGIO",
   });
 
 /**
- * Publisher summary embedded in vaga responses — the user who created the vaga.
+ * Resumo do publicador embutido nas respostas de vaga — o usuário que criou a vaga.
  */
 const vagaPublicadorSchema = z.object({
   nome: z.string().openapi({ example: "João Silva" }),
@@ -25,7 +25,7 @@ const vagaPublicadorSchema = z.object({
 });
 
 /**
- * Entity summary embedded in vaga responses.
+ * Resumo da entidade embutido nas respostas de vaga.
  */
 const vagaEntidadeSchema = z.object({
   id: z.string().uuid(),
@@ -36,8 +36,8 @@ const vagaEntidadeSchema = z.object({
 });
 
 /**
- * Vaga response shape as returned by mapVagaToJson — the canonical JSON
- * representation used by both list and detail endpoints.
+ * Shape da resposta de Vaga conforme retornado por mapVagaToJson — representação
+ * JSON canônica usada tanto pelo endpoint de listagem quanto pelo de detalhe.
  */
 const vagaResponseSchema = z
   .object({
@@ -63,13 +63,13 @@ const vagaResponseSchema = z
   .openapi("VagaResponse");
 
 /**
- * Extended response shape for GET /vagas/{id} which adds an `expirada` flag
- * computed from `dataFinalizacao` vs current time.
+ * Shape estendido da resposta para GET /vagas/{id} — adiciona o flag `expirada`
+ * calculado a partir de `dataFinalizacao` vs hora atual.
  */
 const vagaDetailResponseSchema = vagaResponseSchema
   .extend({
     expirada: z.boolean().openapi({
-      description: "Whether the vaga has passed its dataFinalizacao.",
+      description: "Indica se a vaga já passou da `dataFinalizacao`.",
       example: false,
     }),
   })
@@ -81,23 +81,24 @@ export function registerVagasPaths(registry: OpenAPIRegistry, schemas: CommonSch
     method: "get",
     path: "/vagas",
     tags: ["Vagas"],
-    summary: "List active job opportunities",
-    description: "List non-expired vagas. Filter by job type and/or publishing entity category.",
+    summary: "Listar vagas ativas",
+    description:
+      "Lista as vagas não expiradas. Permite filtrar por tipo de vaga e/ou categoria da entidade publicadora.",
     request: {
       query: z.object({
         tipoVaga: tipoVagaSchema.optional().openapi({
-          description: "Filter by job type.",
+          description: "Filtra pelo tipo de vaga.",
         }),
         entidadeTipos: z.string().optional().openapi({
           description:
-            "Comma-separated list of entity types to filter by (e.g., 'LABORATORIO,GRUPO'). Unknown types are ignored.",
+            "Lista separada por vírgulas dos tipos de entidade para filtrar (ex: 'LABORATORIO,GRUPO'). Tipos desconhecidos são ignorados.",
           example: "LABORATORIO,GRUPO",
         }),
       }),
     },
     responses: {
       200: {
-        description: "List of active vagas.",
+        description: "Lista de vagas ativas.",
         content: { "application/json": { schema: z.array(vagaResponseSchema) } },
       },
     },
@@ -107,9 +108,9 @@ export function registerVagasPaths(registry: OpenAPIRegistry, schemas: CommonSch
     method: "post",
     path: "/vagas",
     tags: ["Vagas"],
-    summary: "Create a new vaga",
+    summary: "Criar uma nova vaga",
     description:
-      "Publish a new vaga. Caller must be MASTER_ADMIN or an active ADMIN of the target entity. `dataFinalizacao` must be in the future.",
+      "Publica uma nova vaga. O usuário deve ser MASTER_ADMIN ou ADMIN ativo da entidade. `dataFinalizacao` deve estar no futuro.",
     security: [{ bearerAuth: [] }],
     request: {
       body: {
@@ -135,7 +136,7 @@ export function registerVagasPaths(registry: OpenAPIRegistry, schemas: CommonSch
     },
     responses: {
       201: {
-        description: "Vaga created successfully.",
+        description: "Vaga criada com sucesso.",
         content: { "application/json": { schema: vagaResponseSchema } },
       },
       ...errorResponses([400, 404]),
@@ -146,14 +147,14 @@ export function registerVagasPaths(registry: OpenAPIRegistry, schemas: CommonSch
     method: "get",
     path: "/vagas/{id}",
     tags: ["Vagas"],
-    summary: "Get a vaga by id",
-    description: "Fetch a single vaga with an `expirada` flag indicating if its deadline passed.",
+    summary: "Buscar uma vaga pelo ID",
+    description: "Retorna uma vaga única com o flag `expirada` indicando se o prazo já passou.",
     request: {
       params: z.object({ id: z.string().uuid() }),
     },
     responses: {
       200: {
-        description: "Vaga details.",
+        description: "Detalhes da vaga.",
         content: { "application/json": { schema: vagaDetailResponseSchema } },
       },
       ...errorResponses([404]),
@@ -164,16 +165,16 @@ export function registerVagasPaths(registry: OpenAPIRegistry, schemas: CommonSch
     method: "delete",
     path: "/vagas/{id}",
     tags: ["Vagas"],
-    summary: "Soft-delete a vaga",
+    summary: "Excluir uma vaga (soft delete)",
     description:
-      "Soft-delete a vaga. Caller must be MASTER_ADMIN or an active ADMIN of the vaga's entity.",
+      "Marca uma vaga como excluída (soft delete). O usuário deve ser MASTER_ADMIN ou ADMIN ativo da entidade dona da vaga.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({ id: z.string().uuid() }),
     },
     responses: {
       204: {
-        description: "Vaga deleted successfully. No response body.",
+        description: "Vaga excluída com sucesso. Sem corpo de resposta.",
       },
       ...errorResponses([404]),
     },

--- a/src/lib/server/openapi/paths/vagas.ts
+++ b/src/lib/server/openapi/paths/vagas.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 
-import { createVagaSchema } from "@/app/api/vagas/route";
+import { createVagaSchema } from "@/lib/server/api-schemas/vagas";
 
 import type { CommonSchemas } from "../common-schemas";
 

--- a/src/lib/server/openapi/paths/vagas.ts
+++ b/src/lib/server/openapi/paths/vagas.ts
@@ -73,6 +73,7 @@ const vagaDetailResponseSchema = vagaResponseSchema
   })
   .openapi("VagaDetailResponse");
 
+/** Registra os paths de vagas no registry OpenAPI. */
 export function registerVagasPaths(registry: OpenAPIRegistry, schemas: CommonSchemas): void {
   const { errorResponses } = schemas;
   registry.registerPath({

--- a/src/lib/server/openapi/paths/vagas.ts
+++ b/src/lib/server/openapi/paths/vagas.ts
@@ -1,0 +1,183 @@
+import { z } from "zod";
+import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
+
+import { createVagaSchema } from "@/app/api/vagas/route";
+
+import { errorResponses } from "../common-schemas";
+
+/**
+ * Enum of supported job/opportunity types. Mirrors TIPO_VAGA_VALUES in
+ * src/app/api/vagas/route.ts — keep in sync.
+ */
+const tipoVagaSchema = z
+  .enum(["ESTAGIO", "TRAINEE", "VOLUNTARIO", "PESQUISA", "CLT", "PJ", "OUTRO"])
+  .openapi({
+    description: "Type of job opportunity.",
+    example: "ESTAGIO",
+  });
+
+/**
+ * Publisher summary embedded in vaga responses — the user who created the vaga.
+ */
+const vagaPublicadorSchema = z.object({
+  nome: z.string().openapi({ example: "João Silva" }),
+  urlFotoPerfil: z.string().optional(),
+});
+
+/**
+ * Entity summary embedded in vaga responses.
+ */
+const vagaEntidadeSchema = z.object({
+  id: z.string().uuid(),
+  nome: z.string().openapi({ example: "PET Computação" }),
+  slug: z.string().optional(),
+  tipo: z.string().openapi({ example: "GRUPO" }),
+  urlFoto: z.string().optional(),
+});
+
+/**
+ * Vaga response shape as returned by mapVagaToJson — the canonical JSON
+ * representation used by both list and detail endpoints.
+ */
+const vagaResponseSchema = z
+  .object({
+    id: z.string().uuid(),
+    titulo: z.string().openapi({ example: "Estágio em Desenvolvimento Backend" }),
+    descricao: z.string().openapi({
+      example: "Atuar no desenvolvimento de APIs em Node.js e PostgreSQL...",
+    }),
+    tipoVaga: tipoVagaSchema,
+    areas: z.array(z.string()).openapi({ example: ["Backend", "Node.js", "PostgreSQL"] }),
+    criadoEm: z.string().datetime(),
+    dataFinalizacao: z.string().datetime().openapi({ example: "2026-05-15T23:59:59.000Z" }),
+    linkInscricao: z.string().url().openapi({ example: "https://empresa.com/vagas/123" }),
+    salario: z.string().optional().openapi({ example: "R$ 1.500,00" }),
+    sobreEmpresa: z.string().optional(),
+    responsabilidades: z.array(z.string()),
+    requisitos: z.array(z.string()),
+    informacoesAdicionais: z.string().optional(),
+    etapasProcesso: z.array(z.string()),
+    entidade: vagaEntidadeSchema,
+    publicador: vagaPublicadorSchema,
+  })
+  .openapi("VagaResponse");
+
+/**
+ * Extended response shape for GET /vagas/{id} which adds an `expirada` flag
+ * computed from `dataFinalizacao` vs current time.
+ */
+const vagaDetailResponseSchema = vagaResponseSchema
+  .extend({
+    expirada: z.boolean().openapi({
+      description: "Whether the vaga has passed its dataFinalizacao.",
+      example: false,
+    }),
+  })
+  .openapi("VagaDetailResponse");
+
+export function registerVagasPaths(registry: OpenAPIRegistry): void {
+  registry.registerPath({
+    method: "get",
+    path: "/vagas",
+    tags: ["Vagas"],
+    summary: "List active job opportunities",
+    description:
+      "Public endpoint returning active (non-expired) vagas. Results can be filtered by job type and by publishing entity category (e.g., only vagas from labs or PET groups).",
+    request: {
+      query: z.object({
+        tipoVaga: tipoVagaSchema.optional().openapi({
+          description: "Filter by job type.",
+        }),
+        entidadeTipos: z.string().optional().openapi({
+          description:
+            "Comma-separated list of entity types to filter by (e.g., 'LABORATORIO,GRUPO'). Unknown types are ignored.",
+          example: "LABORATORIO,GRUPO",
+        }),
+      }),
+    },
+    responses: {
+      200: {
+        description: "List of active vagas.",
+        content: { "application/json": { schema: z.array(vagaResponseSchema) } },
+      },
+      ...errorResponses([500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/vagas",
+    tags: ["Vagas"],
+    summary: "Create a new vaga",
+    description:
+      "Publish a new job opportunity on behalf of an entity. **Custom permission:** the caller must be either a MASTER_ADMIN or an active ADMIN member of the target entity (`canManageVagaForEntidade` check). The `dataFinalizacao` must be in the future.",
+    security: [{ bearerAuth: [] }],
+    request: {
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: createVagaSchema,
+            example: {
+              titulo: "Estágio em Desenvolvimento Backend",
+              descricao: "Atuar no desenvolvimento de APIs em Node.js e PostgreSQL...",
+              tipoVaga: "ESTAGIO",
+              entidadeId: "550e8400-e29b-41d4-a716-446655440000",
+              linkInscricao: "https://empresa.com/vagas/123",
+              dataFinalizacao: "2026-05-15",
+              areas: ["Backend", "Node.js"],
+              salario: "R$ 1.500,00",
+              responsabilidades: ["Desenvolver APIs REST", "Escrever testes automatizados"],
+              requisitos: ["Conhecimento em Node.js", "Familiaridade com PostgreSQL"],
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      201: {
+        description: "Vaga created successfully.",
+        content: { "application/json": { schema: vagaResponseSchema } },
+      },
+      ...errorResponses([400, 401, 403, 404, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/vagas/{id}",
+    tags: ["Vagas"],
+    summary: "Get a vaga by id",
+    description:
+      "Public endpoint to fetch a single vaga with all its details plus an `expirada` flag indicating whether it has passed its deadline.",
+    request: {
+      params: z.object({ id: z.string().uuid() }),
+    },
+    responses: {
+      200: {
+        description: "Vaga details.",
+        content: { "application/json": { schema: vagaDetailResponseSchema } },
+      },
+      ...errorResponses([404, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "delete",
+    path: "/vagas/{id}",
+    tags: ["Vagas"],
+    summary: "Soft-delete a vaga",
+    description:
+      "Soft-delete a vaga (marks it as deleted in the database without removing the record). **Custom permission:** the caller must be either a MASTER_ADMIN or an active ADMIN member of the vaga's entity (`canManageVagaForEntidade` check).",
+    security: [{ bearerAuth: [] }],
+    request: {
+      params: z.object({ id: z.string().uuid() }),
+    },
+    responses: {
+      204: {
+        description: "Vaga deleted successfully. No response body.",
+      },
+      ...errorResponses([401, 403, 404, 500]),
+    },
+  });
+}

--- a/src/lib/server/openapi/paths/vagas.ts
+++ b/src/lib/server/openapi/paths/vagas.ts
@@ -1,20 +1,18 @@
 import { z } from "zod";
 import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 
-import { createVagaSchema } from "@/lib/server/api-schemas/vagas";
+import { createVagaSchema, TIPO_VAGA_VALUES } from "@/lib/server/api-schemas/vagas";
 
 import type { CommonSchemas } from "../common-schemas";
 
 /**
- * Enum dos tipos de vaga suportados. Espelha TIPO_VAGA_VALUES em
- * src/app/api/vagas/route.ts — manter em sincronia.
+ * Enum dos tipos de vaga suportados. Importado de api-schemas/vagas.ts
+ * para evitar duplicação.
  */
-const tipoVagaSchema = z
-  .enum(["ESTAGIO", "TRAINEE", "VOLUNTARIO", "PESQUISA", "CLT", "PJ", "OUTRO"])
-  .openapi({
-    description: "Tipo da oportunidade de vaga.",
-    example: "ESTAGIO",
-  });
+const tipoVagaSchema = z.enum(TIPO_VAGA_VALUES).openapi({
+  description: "Tipo da oportunidade de vaga.",
+  example: "ESTAGIO",
+});
 
 /**
  * Resumo do publicador embutido nas respostas de vaga — o usuário que criou a vaga.

--- a/src/lib/server/openapi/paths/vagas.ts
+++ b/src/lib/server/openapi/paths/vagas.ts
@@ -82,8 +82,7 @@ export function registerVagasPaths(registry: OpenAPIRegistry, schemas: CommonSch
     path: "/vagas",
     tags: ["Vagas"],
     summary: "List active job opportunities",
-    description:
-      "Public endpoint returning active (non-expired) vagas. Results can be filtered by job type and by publishing entity category (e.g., only vagas from labs or PET groups).",
+    description: "List non-expired vagas. Filter by job type and/or publishing entity category.",
     request: {
       query: z.object({
         tipoVaga: tipoVagaSchema.optional().openapi({
@@ -101,7 +100,6 @@ export function registerVagasPaths(registry: OpenAPIRegistry, schemas: CommonSch
         description: "List of active vagas.",
         content: { "application/json": { schema: z.array(vagaResponseSchema) } },
       },
-      ...errorResponses([500]),
     },
   });
 
@@ -111,7 +109,7 @@ export function registerVagasPaths(registry: OpenAPIRegistry, schemas: CommonSch
     tags: ["Vagas"],
     summary: "Create a new vaga",
     description:
-      "Publish a new job opportunity on behalf of an entity. **Custom permission:** the caller must be either a MASTER_ADMIN or an active ADMIN member of the target entity (`canManageVagaForEntidade` check). The `dataFinalizacao` must be in the future.",
+      "Publish a new vaga. Caller must be MASTER_ADMIN or an active ADMIN of the target entity. `dataFinalizacao` must be in the future.",
     security: [{ bearerAuth: [] }],
     request: {
       body: {
@@ -140,7 +138,7 @@ export function registerVagasPaths(registry: OpenAPIRegistry, schemas: CommonSch
         description: "Vaga created successfully.",
         content: { "application/json": { schema: vagaResponseSchema } },
       },
-      ...errorResponses([400, 401, 403, 404, 500]),
+      ...errorResponses([400, 404]),
     },
   });
 
@@ -149,8 +147,7 @@ export function registerVagasPaths(registry: OpenAPIRegistry, schemas: CommonSch
     path: "/vagas/{id}",
     tags: ["Vagas"],
     summary: "Get a vaga by id",
-    description:
-      "Public endpoint to fetch a single vaga with all its details plus an `expirada` flag indicating whether it has passed its deadline.",
+    description: "Fetch a single vaga with an `expirada` flag indicating if its deadline passed.",
     request: {
       params: z.object({ id: z.string().uuid() }),
     },
@@ -159,7 +156,7 @@ export function registerVagasPaths(registry: OpenAPIRegistry, schemas: CommonSch
         description: "Vaga details.",
         content: { "application/json": { schema: vagaDetailResponseSchema } },
       },
-      ...errorResponses([404, 500]),
+      ...errorResponses([404]),
     },
   });
 
@@ -169,7 +166,7 @@ export function registerVagasPaths(registry: OpenAPIRegistry, schemas: CommonSch
     tags: ["Vagas"],
     summary: "Soft-delete a vaga",
     description:
-      "Soft-delete a vaga (marks it as deleted in the database without removing the record). **Custom permission:** the caller must be either a MASTER_ADMIN or an active ADMIN member of the vaga's entity (`canManageVagaForEntidade` check).",
+      "Soft-delete a vaga. Caller must be MASTER_ADMIN or an active ADMIN of the vaga's entity.",
     security: [{ bearerAuth: [] }],
     request: {
       params: z.object({ id: z.string().uuid() }),
@@ -178,7 +175,7 @@ export function registerVagasPaths(registry: OpenAPIRegistry, schemas: CommonSch
       204: {
         description: "Vaga deleted successfully. No response body.",
       },
-      ...errorResponses([401, 403, 404, 500]),
+      ...errorResponses([404]),
     },
   });
 }

--- a/src/lib/server/openapi/registry.ts
+++ b/src/lib/server/openapi/registry.ts
@@ -2,38 +2,54 @@ import { OpenAPIRegistry, extendZodWithOpenApi } from "@asteasolutions/zod-to-op
 import { z } from "zod";
 
 /**
- * Extend Zod with .openapi() method.
- *
- * IMPORTANT: This must be called exactly once, before any schema uses .openapi().
- * Since this file is the entry point for the OpenAPI infrastructure and is imported
- * by every module that touches the registry, calling it here guarantees the extension
- * is applied before any consumer runs.
+ * Extend Zod with the `.openapi()` method. This is a global, idempotent
+ * operation: calling it multiple times has no effect, so keeping it at module
+ * top level is safe. Every consumer that defines Zod schemas with `.openapi()`
+ * metadata must ensure this file has been imported at least once before the
+ * schemas are evaluated — importing `createRegistry` or any path module
+ * transitively triggers it.
  */
 extendZodWithOpenApi(z);
 
 /**
- * Global OpenAPI registry. All component schemas and paths are registered here.
- * Consumed by generator.ts to produce the final OpenAPI document.
+ * Create a fresh OpenAPI registry, pre-configured with the shared security
+ * schemes used across the API.
+ *
+ * **The registry is intentionally NOT a module-level singleton.** An earlier
+ * version of this file exported a global registry, which caused `registerPath`
+ * calls to accumulate across multiple `getOpenApiDocument()` invocations when
+ * the document cache was invalidated (e.g., in Jest `beforeEach` or Next.js
+ * dev-mode hot reload). The result was a monotonically growing `definitions`
+ * array and linear slowdown between calls.
+ *
+ * Making the registry ephemeral guarantees that `getOpenApiDocument()` is a
+ * pure function of the code deployed, with no hidden cross-call state.
  */
-export const registry = new OpenAPIRegistry();
+export function createRegistry(): OpenAPIRegistry {
+  const registry = new OpenAPIRegistry();
 
-/**
- * Bearer JWT security scheme used by all authenticated endpoints.
- * Matches the Authorization: Bearer <token> format enforced by withAuth/withAdmin
- * middlewares in src/lib/server/services/auth/middleware.ts.
- */
-registry.registerComponent("securitySchemes", "bearerAuth", {
-  type: "http",
-  scheme: "bearer",
-  bearerFormat: "JWT",
-  description: "JWT token obtained via POST /auth/login. Send as 'Authorization: Bearer <token>'.",
-});
+  // Bearer JWT security scheme used by every authenticated endpoint.
+  // Matches the Authorization: Bearer <token> format enforced by
+  // withAuth/withAdmin middlewares in src/lib/server/services/auth/middleware.ts.
+  registry.registerComponent("securitySchemes", "bearerAuth", {
+    type: "http",
+    scheme: "bearer",
+    bearerFormat: "JWT",
+    description:
+      "JWT token obtained via POST /auth/login. Send as 'Authorization: Bearer <token>'.",
+  });
+
+  return registry;
+}
 
 /**
  * OpenAPI tags used to group operations in the documentation UI.
- * One tag per resource group under src/app/api/, in the order they should appear.
- * Dev endpoints (src/app/api/dev/) are intentionally NOT listed — they only run
- * in development (IS_DEV guard) and are excluded from the public documentation.
+ * One tag per resource group under src/app/api/, in the order they should
+ * appear. Dev endpoints (src/app/api/dev/) are intentionally NOT listed —
+ * they only run in development (IS_DEV guard) and are excluded from the
+ * public documentation.
+ *
+ * Kept as a module-level constant because it is pure data with no lifecycle.
  */
 export const OPENAPI_TAGS = [
   {

--- a/src/lib/server/openapi/registry.ts
+++ b/src/lib/server/openapi/registry.ts
@@ -1,0 +1,59 @@
+import { OpenAPIRegistry, extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
+import { z } from "zod";
+
+/**
+ * Extend Zod with .openapi() method.
+ *
+ * IMPORTANT: This must be called exactly once, before any schema uses .openapi().
+ * Since this file is the entry point for the OpenAPI infrastructure and is imported
+ * by every module that touches the registry, calling it here guarantees the extension
+ * is applied before any consumer runs.
+ */
+extendZodWithOpenApi(z);
+
+/**
+ * Global OpenAPI registry. All component schemas and paths are registered here.
+ * Consumed by generator.ts to produce the final OpenAPI document.
+ */
+export const registry = new OpenAPIRegistry();
+
+/**
+ * Bearer JWT security scheme used by all authenticated endpoints.
+ * Matches the Authorization: Bearer <token> format enforced by withAuth/withAdmin
+ * middlewares in src/lib/server/services/auth/middleware.ts.
+ */
+registry.registerComponent("securitySchemes", "bearerAuth", {
+  type: "http",
+  scheme: "bearer",
+  bearerFormat: "JWT",
+  description: "JWT token obtained via POST /auth/login. Send as 'Authorization: Bearer <token>'.",
+});
+
+/**
+ * OpenAPI tags used to group operations in the documentation UI.
+ * One tag per resource group under src/app/api/, in the order they should appear.
+ * Dev endpoints (src/app/api/dev/) are intentionally NOT listed — they only run
+ * in development (IS_DEV guard) and are excluded from the public documentation.
+ */
+export const OPENAPI_TAGS = [
+  {
+    name: "Auth",
+    description: "Authentication, registration, password recovery and email verification",
+  },
+  { name: "Users", description: "User profiles, memberships, photos, onboarding and curriculum" },
+  { name: "Entities", description: "Student organizations, labs, and other UFPB entities" },
+  { name: "Vagas", description: "Job and internship listings" },
+  { name: "Guides", description: "Academic guides with sections and subsections" },
+  { name: "Courses", description: "UFPB courses (majors)" },
+  { name: "Academic Centers", description: "UFPB academic centers" },
+  { name: "Campus", description: "UFPB campi" },
+  { name: "Disciplines", description: "Course disciplines and search" },
+  { name: "Curricula", description: "Curriculum grids and discipline trees" },
+  { name: "Academic Calendar", description: "Semesters and academic events" },
+  { name: "Search", description: "Unified full-text search across all entities" },
+  { name: "Health", description: "Service health check" },
+  { name: "Upload", description: "File upload endpoints" },
+  { name: "Content Images", description: "Static image serving from content submodules" },
+] as const;
+
+export type OpenApiTagName = (typeof OPENAPI_TAGS)[number]["name"];

--- a/src/lib/server/openapi/registry.ts
+++ b/src/lib/server/openapi/registry.ts
@@ -75,4 +75,5 @@ export const OPENAPI_TAGS = [
   },
 ] as const;
 
+/** Tipo derivado: nomes das tags OpenAPI registradas. */
 export type OpenApiTagName = (typeof OPENAPI_TAGS)[number]["name"];

--- a/src/lib/server/openapi/registry.ts
+++ b/src/lib/server/openapi/registry.ts
@@ -36,7 +36,7 @@ export function createRegistry(): OpenAPIRegistry {
     scheme: "bearer",
     bearerFormat: "JWT",
     description:
-      "JWT token obtained via POST /auth/login. Send as 'Authorization: Bearer <token>'.",
+      "Token JWT obtido via POST /auth/login. Enviar no header `Authorization: Bearer <token>`.",
   });
 
   return registry;
@@ -53,23 +53,26 @@ export function createRegistry(): OpenAPIRegistry {
  */
 export const OPENAPI_TAGS = [
   {
-    name: "Auth",
-    description: "Authentication, registration, password recovery and email verification",
+    name: "Autenticação",
+    description: "Login, cadastro, recuperação de senha e verificação de email",
   },
-  { name: "Users", description: "User profiles, memberships, photos, onboarding and curriculum" },
-  { name: "Entities", description: "Student organizations, labs, and other UFPB entities" },
-  { name: "Vagas", description: "Job and internship listings" },
-  { name: "Guides", description: "Academic guides with sections and subsections" },
-  { name: "Courses", description: "UFPB courses (majors)" },
-  { name: "Academic Centers", description: "UFPB academic centers" },
-  { name: "Campus", description: "UFPB campi" },
-  { name: "Disciplines", description: "Course disciplines and search" },
-  { name: "Curricula", description: "Curriculum grids and discipline trees" },
-  { name: "Academic Calendar", description: "Semesters and academic events" },
-  { name: "Search", description: "Unified full-text search across all entities" },
-  { name: "Health", description: "Service health check" },
-  { name: "Upload", description: "File upload endpoints" },
-  { name: "Content Images", description: "Static image serving from content submodules" },
+  { name: "Usuários", description: "Perfis, membresias, fotos, onboarding e currículo" },
+  { name: "Entidades", description: "Organizações estudantis, laboratórios e demais entidades" },
+  { name: "Vagas", description: "Estágios, empregos e oportunidades publicadas pelas entidades" },
+  { name: "Guias", description: "Guias acadêmicos com seções e subseções" },
+  { name: "Cursos", description: "Cursos (graduações) da UFPB" },
+  { name: "Centros Acadêmicos", description: "Centros acadêmicos da UFPB" },
+  { name: "Campus", description: "Campi da UFPB" },
+  { name: "Disciplinas", description: "Busca de disciplinas dos cursos" },
+  { name: "Currículos", description: "Grades curriculares e árvores de disciplinas" },
+  { name: "Calendário Acadêmico", description: "Semestres letivos e eventos do calendário" },
+  { name: "Busca", description: "Busca unificada em todas as categorias" },
+  { name: "Health", description: "Health check do serviço" },
+  { name: "Upload", description: "Endpoints de upload de arquivos" },
+  {
+    name: "Imagens de Conteúdo",
+    description: "Imagens estáticas servidas dos submódulos de conteúdo",
+  },
 ] as const;
 
 export type OpenApiTagName = (typeof OPENAPI_TAGS)[number]["name"];


### PR DESCRIPTION
## 📝 Descrição

 Implementei documentação interativa da API usando OpenAPI 3.1 + Scalar UI, cobrindo todos os 56 endpoints do projeto. A issue #149 pedia Swagger — optei pelo Scalar que é mais
 moderno e usa a mesma base OpenAPI.

 **Motivação:** A API do Aquário não tinha documentação — pra consumir qualquer endpoint era preciso ler o código-fonte.

 **O que fiz:**
 - Spec OpenAPI 3.1 gerada a partir dos mesmos Zod schemas usados na validação runtime (single source of truth)
 - UI interativa renderizada com Scalar em `/api-docs` com "Try it out" funcional
 - Endpoint JSON em `GET /api/openapi` pra integração com ferramentas (Postman, Insomnia, geradores de SDK)
 - Toda a documentação em português (público 100% brasileiro)
 - Error examples de cada endpoint espelham **exatamente** o que cada `ApiError.xxx()` retorna no route handler — testei todos os 56 endpoints via curl pra garantir

 ## 🔗 Issue Relacionada

 Closes #149

 ## ⚠️ Nota importante: mudanças em 30 route.ts existentes

 Esse PR **mexe em 30 arquivos route.ts existentes** além de adicionar arquivos novos. Quero explicar o porquê:

 Pra gerar a documentação, a lib `zod-to-openapi` precisa importar os Zod schemas dos endpoints. Tentei inicialmente exportar eles direto dos route.ts, mas o Next.js 15 App
 Router recusou o build:

 ```
 "loginSchema" is not a valid Route export field
 ```

 O Next.js 15 é rigoroso: `route.ts` só pode exportar handlers HTTP (`GET`, `POST`, etc.) e `config`. Qualquer outro export é erro de build.

 **A solução que encontrei** foi extrair os schemas Zod de dentro dos route.ts pra arquivos dedicados em `src/lib/server/api-schemas/`:

 ```diff
  // ANTES (inline no route.ts)
 -const loginSchema = z.object({
 -  email: z.string().email("Email inválido"),
 -  senha: z.string().min(1, "Senha é obrigatória"),
 -});

  // DEPOIS (importado de api-schemas/)
 +import { loginSchema } from "@/lib/server/api-schemas/auth";
 ```

 **O que NÃO mudou:**
 - Os schemas são **idênticos** (copiei byte a byte pro novo arquivo)
 - Os routes continuam importando e usando o mesmo objeto
 - **Zero mudança de comportamento** — a validação funciona exatamente igual
 - Nenhuma lógica de negócio foi alterada em nenhum route handler

 **Arquivos de schemas criados (5):**
 - `api-schemas/auth.ts` — loginSchema, registerSchema, verifySchema, etc.
 - `api-schemas/usuarios.ts` — updateUserInfoSchema, updateSlugSchema, etc.
 - `api-schemas/entidades.ts` — updateEntidadeSchema, addMemberSchema, etc.
 - `api-schemas/vagas.ts` — createVagaSchema
 - `api-schemas/calendario.ts` — createSemestreSchema, createEventoSchema, etc.

 **Se preferirem uma abordagem diferente pra essa extração, fico aberto a ajustar!** Tentei manter a refatoração o mais mecânica possível.

 ## 🧪 Testes

 - [x] Testes unitários passam (202 testes, 17 suites)
 - [ ] Testes de integração passam — N/A
 - [ ] Testes E2E passam — N/A (scripts de E2E não configurados no repositório)
 - [x] Testes manuais concluídos — testei todos os 56 endpoints via curl contra o dev server local, validando status codes, error codes e response shapes

 **Testes que adicionei (4 suites):**
 - `generator.test.ts` — estrutura da spec, cache, tags, security scheme
 - `common-schemas.test.ts` — schemas compartilhados de erro e paginação
 - `paths.test.ts` — sanity checks por grupo de recurso
 - `route.test.ts` — validação do endpoint `/api/openapi`

 ## 📋 Checklist

 - [x] Código segue as diretrizes de estilo do projeto
 - [x] Revisão própria concluída
 - [x] Código está devidamente comentado
 - [x] Nenhum console.log deixado no código
 - [x] Todos os testes passam localmente
 - [x] Build passa sem erros
 - [x] CHANGELOG.md atualizado
 - [x] README-DEV.md atualizado com seção "API Documentation"

 ## 🚀 Notas de Deploy

 - **Zero config:** Nenhuma variável de ambiente, migração ou setup extra. A página `/api-docs` e o endpoint `/api/openapi` ficam disponíveis automaticamente após deploy.
 - **Dependências novas:** `@asteasolutions/zod-to-openapi@7.3.4` e `@scalar/api-reference-react@0.9.20` (ambas pinadas pra compatibilidade com Zod 3 e React 18 do projeto)
 - **Override de segurança:** `dompurify` forçado pra `3.3.3` via overrides no `package.json` — o Scalar trazia transitivamente a `3.1.7` (vulnerável), mas o projeto já usava a `3.3.3`

 ## 📚 Contexto Adicional

 ### Como adicionar docs pra endpoints novos

 Coloquei instruções no README-DEV.md (seção "API Documentation"), mas o resumo é:

 1. Criar/editar arquivo em `src/lib/server/openapi/paths/`
 2. Registrar em `paths/index.ts`
 3. Usar `errorResponses()` com examples reais do route handler
 4. Rodar `npm run test` — o teste valida a estrutura da spec

 ### Coisas que encontrei durante o desenvolvimento

 1. **Bug no register:** O route handler de `POST /auth/register` verifica `message === "EMAIL_JA_CADASTRADO"` mas o service lança `"Este e-mail já está em uso."` — as strings não batem, então o `ApiError.emailExists()` (409) nunca é chamado e cai no fallback `badRequest` (400). Documentei o **comportamento atual** (400), não a intenção do código. Pode valer um fix separado se for intencional retornar 409.

 ### Sugestões pra PRs futuros

 Sugestões em aberto:

 - **Link de navegação pra `/api-docs`** — a página existe mas não tem link de nenhum lugar do site. Vocês decidem onde faz sentido (header, footer, dropdown, etc.)
 - **Atualizar versões quando o projeto migrar** — quando migrarem pra React 19 ou Zod 4, as dependências podem ser despinadas pra versões mais recentes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive API docs at /api-docs (Scalar UI) and machine-readable OpenAPI 3.1 JSON at GET /api/openapi (56 endpoints)

* **Documentation**
  * README-DEV updated with an “API Documentation” section describing the docs/spec and how to add endpoint docs

* **Style**
  * Page-scoped CSS to hide site chrome and toolbar for a focused docs view

* **Tests**
  * New test suites validating OpenAPI generation, registered paths, routes, and common schemas
<!-- end of auto-generated comment: release notes by coderabbit.ai -->