### PR TITLE
chore: prepare release v1.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.2] - 2026-07-03
+
+### Fixed
+- **Copa do Mundo 2026 – pareamento dos terceiros colocados**: O algoritmo de backtracking com heurística de menor número de candidatos (most-constrained-variable) encontrava *um* pareamento válido entre os 8 melhores terceiros colocados e os slots do mata-mata, mas nem sempre o mesmo definido pela FIFA — havia 22 pareamentos válidos possíveis para a combinação atual de grupos classificados, e nenhuma heurística genérica de CSP consegue preferir o oficial. Substituído por uma tabela explícita com o pareamento correto verificado (Alemanha x Paraguai, França x Suécia, Bélgica x Senegal, Suíça x Argélia, entre outros), com fallback defensivo caso a combinação de grupos classificados mude. Adicionado teste de regressão travando os 8 pareamentos corretos.
+
 ## [1.10.1] - 2026-07-03
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aquario",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aquario",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "hasInstallScript": true,
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^7.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquario",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## What

Version bump and CHANGELOG entry for v1.10.2, covering the third-place knockout-slot assignment fix merged in #216.

## Why

Following the standard release process: CHANGELOG entries move from `[Unreleased]` to a dated version section, `package.json` version bumps, then `npm run release:*` (or manual tag + `gh release create`) publishes the GitHub Release that triggers the production deploy.

## Changes

- `CHANGELOG.md` — moved the third-place assignment fix into a new `[1.10.2] - 2026-07-03` section
- `package.json` / `package-lock.json` — version bumped `1.10.1` → `1.10.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)