### PR TITLE
fix(copa): pular hooks do husky no push do workflow de resultados

### DIFF
--- a/.github/workflows/update-copa-results.yml
+++ b/.github/workflows/update-copa-results.yml
@@ -13,6 +13,13 @@ jobs:
   update-copa-results:
     runs-on: ubuntu-latest
 
+    # O repo usa um pre-push do husky que roda `check-all` (inclui type-check
+    # do projeto inteiro). Este job só altera um JSON e faz checkout sem os
+    # submódulos de `content/`, então o type-check falharia em `@/content/...`.
+    # HUSKY=0 pula os hooks para que o push do bot não seja bloqueado.
+    env:
+      HUSKY: "0"
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
O job falhava no `git push`: o pre-push do husky roda `check-all`
(type-check do projeto), que quebra porque o checkout do workflow não
inclui o submódulo `content/aquario-mapas`, deixando `@/content/...`
sem resolução. Define HUSKY=0 no job para que o push do bot não seja
bloqueado pelo hook.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QzNUG23c8KXDrhLgqSbpz7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the automated Copa results update workflow to ensure reliable execution without interruptions from development tooling checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->