### PR TITLE
feat(projetos): order /projetos by dataInicio with criadoEm fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Projetos**: Default ordering on `/projetos` now uses `dataInicio` (start date) instead of `criadoEm`, falling back to `criadoEm` for projects without a start date.
+
 ## [1.7.0] - 2026-05-02
 
 ### Added

--- a/src/app/projetos/page.tsx
+++ b/src/app/projetos/page.tsx
@@ -51,8 +51,8 @@ const SORT_OPTIONS: {
   orderBy: ProjetoOrderBy;
   order: ProjetoOrder;
 }[] = [
-  { value: "recent", label: "Mais recentes", orderBy: "criadoEm", order: "desc" },
-  { value: "oldest", label: "Mais antigos", orderBy: "criadoEm", order: "asc" },
+  { value: "recent", label: "Mais recentes", orderBy: "dataInicio", order: "desc" },
+  { value: "oldest", label: "Mais antigos", orderBy: "dataInicio", order: "asc" },
   { value: "title-asc", label: "Título (A–Z)", orderBy: "titulo", order: "asc" },
   { value: "title-desc", label: "Título (Z–A)", orderBy: "titulo", order: "desc" },
   { value: "authors-desc", label: "Mais autores", orderBy: "autoresCount", order: "desc" },

--- a/src/lib/client/api/projetos.ts
+++ b/src/lib/client/api/projetos.ts
@@ -8,7 +8,7 @@ import type {
 } from "@/lib/shared/validations/projetos";
 
 export type ProjetoStatus = "PUBLICADO" | "RASCUNHO" | "ARQUIVADO";
-export type ProjetoOrderBy = "criadoEm" | "publicadoEm" | "titulo" | "autoresCount";
+export type ProjetoOrderBy = "dataInicio" | "criadoEm" | "publicadoEm" | "titulo" | "autoresCount";
 export type ProjetoOrder = "asc" | "desc";
 
 /**

--- a/src/lib/client/hooks/use-projetos.ts
+++ b/src/lib/client/hooks/use-projetos.ts
@@ -56,7 +56,7 @@ export function useProjetosInfinite(params: UseProjetosInfiniteParams = {}) {
         search: search ?? "",
         tipoEntidade: tipoEntidade ?? "",
         status: status ?? "PUBLICADO",
-        orderBy: orderBy ?? "criadoEm",
+        orderBy: orderBy ?? "dataInicio",
         order: order ?? "desc",
         scopedToMe: !!scopedToMe,
         pageSize,

--- a/src/lib/server/db/implementations/prisma/prisma-projetos-repository.ts
+++ b/src/lib/server/db/implementations/prisma/prisma-projetos-repository.ts
@@ -156,10 +156,18 @@ export class PrismaProjetosRepository implements IProjetosRepository {
       where.AND = [...((where.AND as Prisma.ProjetoWhereInput[]) ?? []), visibilityFilter];
     }
 
-    const orderByClause: Prisma.ProjetoOrderByWithRelationInput =
+    const sortOrder = order as Prisma.SortOrder;
+    // dataInicio is a tiered sort: projects with a start date sort by it first,
+    // then projects without fall back to criadoEm. Prisma can't do COALESCE in
+    // orderBy, so we approximate with `nulls: 'last'` followed by criadoEm.
+    const orderByClause:
+      | Prisma.ProjetoOrderByWithRelationInput
+      | Prisma.ProjetoOrderByWithRelationInput[] =
       orderBy === "autoresCount"
-        ? { autores: { _count: order as Prisma.SortOrder } }
-        : { [orderBy]: order as Prisma.SortOrder };
+        ? { autores: { _count: sortOrder } }
+        : orderBy === "dataInicio"
+          ? [{ dataInicio: { sort: sortOrder, nulls: "last" } }, { criadoEm: sortOrder }]
+          : { [orderBy]: sortOrder };
 
     const [projetos, total] = await Promise.all([
       prisma.projeto.findMany({

--- a/src/lib/shared/validations/projetos.ts
+++ b/src/lib/shared/validations/projetos.ts
@@ -137,7 +137,9 @@ export const listProjetosSchema = z.object({
       "OUTRO",
     ])
     .optional(),
-  orderBy: z.enum(["criadoEm", "publicadoEm", "titulo", "autoresCount"]).default("criadoEm"),
+  orderBy: z
+    .enum(["dataInicio", "criadoEm", "publicadoEm", "titulo", "autoresCount"])
+    .default("dataInicio"),
   order: z.enum(["asc", "desc"]).default("desc"),
   /**
    * When true, restrict results to projects the caller authors or admins —


### PR DESCRIPTION
## Summary
- Default ordering on `/projetos` now sorts by `dataInicio` instead of `criadoEm`, so projects line up on a real timeline.
- Projects without a `dataInicio` fall to the bottom of the list and sort among themselves by `criadoEm` in the same direction (tiered sort via Prisma `nulls: 'last'` + secondary key — no DB migration).
- "Mais recentes" / "Mais antigos" labels and the server's default `orderBy` both updated; new `"dataInicio"` value added to the `ProjetoOrderBy` enum on client and server.

## Test plan
- [ ] `/projetos` loads with "Mais recentes" selected by default and shows projects ordered by start date (newest first).
- [ ] Projects with no `dataInicio` appear at the bottom, ordered by `criadoEm` desc.
- [ ] Switching to "Mais antigos" reverses both tiers (oldest start dates first; nulls still last but ordered by `criadoEm` asc).
- [ ] Other sort options (Título A–Z/Z–A, Mais/Menos autores) unchanged.
- [ ] Status tabs, type filters, and search still work alongside the new default sort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Project listings now default to sorting by start date instead of creation date, with creation date as a fallback when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->