### PR TITLE
feat(projetos): similar section, detail-page polish, and landing destaque carousel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Navigation**: Add `Projetos` link to the desktop navbar and mobile hamburger menu.
 - **Landing Page**: Add a "Projetos destaque" section inside the underwater area, above Recursos — an infinite-loop carousel showing 3 cards at a time, drawn from a random sample of the top projects by author count.
+- **Projeto Page**: New "Projetos similares" section on `/projetos/[slug]` — shows up to 4 related projetos. Powered by a new `GET /api/projetos/[slug]/similar` endpoint that ranks PUBLICADO projetos server-side by shared autores (entidade > usuário) and tag overlap.
 
 ### Changed
 - **Projetos**: Default ordering on `/projetos` now uses `dataInicio` (start date) instead of `criadoEm`, falling back to `criadoEm` for projects without a start date.
 - **Landing Page**: Bump the GitHub stars stat to 80.
+- **Sobre**: Refresh the Funcionalidades copy for semestre 2026.1 — list every live module (Guias, Entidades, Projetos, Vagas, Minhas Disciplinas, Grades Curriculares, Calendário Acadêmico, Mapas, busca global) and drop Vagas from the "em breve" list now that it's live.
+
+### Fixed
+- **Entidade**: Members table now scrolls horizontally instead of squeezing the Usuário column when a row enters edit mode. The user column has a guaranteed min-width and the table grows to fit the inline edit controls.
+- **DatePicker**: Date picker popovers no longer fail to open when used inside dialogs (e.g. add-member form on entidade page, add-vínculo dialog on profile). Popover now runs in modal mode so the parent Dialog's focus trap doesn't immediately close it.
+- **Projeto Page**: "Voltar" button on `/projetos/[id]` now returns to the previous page (e.g. the entidade page the user came from) instead of always going to `/projetos`. Falls back to `/projetos` when there's no in-app history.
 
 ## [1.7.0] - 2026-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Navigation**: Add `Projetos` link to the desktop navbar and mobile hamburger menu.
+- **Landing Page**: Add a "Projetos destaque" section beneath the underwater hero — an infinite-loop carousel showing 3 cards at a time, drawn from a random sample of the top projects by author count.
+
 ### Changed
 - **Projetos**: Default ordering on `/projetos` now uses `dataInicio` (start date) instead of `criadoEm`, falling back to `criadoEm` for projects without a start date.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Navigation**: Add `Projetos` link to the desktop navbar and mobile hamburger menu.
-- **Landing Page**: Add a "Projetos destaque" section beneath the underwater hero — an infinite-loop carousel showing 3 cards at a time, drawn from a random sample of the top projects by author count.
+- **Landing Page**: Add a "Projetos destaque" section inside the underwater area, above Recursos — an infinite-loop carousel showing 3 cards at a time, drawn from a random sample of the top projects by author count.
 
 ### Changed
 - **Projetos**: Default ordering on `/projetos` now uses `dataInicio` (start date) instead of `criadoEm`, falling back to `criadoEm` for projects without a start date.
+- **Landing Page**: Bump the GitHub stars stat to 80.
 
 ## [1.7.0] - 2026-05-02
 

--- a/src/app/api/landing-stats/route.ts
+++ b/src/app/api/landing-stats/route.ts
@@ -14,6 +14,6 @@ export async function GET() {
 
   return NextResponse.json({
     totalUsuarios: total,
-    githubStars: 75,
+    githubStars: 80,
   });
 }

