### PR TITLE
feat(projetos): add PostHog analytics across /projetos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Navigation**: Add `Projetos` link to the desktop navbar and mobile hamburger menu.
 - **Landing Page**: Add a "Projetos destaque" section inside the underwater area, above Recursos — an infinite-loop carousel showing 3 cards at a time, drawn from a random sample of the top projects by author count.
 - **Projeto Page**: New "Projetos similares" section on `/projetos/[slug]` — shows up to 4 related projetos. Powered by a new `GET /api/projetos/[slug]/similar` endpoint that ranks PUBLICADO projetos server-side by shared autores (entidade > usuário) and tag overlap.
+- **Projetos**: PostHog analytics across the projetos feature — `projetos_list_viewed` (initial mount + tab change), `projeto_viewed`, `projeto_link_clicked` (repositorio/prototipo/outro), `projeto_create_clicked`, `projeto_created`, `projeto_edited`, `projeto_archived`, and `projeto_unarchived`.
 
 ### Changed
 - **Projetos**: Default ordering on `/projetos` now uses `dataInicio` (start date) instead of `criadoEm`, falling back to `criadoEm` for projects without a start date.

--- a/src/analytics/posthog-events.ts
+++ b/src/analytics/posthog-events.ts
@@ -94,6 +94,29 @@ export type OnboardingEvent =
   | { name: "onboarding_step_completed"; step_id: OnboardingStepId }
   | { name: "onboarding_step_skipped"; step_id: OnboardingStepId };
 
+export type ProjetoStatus = "PUBLICADO" | "RASCUNHO" | "ARQUIVADO";
+
+export type ProjetosEvent =
+  | {
+      name: "projetos_list_viewed";
+      tab: "PUBLICADO" | "MEUS_PUBLICADOS" | "RASCUNHO" | "ARQUIVADO";
+    }
+  | {
+      name: "projeto_viewed";
+      projeto_slug: string;
+      status: ProjetoStatus;
+    }
+  | {
+      name: "projeto_link_clicked";
+      projeto_slug: string;
+      link_type: "repositorio" | "prototipo" | "outro";
+    }
+  | { name: "projeto_create_clicked"; logged_in: boolean }
+  | { name: "projeto_created"; projeto_slug: string; posted_as: "user" | "entidade" }
+  | { name: "projeto_edited"; projeto_slug: string; status: ProjetoStatus }
+  | { name: "projeto_archived"; projeto_slug: string }
+  | { name: "projeto_unarchived"; projeto_slug: string };
+
 // Union of all PostHog events
 export type PostHogEvent =
   | UIInteractionEvent
@@ -106,4 +129,5 @@ export type PostHogEvent =
   | MapasEvent
   | GuiasEvent
   | UsuariosEvent
-  | OnboardingEvent;
+  | OnboardingEvent
+  | ProjetosEvent;

--- a/src/app/projetos/[id]/editar/page.tsx
+++ b/src/app/projetos/[id]/editar/page.tsx
@@ -27,6 +27,7 @@ import { ImageIcon } from "lucide-react";
 import { deleteProjetoImage, uploadProjetoImage } from "@/lib/client/api/projetos";
 import { getDefaultAvatarUrl } from "@/lib/client/utils";
 import Image from "next/image";
