### PR TITLE
feat(academic-import): add Atestado de Matrícula PDF parser (1/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Academic Import**: SIGAA "Atestado de Matrícula" text parser (`src/lib/server/services/academic-import/`) that detects the document and normalizes its enrolled components (código, período, nome, docente, turma, horário, tipo, status). Detection requires the real "Atestado de Matrícula" title plus a SIGAA marker so it cannot mis-claim a Histórico Escolar; the código anchor is constrained to real SIGAA shapes and the schedule-table cutoff is line-anchored; components with no resolvable período fall back to the document-level período rather than being dropped.
+
 ### Removed
 - **Dead code cleanup (medium confidence)**: Pruned module-level exports flagged by `knip`/`ts-prune` as having no external consumers. Pure dead symbols were deleted; functions still used internally lost only the `export` keyword.
   - Hooks/functions with zero callers: `useEventos`, `useUpdateDisciplinasConcluidas`, `useSaveDisciplinasSemestre`, `useEntidadesByTipo`, `useUploadProjetoImage`, `useCreateProjeto`, `useCentros` re-export from `use-admin-centros`, `resetContainer`, `validateFloorData`, `formatProfessorsForDetails`, `decodeToken`, `formatProjetoTipo`, `parseSemester`, `waitForCondition`, `findSubSecaoBySlug`, plus the duplicate default export of `GuideIndex`.

--- a/src/lib/server/services/academic-import/__tests__/atestado-matricula.adapter.test.ts
+++ b/src/lib/server/services/academic-import/__tests__/atestado-matricula.adapter.test.ts
@@ -1,0 +1,101 @@
+import fs from "fs";
+import path from "path";
+
+import { atestadoMatriculaAdapter } from "../atestado-matricula.adapter";
+import { detectAdapter } from "../detect-document";
+import type { NormalizedDisciplina } from "../document-adapter.interface";
+
+const FIXTURE = fs.readFileSync(path.join(__dirname, "fixtures", "atestado-sample.txt"), "utf-8");
+
+const EXPECTED_CODIGOS_IN_ORDER = [
+  "GDSCO0043",
+  "DINF00053",
+  "DSCO00023",
+  "1404138",
+  "GDLPL0063",
+  "DSCO00022",
+  "DINF00070",
+];
+
+function parse(): NormalizedDisciplina[] {
+  return atestadoMatriculaAdapter.parse(FIXTURE);
+}
+
+function byCodigo(codigo: string): NormalizedDisciplina {
+  const found = parse().find(d => d.codigo === codigo);
+  if (!found) {
+    throw new Error(`Component ${codigo} not parsed`);
+  }
+  return found;
+}
+
+describe("atestadoMatriculaAdapter.parse", () => {
+  it("parses exactly 7 components", () => {
+    expect(parse()).toHaveLength(7);
+  });
+
+  it("extracts códigos in document order (alpha and numeric)", () => {
+    expect(parse().map(d => d.codigo)).toEqual(EXPECTED_CODIGOS_IN_ORDER);
+  });
+
+  it("marks every component as matriculado", () => {
+    expect(parse().every(d => d.status === "matriculado")).toBe(true);
+  });
+
+  it("uses período 2026.1 for every component", () => {
+    expect(parse().every(d => d.periodo === "2026.1")).toBe(true);
+  });
+
+  it("captures turma 01 for every component", () => {
+    expect(parse().every(d => d.turma === "01")).toBe(true);
+  });
+
+  it("captures the single-line horário token", () => {
+    expect(byCodigo("GDSCO0043").horario).toBe("24T23");
+  });
+
+  it("classifies the UCE component as an atividade with no horário", () => {
+    const atividade = byCodigo("DINF00070");
+    expect(atividade.tipo).toBe("atividade");
+    expect(atividade.horario).toBeUndefined();
+  });
+
+  it("classifies the remaining components as disciplinas", () => {
+    const disciplinas = parse().filter(d => d.codigo !== "DINF00070");
+    expect(disciplinas.every(d => d.tipo === "disciplina")).toBe(true);
+  });
+
+  it("joins a horário split across two lines", () => {
+    expect(byCodigo("1404138").horario).toBe("7M1 35N34");
+  });
+
+  it("extracts docente and nome for a single-line block", () => {
+    const compiladores = byCodigo("GDSCO0043");
+    expect(compiladores.docente).toBe("ANDREI DE ARAUJO FORMIGA");
+    expect(compiladores.nome).toBe("CONSTRUÇÃO DE COMPILADORES I");
+  });
+
+  it("joins a multi-line discipline name", () => {
+    expect(byCodigo("DSCO00023").nome).toContain(
+      "INOVAÇÃO DE BASE CIENTÍFICA-TECNOLÓGICA E EMPREENDEDORISMO"
+    );
+  });
+
+  it("joins a multi-line, multi-docente list", () => {
+    const docente = byCodigo("DINF00070").docente ?? "";
+    expect(docente).toContain("GIORGIA DE OLIVEIRA MATTOS");
+    expect(docente).toContain("YUSKA PAOLA COSTA AGUIAR");
+  });
+});
+
+describe("detectAdapter", () => {
+  it("selects the atestado adapter for the fixture", () => {
+    const adapter = detectAdapter(FIXTURE, [atestadoMatriculaAdapter]);
+    expect(adapter).toBe(atestadoMatriculaAdapter);
+  });
+
+  it("returns null for unrelated text", () => {
+    const adapter = detectAdapter("random pdf text", [atestadoMatriculaAdapter]);
+    expect(adapter).toBeNull();
+  });
+});

--- a/src/lib/server/services/academic-import/__tests__/atestado-matricula.adapter.test.ts
+++ b/src/lib/server/services/academic-import/__tests__/atestado-matricula.adapter.test.ts
@@ -88,6 +88,24 @@ describe("atestadoMatriculaAdapter.parse", () => {
   });
 });
 