--- a/src/app/api/projetos/[slug]/similar/route.ts
+++ b/src/app/api/projetos/[slug]/similar/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getContainer } from "@/lib/server/container";
+import { ApiError } from "@/lib/server/errors";
+
+export const dynamic = "force-dynamic";
+
+type RouteContext = {
+  params: Promise<{ slug: string }>;
+};
+
+const DEFAULT_LIMIT = 4;
+const MAX_LIMIT = 12;
+
+/**
+ * GET /api/projetos/[slug]/similar?limit=4
+ * Public — returns up to `limit` PUBLICADO projetos similar to the source,
+ * ranked by shared autores and tags. Source must itself be PUBLICADO; non-public
+ * projetos return 404 to avoid leaking their existence.
+ */
+export async function GET(request: NextRequest, context: RouteContext) {
+  try {
+    const { slug } = await context.params;
+    const url = new URL(request.url);
+    const rawLimit = Number(url.searchParams.get("limit") ?? DEFAULT_LIMIT);
+    const limit = Math.min(
+      MAX_LIMIT,
+      Math.max(1, Number.isFinite(rawLimit) ? rawLimit : DEFAULT_LIMIT)
+    );
+
+    const { projetosRepository } = getContainer();
+    const source = await projetosRepository.findBySlug(slug);
+    if (!source || source.status !== "PUBLICADO") {
+      return ApiError.notFound("Projeto");
+    }
+
+    const similar = await projetosRepository.findSimilar(source.id, limit);
+    return NextResponse.json({ projetos: similar });
+  } catch (error) {
+    console.error("Error fetching similar projetos:", error);
+    return ApiError.internal("Erro ao buscar projetos similares");
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 import { trackEvent } from "@/analytics/posthog-client";
 import { FeatureCard } from "@/components/pages/landing/features/feature-card";
 import { landingFeatures } from "@/components/pages/landing/features/feature-data";
+import { TopProjetosCarousel } from "@/components/pages/landing/top-projetos-carousel";
 import { WaterTransitionSection } from "@/components/pages/landing/water-transition-section";
 import { Button } from "@/components/ui/button";
 import { useEntidades } from "@/lib/client/hooks";
@@ -141,6 +142,7 @@ export default function Home() {
       </div>
 
       <WaterTransitionSection>
+        <TopProjetosCarousel />
         <div className="mx-auto max-w-6xl">
           <div className="mb-10 grid gap-6 md:grid-cols-[1fr_0.75fr] md:items-end">
             <div>
@@ -162,7 +164,7 @@ export default function Home() {
             ))}
           </div>
 
-          <section className="pt-20 md:pt-28">
+          <section className="pt-28 md:pt-40">
             <div className="grid gap-8 rounded-[2rem] border border-white/10 bg-white/[0.05] p-6 shadow-sm backdrop-blur-sm md:grid-cols-[0.85fr_1.15fr] md:items-center md:p-10">
               <div>
                 <p className="mb-4 text-sm font-semibold uppercase tracking-[0.2em] text-sky-200">

--- a/src/app/projetos/[id]/page.tsx
+++ b/src/app/projetos/[id]/page.tsx
@@ -29,6 +29,7 @@ import { format } from "date-fns";
 import { ptBR } from "date-fns/locale/pt-BR";
 import { toast } from "sonner";
 import { ConfirmDeleteDialog } from "@/components/shared/confirm-delete-dialog";
+import { SimilarProjetosSection } from "@/components/pages/projetos/similar-projetos-section";
 
 /** "jan/2025" — empty string if no date. */
 function formatMonthYear(d: Date | string | null | undefined): string {
@@ -123,11 +124,23 @@ export default function ProjetoPage() {
   return (
     <div className="container mx-auto p-4 md:p-8 mt-8 max-w-7xl pb-32">
       <div className="flex items-center justify-between mb-8">
-        <Button variant="ghost" className="pl-0 hover:bg-transparent hover:text-primary" asChild>
-          <Link href="/projetos">
-            <ArrowLeft className="mr-2 h-4 w-4" />
-            Voltar
-          </Link>
+        <Button
+          variant="ghost"
+          className="pl-0 hover:bg-transparent hover:text-primary"
+          onClick={() => {
+            const sameOriginReferrer =
+              typeof document !== "undefined" &&
+              document.referrer &&
+              new URL(document.referrer).origin === window.location.origin;
+            if (sameOriginReferrer && window.history.length > 1) {
+              router.back();
+            } else {
+              router.push("/projetos");
+            }
+          }}
+        >
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Voltar
         </Button>
         {canEdit && (
           <div className="flex items-center gap-2">
@@ -398,6 +411,8 @@ export default function ProjetoPage() {
           )}
         </aside>
       </div>
+
+      {raw?.status === "PUBLICADO" && <SimilarProjetosSection slug={id} />}
 
       <ConfirmDeleteDialog
         open={archiveOpen}

--- a/src/app/sobre/page.tsx
+++ b/src/app/sobre/page.tsx
@@ -90,16 +90,19 @@ export default function SobrePage() {
                 professores e laboratórios possam se conectar e colaborar.
               </p>
               <p className="text-base leading-relaxed text-slate-600 dark:text-sky-100 md:text-lg">
-                A versão atual, lançada no semestre <strong>2025.2</strong>, já conta com as
-                funcionalidades de <strong>Guias</strong> e <strong>Entidades</strong> totalmente
-                disponíveis. Estes módulos permitem que os alunos encontrem orientações sobre cursos
-                e disciplinas, além de explorarem o diretório completo de laboratórios, grupos de
-                pesquisa, ligas acadêmicas e outras entidades do CI.
+                Já no ar no semestre <strong>2026.1</strong>: <strong>Guias</strong> com orientações
+                sobre cursos e disciplinas, <strong>Entidades</strong> com o diretório completo de
+                laboratórios, grupos de pesquisa e ligas acadêmicas, <strong>Projetos</strong> com
+                portfólio publicado pela própria comunidade, <strong>Vagas</strong> de estágio e
+                pesquisa, <strong>Minhas Disciplinas</strong> para montar seu calendário pessoal a
+                partir das turmas do semestre, <strong>Grades Curriculares</strong> interativas,{" "}
+                <strong>Calendário Acadêmico</strong> da UFPB, <strong>Mapas</strong> dos prédios do
+                CI e <strong>busca global</strong> (Ctrl+K) que cobre toda a plataforma.
               </p>
               <p className="text-base leading-relaxed text-slate-600 dark:text-sky-100 md:text-lg">
-                Estamos trabalhando continuamente para expandir as funcionalidades da plataforma,
-                incluindo sistema de vagas, blog e publicações, achados e perdidos, e muito mais. O
-                Aquário é um projeto open source e novas contribuições são sempre bem-vindas!
+                Continuamos trabalhando para expandir o Aquário, com novidades como blog e
+                publicações, achados e perdidos, e muito mais a caminho. O Aquário é um projeto open
+                source e novas contribuições são sempre bem-vindas!
               </p>
             </CardContent>
           </Card>

--- a/src/components/pages/entidades/members-table.tsx
+++ b/src/components/pages/entidades/members-table.tsx
@@ -15,7 +15,6 @@ import { Pencil, Trash2 } from "lucide-react";
 import Image from "next/image";
 import { getDefaultAvatarUrl } from "@/lib/client/utils";
 import type { Membro, Cargo } from "@/lib/shared/types/membro.types";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { useUpdateEntidadeMember, useDeleteEntidadeMember } from "@/lib/client/hooks/use-entidades";
 import { toast } from "sonner";
 import { useQueryClient } from "@tanstack/react-query";
@@ -123,17 +122,19 @@ export function MembersTable({ members, cargos, entidade }: MembersTableProps) {
 
   return (
     <div className="border rounded-lg overflow-hidden">
-      <ScrollArea className="h-[400px]">
-        <div className="min-w-full">
+      <div className="max-h-[400px] overflow-auto">
+        <div className="min-w-max">
           <table className="w-full">
-            <thead className="bg-muted/50 sticky top-0">
+            <thead className="bg-muted/50 sticky top-0 z-10">
               <tr>
-                <th className="text-left p-3 text-sm font-medium">Usuário</th>
-                <th className="text-left p-3 text-sm font-medium">Cargo</th>
-                <th className="text-left p-3 text-sm font-medium">Papel</th>
-                <th className="text-left p-3 text-sm font-medium">Início</th>
-                <th className="text-left p-3 text-sm font-medium">Término</th>
-                <th className="text-right p-3 text-sm font-medium">Ações</th>
+                <th className="text-left p-3 text-sm font-medium">
+                  <div className="min-w-[220px]">Usuário</div>
+                </th>
+                <th className="text-left p-3 text-sm font-medium whitespace-nowrap">Cargo</th>
+                <th className="text-left p-3 text-sm font-medium whitespace-nowrap">Papel</th>
+                <th className="text-left p-3 text-sm font-medium whitespace-nowrap">Início</th>
+                <th className="text-left p-3 text-sm font-medium whitespace-nowrap">Término</th>
+                <th className="text-right p-3 text-sm font-medium whitespace-nowrap">Ações</th>
               </tr>
             </thead>
             <tbody>
@@ -312,7 +313,7 @@ export function MembersTable({ members, cargos, entidade }: MembersTableProps) {
             </tbody>
           </table>
         </div>
-      </ScrollArea>
+      </div>
     </div>
   );
 }

--- a/src/components/pages/landing/top-projetos-carousel.tsx
+++ b/src/components/pages/landing/top-projetos-carousel.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import Link from "next/link";
+import { useMemo } from "react";
+import { ArrowRight } from "lucide-react";
+
+import ProjectCard from "@/components/shared/project-card";
+import { listProjetos } from "@/lib/client/api/projetos";
+import { mapProjetoToCard } from "@/lib/client/mappers/projeto-mapper";
+
+const POOL_SIZE = 30;
+const VISIBLE_COUNT = 10;
+
+export function TopProjetosCarousel() {
+  const { data: projetos } = useQuery({
+    queryKey: ["projetos", "top-by-autores", { pool: POOL_SIZE }],
+    queryFn: async () => {
+      const data = await listProjetos({
+        status: "PUBLICADO",
+        orderBy: "autoresCount",
+        order: "desc",
+        limit: POOL_SIZE,
+      });
+      return data.projetos;
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const cards = useMemo(() => {
+    if (!projetos || projetos.length === 0) {
+      return [];
+    }
+    const shuffled = [...projetos];
+    for (let i = shuffled.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+    }
+    return shuffled.slice(0, VISIBLE_COUNT).map(mapProjetoToCard);
+  }, [projetos]);
+
+  if (cards.length === 0) {
+    return null;
+  }
+
+  // Duplicate the list so the marquee can wrap seamlessly at translateX(-50%).
+  const looped = [...cards, ...cards];
+
+  return (
+    <div className="mx-auto mb-24 max-w-6xl md:mb-32">
+      <div className="mb-8 flex items-end justify-between gap-4 md:mb-10">
+        <div>
+          <p className="mb-2 text-sm font-semibold uppercase tracking-[0.2em] text-sky-200">
+            Em destaque
+          </p>
+          <h2 className="font-display text-3xl font-bold leading-tight text-white md:text-4xl">
+            Projetos destaque
+          </h2>
+        </div>
+        <Link
+          href="/projetos"
+          className="hidden shrink-0 items-center gap-1 rounded-full px-3 py-2 text-sm font-medium text-sky-100 transition-colors hover:bg-white/10 hover:text-white md:inline-flex"
+        >
+          Ver todos
+          <ArrowRight className="h-4 w-4" />
+        </Link>
+      </div>
+
+      <div className="group relative -mx-4 overflow-hidden">
+        <div className="pointer-events-none absolute inset-y-0 left-0 z-10 w-12 bg-gradient-to-r from-aquario-primary to-transparent md:w-20" />
+        <div className="pointer-events-none absolute inset-y-0 right-0 z-10 w-12 bg-gradient-to-l from-aquario-primary to-transparent md:w-20" />
+
+        <div
+          className="flex w-fit gap-6 px-4 motion-safe:animate-group-marquee group-hover:[animation-play-state:paused]"
+          aria-label="Carrossel de projetos em destaque"
+        >
+          {looped.map((projeto, index) => (
+            <Link
+              key={`${projeto.id}-${index}`}
+              href={`/projetos/${projeto.id}`}
+              aria-hidden={index >= cards.length}
+              tabIndex={index >= cards.length ? -1 : undefined}
+              className="block w-[260px] flex-shrink-0 sm:w-[300px] md:w-[340px] lg:w-[360px]"
+            >
+              <div className="rounded-2xl bg-white p-3 shadow-lg dark:bg-slate-900">
+                <ProjectCard projeto={projeto} />
+              </div>
+            </Link>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-6 md:hidden">
+        <Link
+          href="/projetos"
+          className="inline-flex items-center gap-1 text-sm font-medium text-sky-100"
+        >
+          Ver todos os projetos
+          <ArrowRight className="h-4 w-4" />
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/pages/projetos/similar-projetos-section.tsx
+++ b/src/components/pages/projetos/similar-projetos-section.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import Link from "next/link";
+import ProjectCard from "@/components/shared/project-card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { mapProjetoToCard } from "@/lib/client/mappers/projeto-mapper";
+import { useSimilarProjetos } from "@/lib/client/hooks/use-projetos";
+
+type SimilarProjetosSectionProps = {
+  slug: string;
+};
+
+const LIMIT = 4;
+
+export function SimilarProjetosSection({ slug }: SimilarProjetosSectionProps) {
+  const { data, isLoading } = useSimilarProjetos(slug, LIMIT);
+
+  if (isLoading) {
+    return (
+      <section className="mt-16">
+        <h2 className="text-2xl font-display font-bold mb-6">Projetos similares</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+          {Array.from({ length: LIMIT }).map((_, i) => (
+            <Skeleton key={i} className="h-72 rounded-xl" />
+          ))}
+        </div>
+      </section>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="mt-16">
+      <h2 className="text-2xl font-display font-bold mb-6">Projetos similares</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 auto-rows-fr">
+        {data.map(p => {
+          const card = mapProjetoToCard(p);
+          return (
+            <Link key={card.id} href={`/projetos/${card.id}`} className="h-full">
+              <ProjectCard projeto={card} />
+            </Link>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/shared/hamburguer-menu.tsx
+++ b/src/components/shared/hamburguer-menu.tsx
@@ -247,6 +247,7 @@ const NAV_LINKS = [
   { href: "/mapas", label: "MAPAS" },
   { href: "/guias", label: "GUIAS" },
   { href: "/entidades", label: "ENTIDADES" },
+  { href: "/projetos", label: "PROJETOS" },
 ] as const;
 
 // ============================================================================

--- a/src/components/shared/nav-bar.tsx
+++ b/src/components/shared/nav-bar.tsx
@@ -298,12 +298,9 @@ function NavLinks() {
       <Link href="/entidades" className={navLinkClass}>
         Entidades
       </Link>
-      {/* Hidden until prod has the projetos backfill — re-enable after the
-          ingest script populates real content (the route stays reachable by URL
-          for QA in the meantime). */}
-      {/* <Link href="/projetos" className={navLinkClass}>
+      <Link href="/projetos" className={navLinkClass}>
         Projetos
-      </Link> */}
+      </Link>
     </div>
   );
 }

--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -141,7 +141,7 @@ export function DatePicker({
   };
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={setOpen} modal>
       <PopoverTrigger asChild>
         <Button
           id={id}

--- a/src/lib/client/api/projetos.ts
+++ b/src/lib/client/api/projetos.ts
@@ -95,6 +95,16 @@ export async function getProjetoBySlug(slug: string): Promise<ProjetoWithRelatio
   return res.json();
 }
 
+/** GET /api/projetos/[slug]/similar — server-ranked recommendations. */
+export async function getSimilarProjetos(slug: string, limit = 4): Promise<ProjetoWithRelations[]> {
+  const res = await apiClient(`/projetos/${slug}/similar?limit=${limit}`);
+  if (!res.ok) {
+    await throwApiError(res);
+  }
+  const data = (await res.json()) as { projetos: ProjetoWithRelations[] };
+  return data.projetos;
+}
+
 /** POST /api/projetos. */
 export async function createProjeto(data: CreateProjetoInput): Promise<ProjetoWithRelations> {
   const res = await apiClient("/projetos", {

--- a/src/lib/client/hooks/use-projetos.ts
+++ b/src/lib/client/hooks/use-projetos.ts
@@ -3,6 +3,7 @@ import { queryKeys } from "@/lib/client/query-keys";
 import {
   fetchProjetos,
   getProjetoBySlug,
+  getSimilarProjetos,
   listProjetos,
   type ProjetoOrder,
   type ProjetoOrderBy,
@@ -274,6 +275,16 @@ export function useProjetoBySlug(slug?: string) {
   return useQuery({
     queryKey: queryKeys.projetos.bySlug(slug ?? ""),
     queryFn: () => getProjetoBySlug(slug as string),
+    enabled: !!slug,
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+// Server-ranked similar projetos for the given source slug.
+export function useSimilarProjetos(slug?: string, limit = 4) {
+  return useQuery({
+    queryKey: [...queryKeys.projetos.bySlug(slug ?? ""), "similar", limit],
+    queryFn: () => getSimilarProjetos(slug as string, limit),
     enabled: !!slug,
     staleTime: 5 * 60 * 1000,
   });

--- a/src/lib/server/db/implementations/prisma/prisma-projetos-repository.ts
+++ b/src/lib/server/db/implementations/prisma/prisma-projetos-repository.ts
@@ -306,4 +306,102 @@ export class PrismaProjetosRepository implements IProjetosRepository {
 
     return this.findBySlug(slug);
   }
+
+  async findSimilar(projetoId: string, limit: number): Promise<ProjetoWithRelations[]> {
+    const source = await prisma.projeto.findUnique({
+      where: { id: projetoId },
+      select: {
+        id: true,
+        tags: true,
+        autores: { select: { usuarioId: true, entidadeId: true } },
+      },
+    });
+    if (!source) {
+      return [];
+    }
+
+    const sourceUsuarioIds = source.autores.map(a => a.usuarioId).filter((x): x is string => !!x);
+    const sourceEntidadeIds = source.autores.map(a => a.entidadeId).filter((x): x is string => !!x);
+    const sourceTags = source.tags;
+    const sourceTagsLower = new Set(sourceTags.map(t => t.toLowerCase()));
+
+    // No signal to score against → no recommendations.
+    if (
+      sourceTags.length === 0 &&
+      sourceUsuarioIds.length === 0 &&
+      sourceEntidadeIds.length === 0
+    ) {
+      return [];
+    }
+
+    const overlapClauses: Prisma.ProjetoWhereInput[] = [];
+    if (sourceTags.length > 0) {
+      overlapClauses.push({ tags: { hasSome: sourceTags } });
+    }
+    if (sourceUsuarioIds.length > 0) {
+      overlapClauses.push({ autores: { some: { usuarioId: { in: sourceUsuarioIds } } } });
+    }
+    if (sourceEntidadeIds.length > 0) {
+      overlapClauses.push({ autores: { some: { entidadeId: { in: sourceEntidadeIds } } } });
+    }
+
+    const candidates = await prisma.projeto.findMany({
+      where: {
+        status: "PUBLICADO",
+        id: { not: projetoId },
+        OR: overlapClauses,
+      },
+      ...projetoWithAutoresArgs,
+    });
+
+    // Per-overlap weights — entidade overlap is a stronger signal than a single
+    // shared tag (a lab's projects are highly related); shared usuario sits in
+    // between. Tweak as the corpus grows and we get a feel for ordering.
+    const ENTIDADE_WEIGHT = 5;
+    const USUARIO_WEIGHT = 3;
+    const TAG_WEIGHT = 2;
+
+    const sourceUsuarioSet = new Set(sourceUsuarioIds);
+    const sourceEntidadeSet = new Set(sourceEntidadeIds);
+
+    const scored = candidates.map(p => {
+      let score = 0;
+      const seenUsuario = new Set<string>();
+      const seenEntidade = new Set<string>();
+      for (const a of p.autores) {
+        if (a.usuarioId && sourceUsuarioSet.has(a.usuarioId) && !seenUsuario.has(a.usuarioId)) {
+          score += USUARIO_WEIGHT;
+          seenUsuario.add(a.usuarioId);
+        }
+        if (
+          a.entidadeId &&
+          sourceEntidadeSet.has(a.entidadeId) &&
+          !seenEntidade.has(a.entidadeId)
+        ) {
+          score += ENTIDADE_WEIGHT;
+          seenEntidade.add(a.entidadeId);
+        }
+      }
+      for (const t of p.tags) {
+        if (sourceTagsLower.has(t.toLowerCase())) {
+          score += TAG_WEIGHT;
+        }
+      }
+      return { p, score };
+    });
+
+    return scored
+      .filter(s => s.score > 0)
+      .sort((a, b) => {
+        if (b.score !== a.score) {
+          return b.score - a.score;
+        }
+        // Tie-break: most recently published first.
+        const at = a.p.publicadoEm?.getTime() ?? a.p.criadoEm.getTime();
+        const bt = b.p.publicadoEm?.getTime() ?? b.p.criadoEm.getTime();
+        return bt - at;
+      })
+      .slice(0, limit)
+      .map(s => asProjetoWithRelations(s.p));
+  }
 }

--- a/src/lib/server/db/interfaces/projetos-repository.interface.ts
+++ b/src/lib/server/db/interfaces/projetos-repository.interface.ts
@@ -133,4 +133,11 @@ export type IProjetosRepository = {
   ): Promise<ProjetoWithRelations | null>;
 
   findBySlugWithAutores(slug: string): Promise<(Projeto & { autores: ProjetoAutor[] }) | null>;
+
+  /**
+   * Returns up to `limit` PUBLICADO projetos most similar to the source,
+   * scored by overlap of tags and shared autores (usuario/entidade).
+   * Excludes the source itself. Empty array when no overlap exists.
+   */
+  findSimilar(projetoId: string, limit: number): Promise<ProjetoWithRelations[]>;
 };


### PR DESCRIPTION
## Summary
- New **Projetos similares** section on `/projetos/[slug]` (up to 4 cards) backed by `GET /api/projetos/[slug]/similar` — server-side ranking by shared autores (entidade > usuário) and tag overlap, with recency tie-break. Source must be PUBLICADO; non-public projetos return 404.
- **Landing destaque carousel** in the underwater section: infinite-loop marquee drawn from a random sample of the top projetos by author count, with pause-on-hover and proper a11y (`aria-hidden` + `tabIndex={-1}` on the duplicated half).
- **Navigation**: re-enable the `Projetos` link in the desktop navbar and hamburger menu now that the catalog is populated.
- **Default sort** on `/projetos` switches to `dataInicio` with `criadoEm` fallback (Prisma multi-orderBy with `nulls: 'last'`).
- **Detail-page polish**:
  - "Voltar" button uses `router.back()` when the referrer is same-origin (so users return to the entidade/profile they came from), `/projetos` otherwise.
  - Members table swaps Radix `ScrollArea` for a native overflow wrapper — keeps a `min-width` on the Usuário column during inline edits and grows horizontally to fit the controls.
  - DatePicker `Popover` runs in `modal` mode so it stops closing instantly inside Dialog focus traps (add-member, add-vínculo).
- **Sobre** Funcionalidades copy refreshed for semestre 2026.1 (lists every live module, drops Vagas from "em breve").

## Test plan
- [ ] Landing page loads and the "Projetos destaque" carousel renders, scrolls, and pauses on hover; "Ver todos" link navigates to `/projetos`.
- [ ] `/projetos` defaults to "Mais recentes" by `dataInicio`; projetos without a start date appear last and are then ordered by `criadoEm`.
- [ ] On a PUBLICADO projeto detail page, "Projetos similares" renders up to 4 cards; section is hidden for non-PUBLICADO.
- [ ] `GET /api/projetos/[slug]/similar` returns 404 for non-PUBLICADO sources, empty array when no overlap exists, and respects `limit` (1–12, default 4).
- [ ] "Voltar" returns to the previous in-app page when navigating in from `/entidades/...` or a profile; falls back to `/projetos` when entering directly via URL.
- [ ] Members table on an entidade page: enter edit mode on a row — table scrolls horizontally, Usuário column stays readable, sticky header.
- [ ] DatePicker inside the add-member dialog and add-vínculo dialog opens and closes correctly.
- [ ] `/sobre` Funcionalidades paragraph reflects 2026.1 modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Projetos" navigation link to main navigation menu
  * Launched featured projects carousel on landing page
  * Introduced similar projects section on individual project pages

* **Bug Fixes**
  * Fixed members table horizontal scrolling and layout issues
  * Fixed DatePicker popover focus behavior in dialogs
  * Improved back button navigation on project pages to respect browser history

* **Updates**
  * Updated GitHub stars count to 80
  * Refreshed About page content for semester 2026.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->