+import { trackEvent } from "@/analytics/posthog-client";
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 
@@ -334,6 +335,8 @@ export default function EditarProjetoPage() {
       if (newKey !== originalAutoresKey) {
         await updateAutores.mutateAsync({ autores: newAutoresList });
       }
+
+      trackEvent("projeto_edited", { projeto_slug: slug, status });
 
       toast.success("Projeto atualizado com sucesso!", { id: toastId });
       setUploadedBlobs([]);

--- a/src/app/projetos/[id]/page.tsx
+++ b/src/app/projetos/[id]/page.tsx
@@ -87,7 +87,10 @@ export default function ProjetoPage() {
 
   const isArchived = raw?.status === "ARQUIVADO";
 
-  // Fire once per loaded projeto (keyed on slug, not the raw reference).
+  // Fire once per loaded projeto. Depending on `raw.id` (not `raw`) avoids
+  // duplicate fires from React Query refetches/mutations: structural sharing
+  // can't help when the mutation changes a field (e.g. archive/unarchive flips
+  // status), so the object reference would change but the id stays put.
   useEffect(() => {
     if (!raw) {
       return;
@@ -96,7 +99,8 @@ export default function ProjetoPage() {
       projeto_slug: id,
       status: raw.status as ProjetoStatus,
     });
-  }, [id, raw]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, raw?.id]);
 
   const handleArchiveToggle = async () => {
     if (!raw) {

--- a/src/app/projetos/[id]/page.tsx
+++ b/src/app/projetos/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
@@ -30,6 +30,8 @@ import { ptBR } from "date-fns/locale/pt-BR";
 import { toast } from "sonner";
 import { ConfirmDeleteDialog } from "@/components/shared/confirm-delete-dialog";
 import { SimilarProjetosSection } from "@/components/pages/projetos/similar-projetos-section";
+import { trackEvent } from "@/analytics/posthog-client";
+import type { ProjetoStatus } from "@/analytics/posthog-events";
 
 /** "jan/2025" — empty string if no date. */
 function formatMonthYear(d: Date | string | null | undefined): string {
@@ -85,6 +87,17 @@ export default function ProjetoPage() {
 
   const isArchived = raw?.status === "ARQUIVADO";
 
+  // Fire once per loaded projeto (keyed on slug, not the raw reference).
+  useEffect(() => {
+    if (!raw) {
+      return;
+    }
+    trackEvent("projeto_viewed", {
+      projeto_slug: id,
+      status: raw.status as ProjetoStatus,
+    });
+  }, [id, raw]);
+
   const handleArchiveToggle = async () => {
     if (!raw) {
       return;
@@ -95,6 +108,9 @@ export default function ProjetoPage() {
     const toastId = toast.loading(`${verb} projeto...`);
     try {
       await updateProjeto.mutateAsync({ status: nextStatus });
+      trackEvent(isArchived ? "projeto_unarchived" : "projeto_archived", {
+        projeto_slug: id,
+      });
       toast.success(`Projeto ${verbDone}.`, { id: toastId });
       setArchiveOpen(false);
       if (!isArchived) {
@@ -378,6 +394,12 @@ export default function ProjetoPage() {
                     href={projeto.linkRepositorio}
                     target="_blank"
                     rel="noopener noreferrer"
+                    onClick={() =>
+                      trackEvent("projeto_link_clicked", {
+                        projeto_slug: id,
+                        link_type: "repositorio",
+                      })
+                    }
                     className="flex items-center gap-3 -ml-2 rounded-lg p-2 text-sm font-medium transition-colors hover:bg-muted/50 hover:text-aquario-primary"
                   >
                     <Github className="h-4 w-4 text-muted-foreground" />
@@ -389,6 +411,12 @@ export default function ProjetoPage() {
                     href={projeto.linkPrototipo}
                     target="_blank"
                     rel="noopener noreferrer"
+                    onClick={() =>
+                      trackEvent("projeto_link_clicked", {
+                        projeto_slug: id,
+                        link_type: "prototipo",
+                      })
+                    }
                     className="flex items-center gap-3 -ml-2 rounded-lg p-2 text-sm font-medium transition-colors hover:bg-muted/50 hover:text-aquario-primary"
                   >
                     <ExternalLink className="h-4 w-4 text-muted-foreground" />
@@ -400,6 +428,12 @@ export default function ProjetoPage() {
                     href={projeto.linkOutro}
                     target="_blank"
                     rel="noopener noreferrer"
+                    onClick={() =>
+                      trackEvent("projeto_link_clicked", {
+                        projeto_slug: id,
+                        link_type: "outro",
+                      })
+                    }
                     className="flex items-center gap-3 -ml-2 rounded-lg p-2 text-sm font-medium transition-colors hover:bg-muted/50 hover:text-aquario-primary"
                   >
                     <ExternalLink className="h-4 w-4 text-muted-foreground" />

--- a/src/app/projetos/novo/page.tsx
+++ b/src/app/projetos/novo/page.tsx
@@ -24,6 +24,7 @@ import { ImageIcon } from "lucide-react";
 import { createProjeto, deleteProjetoImage, uploadProjetoImage } from "@/lib/client/api/projetos";
 import { getDefaultAvatarUrl } from "@/lib/client/utils";
 import Image from "next/image";
+import { trackEvent } from "@/analytics/posthog-client";
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 
@@ -280,6 +281,11 @@ export default function NovoProjetoPage() {
       };
 
       await createProjeto(body as Parameters<typeof createProjeto>[0]);
+
+      trackEvent("projeto_created", {
+        projeto_slug: slug,
+        posted_as: postandoComo === POSTAR_COMO_USUARIO ? "user" : "entidade",
+      });
 
       toast.success("Projeto criado com sucesso!", { id: toastId });
       setUploadedBlobs([]);

--- a/src/app/projetos/page.tsx
+++ b/src/app/projetos/page.tsx
@@ -28,6 +28,7 @@ import { Plus, FolderKanban } from "lucide-react";
 import { LoginPromptDialog } from "@/components/shared/login-prompt-dialog";
 import { PageHeader } from "@/components/ui/page-header";
 import { PAGE_HEADER_TEXT } from "@/lib/shared/constants/page-header-text";
+import { trackEvent } from "@/analytics/posthog-client";
 
 const FILTER_TO_TIPO: Record<string, string | undefined> = {
   pessoais: "PESSOAL",
@@ -155,7 +156,14 @@ export default function Projetos() {
     return () => observer.disconnect();
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
+  // Fires once on mount (initial tab) and on every tab change. Filter/sort/search
+  // changes are intentionally not tracked here — they'd be too noisy.
+  useEffect(() => {
+    trackEvent("projetos_list_viewed", { tab });
+  }, [tab]);
+
   const handleNovoProjetoClick = () => {
+    trackEvent("projeto_create_clicked", { logged_in: !!user });
     if (user) {
       router.push("/projetos/novo");
     } else {


### PR DESCRIPTION
## Summary
- Adds the `ProjetosEvent` union to `src/analytics/posthog-events.ts` (8 events: list view per tab, detail view, link clicks, create-clicked, created, edited, archived, unarchived).
- Wires `trackEvent` calls into the four `/projetos` pages (list, detail, novo, editar).
- List view fires once on mount + on every tab change (filter/sort/search are intentionally not tracked — too noisy).
- Detail view fires once per loaded projeto, keyed on slug.

## Test plan
- [ ] `npm run check-all` passes
- [ ] In production build, navigate `/projetos` and confirm `projetos_list_viewed` fires on load and on each tab switch
- [ ] Open a projeto detail page → `projeto_viewed` fires once with correct slug + status
- [ ] Click each external link (Repositório / Demo / Saiba mais) → `projeto_link_clicked` fires with the right `link_type`
- [ ] Click "Novo Projeto" while logged out → `projeto_create_clicked` with `logged_in: false`; while logged in → `logged_in: true`
- [ ] Create a projeto → `projeto_created` fires with `posted_as` reflecting the principal autor
- [ ] Edit a projeto → `projeto_edited` fires with current status
- [ ] Archive / unarchive → `projeto_archived` / `projeto_unarchived` fires with slug
- [ ] In dev (no `POSTHOG_KEY`) the calls are no-ops — no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)