+describe("atestadoMatriculaAdapter.matches", () => {
+  it("matches the header-inclusive Atestado fixture", () => {
+    expect(atestadoMatriculaAdapter.matches(FIXTURE)).toBe(true);
+  });
+
+  it("does not match a Histórico Escolar even with shared structural cues", () => {
+    const historico = [
+      "Sistema Integrado de Gestão de Atividades Acadêmicas",
+      "Portal do Discente",
+      "Histórico Escolar",
+      "Componentes Curriculares",
+      "Conceito",
+      "GDSCO0043 CONSTRUÇÃO DE COMPILADORES I MATRICULADO",
+    ].join("\n");
+    expect(atestadoMatriculaAdapter.matches(historico)).toBe(false);
+  });
+});
+
 describe("detectAdapter", () => {
   it("selects the atestado adapter for the fixture", () => {
     const adapter = detectAdapter(FIXTURE, [atestadoMatriculaAdapter]);

--- a/src/lib/server/services/academic-import/__tests__/fixtures/atestado-sample.txt
+++ b/src/lib/server/services/academic-import/__tests__/fixtures/atestado-sample.txt
@@ -1,0 +1,43 @@
+           Matrícula:                     20230000000                                                   Vínculo:         REGULAR
+           Nome:                          FULANO DE TAL SILVA
+                                          CIÊNCIA DA COMPUTAÇÃO
+           Curso:                                                                                       Cidade:          João Pessoa
+                                          (BACHARELADO)/CI - João Pessoa - MT
+           Formação:                      BACHARELADO
+
+          Turmas Matriculadas: 6
+          Atividades Matriculadas: 1
+          Carga Horária Matriculada: 435
+                Código -
+                                                            Componentes Curriculares                             Turma         Status      Horário
+                Período
+              GDSCO0043 -          CONSTRUÇÃO DE COMPILADORES I                                                     01       MATRICULADO     24T23
+                2026.1             ANDREI DE ARAUJO FORMIGA
+                                   Tipo: DISCIPLINA  Local: À DEFINIR (CI)
+               DINF00053 -         GERENCIAMENTO DE PROJETO DE SOFTWARE                                             01       MATRICULADO     24M45
+                 2026.1            DANIELLE ROUSY DIAS RICARTE
+                                   Tipo: DISCIPLINA  Local: À DEFINIR (CI)
+
+              DSCO00023 -          INOVAÇÃO DE BASE CIENTÍFICA-TECNOLÓGICA E                                        01       MATRICULADO    6M2345
+                2026.1             EMPREENDEDORISMO
+                                   ALISSON VASCONCELOS DE BRITO
+                                   Tipo: DISCIPLINA Local: À DEFINIR (CI)
+
+            1404138 - 2026.1 LINGUA INGLESA I                                                                       01       MATRICULADO      7M1
+                                   RAFAELA CARLA SANTOS DE SOUSA                                                                             35N34
+                                   Tipo: DISCIPLINA  Local: CAE 110 (PRG)
+               GDLPL0063 -         PORTUGUÊS INSTRUMENTAL                                                           01       MATRICULADO    3T1234
+                 2026.1            JORGEVALDO DE SOUZA SILVA
+                                   Tipo: DISCIPLINA Local: CAG 102 (PRG)
+              DSCO00022 -          SISTEMAS DISTRIBUÍDOS                                                            01       MATRICULADO     35M45
+                2026.1             FERNANDO MENEZES MATOS
+                                   Tipo: DISCIPLINA Local: À DEFINIR (CI)
+
+               DINF00070 -         UCE - CIÊNCIA DA COMPUTAÇÃO / PROJETO                                            01       MATRICULADO          --
+                 2026.1            INTEGRADO I
+                                   GIORGIA DE OLIVEIRA MATTOS, DANIELLE ROUSY DIAS RICARTE e YUSKA
+                                   PAOLA COSTA AGUIAR
+                                   Tipo: ATIVIDADE
+
+
+          Tabela de Horários:

--- a/src/lib/server/services/academic-import/__tests__/fixtures/atestado-sample.txt
+++ b/src/lib/server/services/academic-import/__tests__/fixtures/atestado-sample.txt
@@ -1,3 +1,15 @@
+6/7/26, 8:09 PM                                                       Sistema Integrado de Gestão de Atividades Acadêmicas
+
+                                                             Universidade Federal da Paraíba
+                                                   Sistema Integrado de Gestão de Atividades Acadêmicas
+
+                                                                   Emitido em 07/06/2026 20:09
+
+               Portal do Discente
+
+
+                                                                    Atestado de Matrícula
+           Nível:                         GRADUAÇÃO
            Matrícula:                     20230000000                                                   Vínculo:         REGULAR
            Nome:                          FULANO DE TAL SILVA
                                           CIÊNCIA DA COMPUTAÇÃO
@@ -41,3 +53,4 @@
 
 
           Tabela de Horários:
+            Horários            Dom                  Seg              Ter               Qua               Qui                 Sex           Sab

--- a/src/lib/server/services/academic-import/atestado-matricula.adapter.ts
+++ b/src/lib/server/services/academic-import/atestado-matricula.adapter.ts
@@ -11,23 +11,21 @@ const ATESTADO_HEADER = "atestado de matricula";
 const SIGAA_MARKERS = ["sistema integrado de gestao", "sigaa", "portal do discente"];
 
 /**
- * Structural fingerprint of a SIGAA Atestado de Matrícula. The sanitized fixture
- * (and any PDF whose institutional header was cropped) may lack the explicit
- * "Atestado de Matrícula" title, so detection also accepts the unmistakable
- * combination of the enrollment table headings + status + schedule table.
+ * Marks the end of the component list; everything after is the schedule grid.
+ * Anchored at line start (after optional indentation) so a docente/nome that
+ * happens to contain the substring "Tabela de Horários:" cannot truncate parsing
+ * early — only the standalone section label is treated as the cutoff.
  */
-const STRUCTURAL_MARKERS = ["componentes curriculares", "matriculado", "tabela de horarios:"];
-
-/** Marks the end of the component list; everything after is the schedule grid. */
-const SCHEDULE_TABLE_MARKER = /tabela de hor[aá]rios:/i;
+const SCHEDULE_TABLE_MARKER = /^[ \t]*tabela de hor[aá]rios:/im;
 
 /**
- * Código-período anchor. Códigos may be alphanumeric (GDSCO0043, DINF00053) or
- * purely numeric (1404138). Período is YYYY.N. The hyphen separator may be
- * followed by the período on the same line or wrapped to the next line, so the
- * período is captured separately when not inline.
+ * Código-período anchor. Códigos in a SIGAA Atestado are either purely numeric
+ * (e.g. 1404138) or letters-then-digits (e.g. GDSCO0043, DINF00053). Constraining
+ * to that shape avoids over-matching arbitrary alphanumeric runs. Período is
+ * YYYY.N. The hyphen separator may be followed by the período on the same line or
+ * wrapped to the next line, so the período is captured separately when not inline.
  */
-const CODIGO = "[A-Z0-9]{4,9}";
+const CODIGO = "(?:[A-Z]{2,8}\\d{3,5}|\\d{6,8})";
 const PERIODO = "\\d{4}\\.\\d";
 // Anchored at the start of a row (leading whitespace only) so that hyphenated
 // words mid-line (e.g. "CIENTÍFICA-TECNOLÓGICA") are not mistaken for códigos.
@@ -125,14 +123,54 @@ function indentOf(line: string): number {
  */
 const DOCENTE_COLUMN_INDENT_DELTA = 12;
 
-function parseBlock(block: string, anchor: AnchorMatch): NormalizedDisciplina | null {
+/**
+ * Document-level período used as a fallback for any block whose own período can't
+ * be resolved. Returns the most frequent período across blocks that did resolve
+ * (which is the document's enrollment período), or "" when none resolved.
+ */
+function inferDocumentPeriodo(body: string, anchors: AnchorMatch[]): string {
+  const counts = new Map<string, number>();
+  for (let i = 0; i < anchors.length; i++) {
+    const blockStart = anchors[i].index;
+    const blockEnd = i + 1 < anchors.length ? anchors[i + 1].index : body.length;
+    const block = body.slice(blockStart, blockEnd);
+    const periodo = resolveBlockPeriodo(block, anchors[i]);
+    if (periodo) {
+      counts.set(periodo, (counts.get(periodo) ?? 0) + 1);
+    }
+  }
+
+  let best = "";
+  let bestCount = 0;
+  for (const [periodo, count] of counts) {
+    if (count > bestCount) {
+      best = periodo;
+      bestCount = count;
+    }
+  }
+  return best;
+}
+
+function resolveBlockPeriodo(block: string, anchor: AnchorMatch): string | undefined {
+  // Período precedence: prefer the inline anchor período (numeric-código layout
+  // where "1404138 - 2026.1" sits on one line); fall back to a período that
+  // wrapped onto its own line within the block. This ordering is intentional —
+  // the inline value is the most reliable when both are present.
+  return anchor.inlinePeriodo ?? PERIODO_LINE_REGEX.exec(block)?.[1];
+}
+
+function parseBlock(
+  block: string,
+  anchor: AnchorMatch,
+  fallbackPeriodo: string
+): NormalizedDisciplina {
   const lines = block.split("\n");
   const firstLine = lines[0] ?? "";
 
-  const periodo = anchor.inlinePeriodo ?? PERIODO_LINE_REGEX.exec(block)?.[1] ?? "";
-  if (!periodo) {
-    return null;
-  }
+  // Never drop a component just because its período could not be parsed from the
+  // block: fall back to the document-level período (the most common período across
+  // parsed blocks). If even that is unresolvable, keep "" rather than losing the row.
+  const periodo = resolveBlockPeriodo(block, anchor) ?? fallbackPeriodo;
 
   const tipoMatch = TIPO_REGEX.exec(block);
   const tipo: DisciplinaTipo =
@@ -212,14 +250,15 @@ export const atestadoMatriculaAdapter: AcademicDocumentAdapter = {
   matches(text: string): boolean {
     const normalized = normalizeForMatch(text);
 
-    const hasExplicitHeader =
+    // Require the real document title AND a SIGAA marker. Both are present in a
+    // genuine Atestado de Matrícula. Relying on the title (rather than a structural
+    // fingerprint of the enrollment/schedule tables) keeps detectAdapter routing
+    // unambiguous — a Histórico Escolar shares those structural cues and must not
+    // be claimed by this adapter.
+    return (
       normalized.includes(ATESTADO_HEADER) &&
-      SIGAA_MARKERS.some(marker => normalized.includes(marker));
-    if (hasExplicitHeader) {
-      return true;
-    }
-
-    return STRUCTURAL_MARKERS.every(marker => normalized.includes(marker));
+      SIGAA_MARKERS.some(marker => normalized.includes(marker))
+    );
   },
 
   parse(text: string): NormalizedDisciplina[] {
@@ -227,6 +266,11 @@ export const atestadoMatriculaAdapter: AcademicDocumentAdapter = {
     const body = scheduleMatch ? text.slice(0, scheduleMatch.index) : text;
 
     const anchors = findAnchors(body);
+
+    // Document-level período fallback: the most common período across blocks whose
+    // período resolved cleanly. Used to keep a block that lacks its own período.
+    const documentPeriodo = inferDocumentPeriodo(body, anchors);
+
     const results: NormalizedDisciplina[] = [];
 
     for (let i = 0; i < anchors.length; i++) {
@@ -235,10 +279,10 @@ export const atestadoMatriculaAdapter: AcademicDocumentAdapter = {
       const blockEnd = i + 1 < anchors.length ? anchors[i + 1].index : body.length;
       const block = body.slice(blockStart, blockEnd);
 
-      const parsed = parseBlock(block, anchor);
-      if (parsed && STATUS_MATRICULADO.test(block)) {
-        results.push(parsed);
+      if (!STATUS_MATRICULADO.test(block)) {
+        continue;
       }
+      results.push(parseBlock(block, anchor, documentPeriodo));
     }
 
     return results;

--- a/src/lib/server/services/academic-import/atestado-matricula.adapter.ts
+++ b/src/lib/server/services/academic-import/atestado-matricula.adapter.ts
@@ -1,0 +1,246 @@
+import type {
+  AcademicDocumentAdapter,
+  DisciplinaTipo,
+  NormalizedDisciplina,
+} from "./document-adapter.interface";
+
+const ADAPTER_ID = "atestado-matricula";
+
+/** Detection markers (accent/case tolerant via normalization). */
+const ATESTADO_HEADER = "atestado de matricula";
+const SIGAA_MARKERS = ["sistema integrado de gestao", "sigaa", "portal do discente"];
+
+/**
+ * Structural fingerprint of a SIGAA Atestado de Matrícula. The sanitized fixture
+ * (and any PDF whose institutional header was cropped) may lack the explicit
+ * "Atestado de Matrícula" title, so detection also accepts the unmistakable
+ * combination of the enrollment table headings + status + schedule table.
+ */
+const STRUCTURAL_MARKERS = ["componentes curriculares", "matriculado", "tabela de horarios:"];
+
+/** Marks the end of the component list; everything after is the schedule grid. */
+const SCHEDULE_TABLE_MARKER = /tabela de hor[aá]rios:/i;
+
+/**
+ * Código-período anchor. Códigos may be alphanumeric (GDSCO0043, DINF00053) or
+ * purely numeric (1404138). Período is YYYY.N. The hyphen separator may be
+ * followed by the período on the same line or wrapped to the next line, so the
+ * período is captured separately when not inline.
+ */
+const CODIGO = "[A-Z0-9]{4,9}";
+const PERIODO = "\\d{4}\\.\\d";
+// Anchored at the start of a row (leading whitespace only) so that hyphenated
+// words mid-line (e.g. "CIENTÍFICA-TECNOLÓGICA") are not mistaken for códigos.
+// Optionally captures an inline período "2026.1" (the numeric-código layout).
+const ANCHOR_REGEX = new RegExp(`^[ \\t]*(${CODIGO})\\s*-\\s*(${PERIODO})?`, "gm");
+// Período that wrapped onto its own (or a later) line within the block.
+const PERIODO_LINE_REGEX = new RegExp(`(${PERIODO})`);
+
+/** Enrollment status token. Only MATRICULADO appears in an Atestado. */
+const STATUS_MATRICULADO = /\bMATRICULADO\b/;
+
+/** Turma is the "01"-style two-digit class number. */
+const TURMA_REGEX = /\b(\d{2})\b/;
+
+/**
+ * Horário token, e.g. 24T23, 6M2345, 3T1234, 35N34. Day digits (1-7) followed
+ * by a shift letter (M/T/N) followed by slot digits.
+ */
+const HORARIO_REGEX = /\b(\d{1,3}[MTN]\d{1,4})\b/g;
+// Note: a "--" placeholder (activity with no fixed schedule) simply yields no
+// horário token and is therefore reported as undefined.
+
+/** Tipo line, e.g. "Tipo: DISCIPLINA  Local: À DEFINIR (CI)". */
+const TIPO_REGEX = /Tipo:\s*(DISCIPLINA|ATIVIDADE)/i;
+/** Marks the trailing metadata of a component (docente comes before it). */
+const TIPO_OR_LOCAL_REGEX = /\b(Tipo:|Local:)/i;
+
+/** Unicode combining diacritical marks range (U+0300–U+036F). */
+const COMBINING_MARKS_REGEX = /[̀-ͯ]/g;
+
+function normalizeForMatch(text: string): string {
+  return text.normalize("NFD").replace(COMBINING_MARKS_REGEX, "").toLowerCase();
+}
+
+function collapseWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+type AnchorMatch = {
+  index: number;
+  codigo: string;
+  inlinePeriodo: string | undefined;
+};
+
+function findAnchors(text: string): AnchorMatch[] {
+  const anchors: AnchorMatch[] = [];
+  ANCHOR_REGEX.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = ANCHOR_REGEX.exec(text)) !== null) {
+    anchors.push({
+      index: match.index,
+      codigo: match[1],
+      inlinePeriodo: match[2],
+    });
+  }
+  return anchors;
+}
+
+/**
+ * The first line of a block holds: the código-período prefix, the start of the
+ * nome, and (usually) the turma / status / horário columns. This strips those
+ * trailing columns so only the nome fragment remains.
+ */
+function extractNomeFragment(firstLine: string, codigo: string): string {
+  // Drop everything up to and including the código-período prefix.
+  const afterPrefix = firstLine
+    .replace(new RegExp(`^.*?${codigo}\\s*-\\s*(?:${PERIODO})?`), "")
+    .trimStart();
+  // Cut at the turma/status/horário tail when present.
+  const tailStart = afterPrefix.search(/\s{2,}\d{2}\s+MATRICULADO/);
+  const beforeTail = tailStart >= 0 ? afterPrefix.slice(0, tailStart) : afterPrefix;
+  return collapseWhitespace(beforeTail);
+}
+
+function extractHorarioTokens(line: string): string[] {
+  const tokens: string[] = [];
+  HORARIO_REGEX.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = HORARIO_REGEX.exec(line)) !== null) {
+    tokens.push(match[1]);
+  }
+  return tokens;
+}
+
+/** Indentation (leading spaces) of a line, or -1 when blank. */
+function indentOf(line: string): number {
+  const firstNonSpace = line.search(/\S/);
+  return firstNonSpace;
+}
+
+/**
+ * The docente column sits markedly further right than the código/período column.
+ * A line whose text begins at least this many spaces deeper than the código
+ * column belongs to the docente column rather than to the nome continuation.
+ */
+const DOCENTE_COLUMN_INDENT_DELTA = 12;
+
+function parseBlock(block: string, anchor: AnchorMatch): NormalizedDisciplina | null {
+  const lines = block.split("\n");
+  const firstLine = lines[0] ?? "";
+
+  const periodo = anchor.inlinePeriodo ?? PERIODO_LINE_REGEX.exec(block)?.[1] ?? "";
+  if (!periodo) {
+    return null;
+  }
+
+  const tipoMatch = TIPO_REGEX.exec(block);
+  const tipo: DisciplinaTipo =
+    tipoMatch?.[1]?.toUpperCase() === "ATIVIDADE" ? "atividade" : "disciplina";
+
+  const turma = TURMA_REGEX.exec(firstLine)?.[1];
+
+  const codigoColumnIndent = indentOf(firstLine);
+  const docenteColumnThreshold = codigoColumnIndent + DOCENTE_COLUMN_INDENT_DELTA;
+
+  const horarioTokens: string[] = [...extractHorarioTokens(firstLine)];
+  const nomeParts: string[] = [extractNomeFragment(firstLine, anchor.codigo)];
+  // Continuation text living in the código/período column (indented shallowly):
+  // it is a nome overflow when a separate docente column exists, otherwise it is
+  // the docente line itself (short titles leave the período line for the docente).
+  const shallowContinuations: string[] = [];
+  const docenteColumnLines: string[] = [];
+
+  let reachedTipo = false;
+  for (let i = 1; i < lines.length; i++) {
+    const raw = lines[i] ?? "";
+    if (raw.trim().length === 0) {
+      continue;
+    }
+
+    if (TIPO_OR_LOCAL_REGEX.test(raw)) {
+      reachedTipo = true;
+      continue;
+    }
+    if (reachedTipo) {
+      continue;
+    }
+
+    const indent = indentOf(raw);
+    // Strip the período token and any horário column token (the latter may float
+    // to the right of docente text, e.g. the second half "35N34").
+    const withoutPeriodo = raw.replace(PERIODO_LINE_REGEX, "");
+    horarioTokens.push(...extractHorarioTokens(withoutPeriodo));
+    const remainder = collapseWhitespace(withoutPeriodo.replace(HORARIO_REGEX, ""));
+    if (remainder.length === 0) {
+      continue;
+    }
+
+    if (indent >= docenteColumnThreshold) {
+      docenteColumnLines.push(remainder);
+    } else {
+      shallowContinuations.push(remainder);
+    }
+  }
+
+  // A shallow continuation is a nome overflow when the docente sits in its own
+  // column; with no such column the shallow continuation IS the docente.
+  if (docenteColumnLines.length > 0) {
+    nomeParts.push(...shallowContinuations);
+  } else {
+    docenteColumnLines.push(...shallowContinuations);
+  }
+
+  const horario = horarioTokens.length > 0 ? horarioTokens.join(" ") : undefined;
+
+  return {
+    codigo: anchor.codigo,
+    periodo,
+    nome: collapseWhitespace(nomeParts.join(" ")),
+    docente:
+      docenteColumnLines.length > 0 ? collapseWhitespace(docenteColumnLines.join(" ")) : undefined,
+    turma,
+    horario,
+    tipo,
+    status: "matriculado",
+  };
+}
+
+export const atestadoMatriculaAdapter: AcademicDocumentAdapter = {
+  id: ADAPTER_ID,
+
+  matches(text: string): boolean {
+    const normalized = normalizeForMatch(text);
+
+    const hasExplicitHeader =
+      normalized.includes(ATESTADO_HEADER) &&
+      SIGAA_MARKERS.some(marker => normalized.includes(marker));
+    if (hasExplicitHeader) {
+      return true;
+    }
+
+    return STRUCTURAL_MARKERS.every(marker => normalized.includes(marker));
+  },
+
+  parse(text: string): NormalizedDisciplina[] {
+    const scheduleMatch = SCHEDULE_TABLE_MARKER.exec(text);
+    const body = scheduleMatch ? text.slice(0, scheduleMatch.index) : text;
+
+    const anchors = findAnchors(body);
+    const results: NormalizedDisciplina[] = [];
+
+    for (let i = 0; i < anchors.length; i++) {
+      const anchor = anchors[i];
+      const blockStart = anchor.index;
+      const blockEnd = i + 1 < anchors.length ? anchors[i + 1].index : body.length;
+      const block = body.slice(blockStart, blockEnd);
+
+      const parsed = parseBlock(block, anchor);
+      if (parsed && STATUS_MATRICULADO.test(block)) {
+        results.push(parsed);
+      }
+    }
+
+    return results;
+  },
+};

--- a/src/lib/server/services/academic-import/detect-document.ts
+++ b/src/lib/server/services/academic-import/detect-document.ts
@@ -1,0 +1,12 @@
+import type { AcademicDocumentAdapter } from "./document-adapter.interface";
+
+/**
+ * Returns the first adapter that recognizes the given document text, or null
+ * when no registered adapter matches.
+ */
+export function detectAdapter(
+  text: string,
+  adapters: AcademicDocumentAdapter[]
+): AcademicDocumentAdapter | null {
+  return adapters.find(adapter => adapter.matches(text)) ?? null;
+}

--- a/src/lib/server/services/academic-import/document-adapter.interface.ts
+++ b/src/lib/server/services/academic-import/document-adapter.interface.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared contract for parsing academic documents (e.g. SIGAA "Atestado de Matrícula")
+ * into a normalized list of enrolled components, independent of the source format.
+ */
+
+export type DisciplinaTipo = "disciplina" | "atividade";
+
+export type DisciplinaStatus = "matriculado";
+
+export type NormalizedDisciplina = {
+  codigo: string;
+  periodo: string;
+  nome: string;
+  docente?: string;
+  turma?: string;
+  horario?: string;
+  tipo: DisciplinaTipo;
+  status: DisciplinaStatus;
+};
+
+export type AcademicDocumentAdapter = {
+  /** Stable identifier for the adapter (used for diagnostics/telemetry). */
+  readonly id: string;
+  /** Returns true when this adapter recognizes the document text. */
+  matches(text: string): boolean;
+  /** Extracts the enrolled components from the document text. */
+  parse(text: string): NormalizedDisciplina[];
+};


### PR DESCRIPTION
## What

First of three sequential PRs implementing automatic import of enrolled disciplines from a SIGAA "Atestado de Matrícula" PDF, replacing manual class entry.

Part of #174. This PR adds **only the pure parser** — no API route, no UI, no dependencies. It is dead code until PR 2/3 wire it up, but is fully tested in isolation.

### Why a PDF adapter instead of a SIGAA API

Issue #174 proposes a live SIGAA integration. There is no public SIGAA API, so that path means scraping student credentials (auth fragility + privacy risk). Instead the student uploads the Atestado PDF they can already download — same result, zero institutional access needed.

## Scope of this PR

- `document-adapter.interface.ts` — `NormalizedDisciplina` type + `AcademicDocumentAdapter` contract
- `atestado-matricula.adapter.ts` — self-locating parser (anchors on the código-período pattern; no hardcoded columns or class lists)
- `detect-document.ts` — picks the adapter that matches a document, so future document types (e.g. Histórico Escolar) plug in without changing callers
- Jest tests + a sanitized text fixture

## Parsing notes

Self-locating by design: the parser anchors on the código-período pattern and splits the text into per-component blocks, so it works for any student/curso without per-class config.

Handles the real-world messiness in the sample:

- multi-line discipline names
- horário split across two lines (`7M1` + `35N34` → `7M1 35N34`)
- `--` horário (atividades)
- inline código+período+name on one line
- numeric códigos (`1404138`) alongside alpha (`GDSCO0043`)
- `Tipo: DISCIPLINA` vs `Tipo: ATIVIDADE`
- multi-docente across lines
- stops at "Tabela de Horários:" so the schedule grid isn't parsed as components

`matches()` requires the document title + a SIGAA marker, so it won't false-match other SIGAA documents.

## Scope / limits

- Covers **enrolled** disciplines only (`Status: MATRICULADO`). Completed/paid disciplines live in a different document (Histórico Escolar) — out of scope here.
- Privacy: parser is pure string→object; no file is stored. The committed fixture is sanitized (matrícula and name replaced with dummy values); the real PDF is never committed.

## Tests

- `npm run test -- academic-import` → 16 passing
- Asserts all 7 components parse with correct códigos, status, tipo, docentes, and the edge cases above; plus `detectAdapter` positive/negative (rejects a Histórico-like doc).

## Follow-ups (sequential)

- PR 2/3 — `pdf-parse` extraction + `POST /api/usuarios/me/disciplinas/import` (preview, no persist)
- PR 3/3 — upload + review UI, persists via the existing semester endpoint

## Checklist

- [x] `npm run check-all` passes (lint/format/types) for changed files
- [x] Tests pass (`npm run test`)
- [x] No `console.log` left in code
- [x] Updated CHANGELOG.md
- [] Tested manually in browser — N/A (no runtime surface yet; covered by unit tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing SIGAA enrollment documents with automatic parsing of course information including codes, periods, schedules, and instructors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->