### PR TITLE
feat(search): include Projetos in global search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Search**: Global search bar now indexes Projetos. Matches PUBLICADO projetos by `titulo`, `subtitulo`, and `tags`, opening the projeto detail page (`/projetos/[slug]`). The `/projetos` landing page is also returned as a static-page result.
+
 ## [1.7.1] - 2026-05-03
 
 ### Added

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -25,6 +25,7 @@ export async function GET(req: Request) {
           guias: [],
           entidades: [],
           vagas: [],
+          projetos: [],
           disciplinas: [],
           cursos: [],
           usuarios: [],
@@ -36,19 +37,21 @@ export async function GET(req: Request) {
     const container = getContainer();
     const repo = container.searchRepository;
 
-    const [paginas, guias, entidades, vagas, disciplinas, cursos, usuarios] = await Promise.all([
-      searchStaticPages(query, limit),
-      repo.searchGuias(query, limit),
-      repo.searchEntidades(query, limit),
-      repo.searchVagas(query, limit),
-      repo.searchDisciplinas(query, limit),
-      repo.searchCursos(query, limit),
-      repo.searchUsuarios(query, limit),
-    ]);
+    const [paginas, guias, entidades, vagas, projetos, disciplinas, cursos, usuarios] =
+      await Promise.all([
+        searchStaticPages(query, limit),
+        repo.searchGuias(query, limit),
+        repo.searchEntidades(query, limit),
+        repo.searchVagas(query, limit),
+        repo.searchProjetos(query, limit),
+        repo.searchDisciplinas(query, limit),
+        repo.searchCursos(query, limit),
+        repo.searchUsuarios(query, limit),
+      ]);
 
     const response: SearchResponse = {
       query,
-      results: { paginas, guias, entidades, vagas, disciplinas, cursos, usuarios },
+      results: { paginas, guias, entidades, vagas, projetos, disciplinas, cursos, usuarios },
     };
 
     return NextResponse.json(response);

--- a/src/components/shared/search/search-command.tsx
+++ b/src/components/shared/search/search-command.tsx
@@ -8,6 +8,7 @@ import {
   BookOpen,
   Building2,
   Briefcase,
+  FolderKanban,
   GraduationCap,
   BookMarked,
   User,
@@ -27,6 +28,7 @@ const CATEGORY_CONFIG: Record<SearchResultKind, { label: string; icon: React.Ele
   guia: { label: "GUIAS", icon: BookOpen },
   entidade: { label: "ENTIDADES", icon: Building2 },
   vaga: { label: "VAGAS", icon: Briefcase },
+  projeto: { label: "PROJETOS", icon: FolderKanban },
   disciplina: { label: "DISCIPLINAS", icon: BookMarked },
   curso: { label: "CURSOS", icon: GraduationCap },
   usuario: { label: "USUARIOS", icon: User },
@@ -37,6 +39,7 @@ const RESULTS_KEY_MAP: Record<SearchResultKind, string> = {
   guia: "guias",
   entidade: "entidades",
   vaga: "vagas",
+  projeto: "projetos",
   disciplina: "disciplinas",
   curso: "cursos",
   usuario: "usuarios",
@@ -47,6 +50,7 @@ const CATEGORY_ORDER: SearchResultKind[] = [
   "guia",
   "entidade",
   "vaga",
+  "projeto",
   "disciplina",
   "curso",
   "usuario",
@@ -84,6 +88,8 @@ function getItemLabel(item: SearchResultItem): string {
       return item.nome;
     case "vaga":
       return item.titulo;
+    case "projeto":
+      return item.titulo;
     case "disciplina":
       return `${item.codigo} - ${item.nome}`;
     case "curso":
@@ -103,6 +109,8 @@ function getItemSnippet(item: SearchResultItem): string | null {
       return item.tipo.replace(/_/g, " ").toLowerCase();
     case "vaga":
       return item.tipoVaga.replace(/_/g, " ").toLowerCase();
+    case "projeto":
+      return item.subtitulo;
     case "disciplina":
       return null;
     case "curso":
@@ -122,6 +130,8 @@ function getItemRoute(item: SearchResultItem): string {
       return item.slug ? `/entidade/${item.slug}` : "/entidades";
     case "vaga":
       return `/vagas/${item.id}`;
+    case "projeto":
+      return `/projetos/${item.slug}`;
     case "disciplina":
       return `/grades-curriculares`;
     case "curso":

--- a/src/lib/server/db/implementations/prisma/prisma-search-repository.ts
+++ b/src/lib/server/db/implementations/prisma/prisma-search-repository.ts
@@ -5,6 +5,7 @@ import type {
   SearchResultGuia,
   SearchResultEntidade,
   SearchResultVaga,
+  SearchResultProjeto,
   SearchResultDisciplina,
   SearchResultCurso,
   SearchResultUsuario,
@@ -81,6 +82,35 @@ export class PrismaSearchRepository implements ISearchRepository {
     `);
 
     return results.map(r => ({ kind: "vaga" as const, ...r }));
+  }
+
+  async searchProjetos(query: string, limit: number): Promise<SearchResultProjeto[]> {
+    const results = await prisma.$queryRaw<
+      Array<{ id: string; titulo: string; slug: string; subtitulo: string | null }>
+    >(Prisma.sql`
+      SELECT id, titulo, slug, subtitulo
+      FROM "Projeto"
+      WHERE status = 'PUBLICADO'
+        AND to_tsvector(
+              'portuguese',
+              immutable_unaccent(
+                titulo || ' ' || coalesce(subtitulo, '') || ' ' || array_to_string(tags, ' ')
+              )
+            )
+            @@ plainto_tsquery('portuguese', immutable_unaccent(${query}))
+      ORDER BY ts_rank(
+        to_tsvector(
+          'portuguese',
+          immutable_unaccent(
+            titulo || ' ' || coalesce(subtitulo, '') || ' ' || array_to_string(tags, ' ')
+          )
+        ),
+        plainto_tsquery('portuguese', immutable_unaccent(${query}))
+      ) DESC
+      LIMIT ${limit}
+    `);
+
+    return results.map(r => ({ kind: "projeto" as const, ...r }));
   }
 
   async searchDisciplinas(query: string, limit: number): Promise<SearchResultDisciplina[]> {

--- a/src/lib/server/db/interfaces/search-repository.interface.ts
+++ b/src/lib/server/db/interfaces/search-repository.interface.ts
@@ -2,6 +2,7 @@ import type {
   SearchResultGuia,
   SearchResultEntidade,
   SearchResultVaga,
+  SearchResultProjeto,
   SearchResultDisciplina,
   SearchResultCurso,
   SearchResultUsuario,
@@ -11,6 +12,7 @@ export type ISearchRepository = {
   searchGuias(query: string, limit: number): Promise<SearchResultGuia[]>;
   searchEntidades(query: string, limit: number): Promise<SearchResultEntidade[]>;
   searchVagas(query: string, limit: number): Promise<SearchResultVaga[]>;
+  searchProjetos(query: string, limit: number): Promise<SearchResultProjeto[]>;
   searchDisciplinas(query: string, limit: number): Promise<SearchResultDisciplina[]>;
   searchCursos(query: string, limit: number): Promise<SearchResultCurso[]>;
   searchUsuarios(query: string, limit: number): Promise<SearchResultUsuario[]>;

--- a/src/lib/server/openapi/paths/search.ts
+++ b/src/lib/server/openapi/paths/search.ts
@@ -91,6 +91,28 @@ const searchResultVagaSchema = z
   })
   .openapi("SearchResultVaga");
 
+const searchResultProjetoSchema = z
+  .object({
+    kind: z.literal("projeto"),
+    id: z.string().openapi({
+      description: "Identificador do projeto.",
+      example: "f1e2d3c4-b5a6-7890-1234-56789abcdef0",
+    }),
+    titulo: z.string().openapi({
+      description: "Título do projeto.",
+      example: "Aquario",
+    }),
+    slug: z.string().openapi({
+      description: "Slug usado na rota do projeto.",
+      example: "aquario",
+    }),
+    subtitulo: z.string().nullable().openapi({
+      description: "Subtítulo curto do projeto.",
+      example: "Portal universitário da UFPB",
+    }),
+  })
+  .openapi("SearchResultProjeto");
+
 const searchResultDisciplinaSchema = z
   .object({
     kind: z.literal("disciplina"),
@@ -161,6 +183,7 @@ const searchResponseSchema = z
         guias: z.array(searchResultGuiaSchema),
         entidades: z.array(searchResultEntidadeSchema),
         vagas: z.array(searchResultVagaSchema),
+        projetos: z.array(searchResultProjetoSchema),
         disciplinas: z.array(searchResultDisciplinaSchema),
         cursos: z.array(searchResultCursoSchema),
         usuarios: z.array(searchResultUsuarioSchema),
@@ -180,7 +203,7 @@ export function registerSearchPaths(registry: OpenAPIRegistry, _schemas: CommonS
     tags: ["Busca"],
     summary: "Busca unificada em todas as categorias",
     description:
-      "Full-text search em páginas, guias, entidades, vagas, disciplinas, cursos e usuários. Acento-insensível (português). Queries com menos de 3 caracteres retornam resultados vazios.",
+      "Full-text search em páginas, guias, entidades, vagas, projetos, disciplinas, cursos e usuários. Acento-insensível (português). Queries com menos de 3 caracteres retornam resultados vazios.",
     request: {
       query: z.object({
         q: z.string().optional().openapi({
@@ -233,6 +256,15 @@ export function registerSearchPaths(registry: OpenAPIRegistry, _schemas: CommonS
                   },
                 ],
                 vagas: [],
+                projetos: [
+                  {
+                    kind: "projeto",
+                    id: "f1e2d3c4-b5a6-7890-1234-56789abcdef0",
+                    titulo: "Aquario",
+                    slug: "aquario",
+                    subtitulo: "Portal universitário da UFPB",
+                  },
+                ],
                 disciplinas: [
                   {
                     kind: "disciplina",

--- a/src/lib/server/search/static-pages.ts
+++ b/src/lib/server/search/static-pages.ts
@@ -62,6 +62,12 @@ const STATIC_PAGES: StaticPage[] = [
     descricao: "Estagios, pesquisa e oportunidades para estudantes",
     url: "/vagas",
   },
+  {
+    id: "projetos",
+    titulo: "Projetos",
+    descricao: "Projetos de pesquisa, extensao e iniciativas estudantis da UFPB",
+    url: "/projetos",
+  },
 ];
 
 function normalize(text: string): string {

--- a/src/lib/shared/types/search.types.ts
+++ b/src/lib/shared/types/search.types.ts
@@ -3,6 +3,7 @@ export type SearchResultKind =
   | "guia"
   | "entidade"
   | "vaga"
+  | "projeto"
   | "disciplina"
   | "curso"
   | "usuario";
@@ -39,6 +40,14 @@ export type SearchResultVaga = {
   tipoVaga: string;
 };
 
+export type SearchResultProjeto = {
+  kind: "projeto";
+  id: string;
+  titulo: string;
+  slug: string;
+  subtitulo: string | null;
+};
+
 export type SearchResultDisciplina = {
   kind: "disciplina";
   id: string;
@@ -65,6 +74,7 @@ export type SearchResultItem =
   | SearchResultGuia
   | SearchResultEntidade
   | SearchResultVaga
+  | SearchResultProjeto
   | SearchResultDisciplina
   | SearchResultCurso
   | SearchResultUsuario;
@@ -76,6 +86,7 @@ export type SearchResponse = {
     guias: SearchResultGuia[];
     entidades: SearchResultEntidade[];
     vagas: SearchResultVaga[];
+    projetos: SearchResultProjeto[];
     disciplinas: SearchResultDisciplina[];
     cursos: SearchResultCurso[];
     usuarios: SearchResultUsuario[];


### PR DESCRIPTION
## Summary
- Global search bar now indexes **Projetos**: a new `projeto` result kind matches PUBLICADO projetos by `titulo`, `subtitulo`, and `tags` via Postgres FTS (portuguese, accent-insensitive) and routes to `/projetos/[slug]`.
- The `/projetos` landing page is also indexed as a static-page result.
- Wired across the stack: `SearchResultProjeto` type, `searchRepository.searchProjetos`, `/api/search` route, `SearchCommand` UI (icon, label, ordering, label/snippet/route helpers), OpenAPI schema/example, and `static-pages.ts`.

## Test plan
- [ ] Open the search palette (Cmd/Ctrl+K) and type a known PUBLICADO projeto title — entry appears under a "PROJETOS" section with a `FolderKanban` icon
- [ ] Click the result — navigates to `/projetos/[slug]`
- [ ] Type a substring of a tag on a published projeto — projeto still appears
- [ ] Type "projetos" — `/projetos` landing page surfaces in PAGINAS
- [ ] Verify RASCUNHO/ARQUIVADO projetos do **not** appear
- [ ] `GET /api/search?q=...` response includes a `projetos` array under `results`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Global search now indexes and searches published projects by title, subtitle, and tags, returning relevant results
  * Search results include direct links to individual project detail pages for quick navigation
  * Projects landing page is now discoverable through search functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->