### PR TITLE
fix(copa): auto-update results for the entire remaining knockout stage

### DIFF
--- a/scripts/update-copa-results.ts
+++ b/scripts/update-copa-results.ts
@@ -8,6 +8,7 @@
 import { mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
 import { COPA_MATCHES } from "../src/lib/shared/copa/matches";
+import { resolveMatchParticipants } from "../src/lib/shared/copa/standings";
 
 const API_KEY = process.env.FOOTBALL_DATA_API_KEY;
 
@@ -45,7 +46,15 @@ type ApiMatch = {
   status: string;
   homeTeam: { tla: string };
   awayTeam: { tla: string };
-  score: { fullTime: { home: number | null; away: number | null } };
+  score: {
+    winner: "HOME_TEAM" | "AWAY_TEAM" | "DRAW" | null;
+    fullTime: { home: number | null; away: number | null };
+  };
+};
+
+const API_WINNER_TO_INTERNAL: Record<string, "home" | "away"> = {
+  HOME_TEAM: "home",
+  AWAY_TEAM: "away",
 };
 
 const TOURNAMENT_START = new Date("2026-06-11T00:00:00Z");
@@ -102,11 +111,21 @@ async function main() {
     apiLookup.set(`${homeId}_${awayId}_${dateUTC}`, m);
   }
 
-  const results: Record<string, { homeScore: number; awayScore: number; status: MatchStatus }> = {};
+  const results: Record<
+    string,
+    { homeScore: number; awayScore: number; status: MatchStatus; winner?: "home" | "away" }
+  > = {};
   const unmatched: string[] = [];
 
-  for (const match of COPA_MATCHES) {
-    // Partidas de mata-mata sem equipes definidas ainda são ignoradas.
+  // Resolve knockout-stage participants (e.g. "1º Grupo A", "3º A/B/C/D/F")
+  // from the current group standings before matching against the API —
+  // otherwise every knockout match's homeId/awayId stays null and gets
+  // skipped below, even after the teams are actually known.
+  const resolvedMatches = COPA_MATCHES.map(resolveMatchParticipants);
+
+  for (const match of resolvedMatches) {
+    // Matches whose participants aren't determined yet (e.g. "Vencedor Jogo
+    // 73" before the Round of 32 has been played) are skipped.
     if (!match.homeId || !match.awayId) {
       continue;
     }
@@ -125,7 +144,13 @@ async function main() {
     const awayScore = apiMatch.score.fullTime.away;
 
     if (homeScore !== null && awayScore !== null) {
-      results[String(match.id)] = { homeScore, awayScore, status };
+      // For knockout matches, the API's top-level winner already accounts
+      // for extra time/penalties — a tied fullTime score doesn't mean a draw.
+      const winner =
+        match.stage !== "grupos" && apiMatch.score.winner
+          ? API_WINNER_TO_INTERNAL[apiMatch.score.winner]
+          : undefined;
+      results[String(match.id)] = { homeScore, awayScore, status, ...(winner && { winner }) };
     }
   }
 

--- a/src/lib/shared/copa/results.ts
+++ b/src/lib/shared/copa/results.ts
@@ -6,12 +6,15 @@ type StoredResult = {
   homeScore: number;
   awayScore: number;
   status: MatchStatus;
+  /** Knockout-stage winner (accounts for extra time/penalties). Undefined for group-stage matches. */
+  winner?: "home" | "away";
 };
 
 const StoredResultSchema = z.object({
   homeScore: z.number(),
   awayScore: z.number(),
   status: z.enum(["scheduled", "live", "finished"]),
+  winner: z.enum(["home", "away"]).optional(),
 });
 
 const ResultsFileSchema = z.object({

--- a/src/lib/shared/copa/standings.ts
+++ b/src/lib/shared/copa/standings.ts
@@ -204,37 +204,74 @@ function buildThirdAssignments(): Map<ThirdSlotKey, string | null> {
 
 const THIRD_ASSIGNMENTS = buildThirdAssignments();
 
-function resolveLabel(match: CopaMatch, side: "home" | "away"): string | null {
-  const label = side === "home" ? match.homeLabel : match.awayLabel;
-  if (!label) {
+/**
+ * Resolves every knockout match's participants in a single pass, processing
+ * COPA_MATCHES in its declared order (group stage, then 32avos, oitavas,
+ * quartas, semis, terceiro, final). Later stages reference only earlier
+ * match ids ("Vencedor Jogo 73", "Perdedor Jogo 101"), so by the time a
+ * later match is resolved, every match it depends on already has resolved
+ * participants and — once played — a stored result to read the winner from.
+ */
+function buildResolvedMatches(): Map<number, CopaMatch> {
+  const resolved = new Map<number, CopaMatch>();
+
+  function resolveLabel(match: CopaMatch, side: "home" | "away"): string | null {
+    const label = side === "home" ? match.homeLabel : match.awayLabel;
+    if (!label) {
+      return null;
+    }
+
+    const posGroup = label.match(/^(\d+)º Grupo ([A-L])$/);
+    if (posGroup) {
+      const pos = parseInt(posGroup[1]) - 1;
+      const grupo = posGroup[2] as CopaGroupLetter;
+      return GROUP_STANDINGS.get(grupo)?.[pos]?.teamId ?? null;
+    }
+
+    if (label.match(/^3º /)) {
+      return THIRD_ASSIGNMENTS.get(`${match.id}-${side}`) ?? null;
+    }
+
+    const outcome = label.match(/^(Vencedor|Perdedor) Jogo (\d+)$/);
+    if (outcome) {
+      const [, kind, refIdStr] = outcome;
+      const refMatch = resolved.get(Number(refIdStr));
+      if (!refMatch || !refMatch.homeId || !refMatch.awayId) {
+        return null;
+      }
+      const result = getMatchResult(refMatch.id);
+      if (!result || result.status !== "finished" || !result.winner) {
+        return null;
+      }
+      const winnerId = result.winner === "home" ? refMatch.homeId : refMatch.awayId;
+      const loserId = result.winner === "home" ? refMatch.awayId : refMatch.homeId;
+      return kind === "Vencedor" ? winnerId : loserId;
+    }
+
     return null;
   }
 
-  const posGroup = label.match(/^(\d+)º Grupo ([A-L])$/);
-  if (posGroup) {
-    const pos = parseInt(posGroup[1]) - 1;
-    const grupo = posGroup[2] as CopaGroupLetter;
-    return GROUP_STANDINGS.get(grupo)?.[pos]?.teamId ?? null;
+  for (const match of COPA_MATCHES) {
+    if (match.stage === "grupos") {
+      resolved.set(match.id, match);
+      continue;
+    }
+    resolved.set(match.id, {
+      ...match,
+      homeId: match.homeId ?? resolveLabel(match, "home"),
+      awayId: match.awayId ?? resolveLabel(match, "away"),
+    });
   }
 
-  if (label.match(/^3º /)) {
-    return THIRD_ASSIGNMENTS.get(`${match.id}-${side}`) ?? null;
-  }
-
-  return null;
+  return resolved;
 }
+
+const RESOLVED_MATCHES = buildResolvedMatches();
 
 /**
  * Returns the match with resolved homeId/awayId for knockout stages.
  * Group-stage matches are returned unchanged.
  */
 export function resolveMatchParticipants(match: CopaMatch): CopaMatch {
-  if (match.stage === "grupos") {
-    return match;
-  }
-  return {
-    ...match,
-    homeId: match.homeId ?? resolveLabel(match, "home"),
-    awayId: match.awayId ?? resolveLabel(match, "away"),
-  };
+  return RESOLVED_MATCHES.get(match.id) ?? match;
 }


### PR DESCRIPTION
## Problem

The scheduled `Update Copa Results` action runs every 2 hours during the tournament, but in practice it only ever updated group-stage matches. Round of 32 scores (and every later round) were never fetched automatically.

## Root cause

`scripts/update-copa-results.ts` looked up `match.homeId`/`match.awayId` directly from the static `COPA_MATCHES` data. Every knockout-stage match has both set to `null` by design — the actual participants are only resolved dynamically (via `resolveMatchParticipants`, added in #216) at render/build time on the site. Since the script never called that resolver, every knockout match hit the `if (!match.homeId || !match.awayId) continue;` guard and was silently skipped, even once the group stage finished and the Round of 32 participants were fully knowable.

## Fix

- **`scripts/update-copa-results.ts`** — resolve participants via `resolveMatchParticipants` before matching against the API, so knockout matches whose teams are now known get looked up too.
- **`src/lib/shared/copa/results.ts`** — store an optional `winner: "home" | "away"` per result. Knockout matches can finish level after normal time and go to penalties, so the stored score alone can't tell who advances. The football-data.org API's top-level `score.winner` field already accounts for extra time/penalties, so we capture it directly instead of re-deriving it from the score.
- **`src/lib/shared/copa/standings.ts`** — `resolveMatchParticipants` now resolves the *entire* bracket in one pass, processing `COPA_MATCHES` in its declared stage order (grupos → 32avos → oitavas → quartas → semis → terceiro → final). In addition to the existing "1º/2º/3º Grupo" labels, it now handles "Vencedor Jogo N" / "Perdedor Jogo N" labels by looking up the referenced match's already-resolved participants and stored winner.

## Why this converges automatically

Each 2-hour scheduled run naturally propagates one more round as results land: resolving a round's participants requires the *prior* round's stored result (to know the winner), which this same script just wrote on an earlier run. No manual intervention needed as the tournament progresses.

## Testing

- `npx next lint` on all three changed files → no errors
- `npx tsc --noEmit` → no new errors (pre-existing unrelated `openapi` errors only)
- `npx jest src/lib/shared/copa/standings.test.ts` → both tests still pass (2/2), confirming the Round of 32 third-place regression fix from #216 is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Copa knockout match handling so match participants and outcomes are resolved more reliably.
  * Added support for recording a knockout winner even when the final score is tied.

* **Bug Fixes**
  * Fixed result matching for knockout-stage matches, reducing cases where results could not be linked correctly.
  * Preserved match status while updating stored results with the new winner information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->