### PR TITLE
fix(projetos): represent principal entidade on edit screen for non-member editors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dependencies**: Dropped 7 unused dependencies — `@radix-ui/react-hover-card`, `@radix-ui/react-scroll-area`, `@radix-ui/react-toast` (project uses `sonner`), `three`, `@types/three`, `posthog-node`, `textarea-caret`.
 - **Assets**: Removed `public/plus.png` and `public/plus_Dark.png` (only referenced by the deleted `banner.tsx`).
 
+### Fixed
+- **Projetos**: Project edit screen no longer misrepresents the principal author when the editor is a collaborator who does not administer the principal entidade. The "Postando como" field previously fell back to showing the editor's own name and avatar; it now displays the principal entidade read-only, with a note clarifying the user is editing as a collaborator (#201).
+
 ## [1.8.0] - 2026-05-04
 
 ### Added

--- a/src/app/projetos/[id]/editar/page.tsx
+++ b/src/app/projetos/[id]/editar/page.tsx
@@ -368,6 +368,19 @@ export default function EditarProjetoPage() {
   const userAvatarUrl = usuario.urlFotoPerfil || getDefaultAvatarUrl(usuario.id, usuario.nome);
   const selectedEntidade = adminEntidades.find(e => e.id === postandoComo);
 
+  // When the project's principal author is an entidade the current user does
+  // NOT administer, the "Postando como" picker can't represent it — its options
+  // only list entidades the user admins, so it would silently fall back to the
+  // user's own avatar (issue #201). In that case the user edits purely as a
+  // collaborator, so we show the principal entidade read-only instead.
+  const principalAutor = projeto.autores.find(a => a.autorPrincipal) ?? projeto.autores[0];
+  const principalEntidade = principalAutor?.entidade ?? null;
+  const editingAsCollaborator =
+    !!principalEntidade && !myAdminEntidadeIds.has(principalEntidade.id);
+  const principalEntidadeImagePath = principalEntidade
+    ? mapImagePath(principalEntidade.urlFoto)
+    : null;
+
   return (
     <div className="container mx-auto p-4 sm:p-6 lg:p-8 mt-24 max-w-6xl space-y-6">
       <div className="space-y-1">
@@ -458,7 +471,21 @@ export default function EditarProjetoPage() {
               {/* Postando como */}
               <div className="space-y-2">
                 <Label>Postando como</Label>
-                {hasAdminEntidades ? (
+                {editingAsCollaborator ? (
+                  <div className="flex items-center gap-2 rounded-md border bg-muted/40 px-3 py-2 text-sm">
+                    <div className="relative w-5 h-5 rounded-full overflow-hidden border bg-muted">
+                      {principalEntidadeImagePath && (
+                        <Image
+                          src={principalEntidadeImagePath}
+                          alt={principalEntidade?.nome ?? ""}
+                          fill
+                          className="object-cover"
+                        />
+                      )}
+                    </div>
+                    <span className="truncate">{principalEntidade?.nome}</span>
+                  </div>
+                ) : hasAdminEntidades ? (
                   <Select value={postandoComo} onValueChange={setPostandoComo}>
                     <SelectTrigger>
                       <SelectValue />
@@ -504,11 +531,15 @@ export default function EditarProjetoPage() {
                     <span className="truncate">{usuario.nome}</span>
                   </div>
                 )}
-                {selectedEntidade && (
+                {editingAsCollaborator ? (
+                  <p className="text-xs text-muted-foreground">
+                    Publicado por {principalEntidade?.nome}. Você está editando como colaborador.
+                  </p>
+                ) : selectedEntidade ? (
                   <p className="text-xs text-muted-foreground">
                     Você é admin de {selectedEntidade.nome}.
                   </p>
-                )}
+                ) : null}
               </div>
 
               {/* Status */}


### PR DESCRIPTION
## 📝 Descrição

**Problema:** Na tela de edição de projeto (`/projetos/[id]/editar`), quando o editor é um colaborador que **não administra** a entidade autora principal, o campo "Postando como" exibia o nome e o avatar do próprio editor — dando a entender, incorretamente, que ele era o autor principal. Isso acontecia porque administra; como a entidade principal não estava entre elas, a UI caía num fallback que mostrava o usuário.

**Solução:** Quando o autor principal é uma entidade que o usuário não administra, o campo agora exibe a **entidade em modo somente-leitura**, com uma nota: "Publicado por [Entidade]. Você está editando como colaborador." O estado interno que define o autor principal já guardava a entidade corretamente, então salvar continua preservando a autoria — a mudança é puramente de representação.

**Resultado:** A tela representa corretamente a autoria para colaboradores que não são membros da entidade, resolvendo a confusão descrita na issue.

## 🔗 Issue Relacionada

Closes #201

## 🧪 Testes

- [x] Testes unitários passam (`npm run test` — 313 passando)
- [ ] Testes de integração passam
- [ ] Testes E2E passam
- [x] Testes manuais concluídos

Testado manualmente: usuário colaborador (não-admin da entidade principal) abre a tela de edição → "Postando como" exibe a entidade, read-only, com a nota de colaborador. Cenários sem regressão verificados: autor principal sendo o próprio usuário, e autor principal sendo entidade que o usuário administra (seletor normal preservado).

## 📋 Checklist

- [x] Código segue as diretrizes de estilo do projeto
- [x] Revisão própria concluída
- [x] Código está devidamente comentado
- [x] Nenhum console.log deixado no código
- [x] Todos os testes passam localmente
- [x] Build passa sem erros (`npm run check-all`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the project edit screen to correctly display the principal entity as read-only in the "Posting as" field when editing as a collaborator, instead of incorrectly showing the editor's own information.
  * Updated messaging to clarify when content is being edited in collaborator mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aquario-ufpb/aquario/pull/206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->