### PR TITLE
chore: prepare release v1.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.3] - 2026-07-04
+
+### Fixed
+- **Copa do Mundo 2026 – atualização automática de resultados no mata-mata**: A action `Update Copa Results` (a cada 2h) buscava resultados a partir dos dados brutos de `COPA_MATCHES`, onde `homeId`/`awayId` do mata-mata são sempre `null` por design — toda partida de mata-mata era ignorada silenciosamente, e nenhum placar da fase eliminatória era buscado automaticamente. Corrigido para resolver os participantes via `resolveMatchParticipants` antes da busca. Também passamos a armazenar o vencedor de cada partida (`winner: "home" | "away"`) capturado direto da API — necessário porque o placar sozinho não indica quem avança quando a partida vai para os pênaltis. `resolveMatchParticipants` agora resolve o chaveamento inteiro em uma única passada (grupos → 32-avos → oitavas → quartas → semis → terceiro → final), interpretando labels "Vencedor Jogo N" / "Perdedor Jogo N" a partir do resultado já registrado da partida referenciada.
+- **Copa do Mundo 2026 – release para publicar os placares da Rodada de 32**: Publicada para que a produção (que lê `content/copa-resultados/results.json` em build-time) reflita os placares da Rodada de 32 já registrados desde a última release.
+
 ## [1.10.2] - 2026-07-03
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aquario",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aquario",
-      "version": "1.10.2",
+      "version": "1.10.3",
       "hasInstallScript": true,
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^7.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquario",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## What

Version bump and CHANGELOG entry for v1.10.3.

## Why

Production only rebuilds on a published GitHub Release — the scheduled `Update Copa Results` action commits straight to `main` (updating staging via its push-triggered deploy) but never triggers a production rebuild. The last Production Release was v1.10.2 (2026-07-03), so the Round of 32 scores committed after that (2026-07-04) never reached production, since `content/copa-resultados/results.json` is statically imported at build time.

This release exists purely to publish the already-committed Round of 32 results (and the #219 knockout-resolution fix) to production.

## Changes

- `CHANGELOG.md` — new `[1.10.3] - 2026-07-04` section covering the knockout auto-update fix (#219) and this release
- `package.json` / `package-lock.json` — version bumped `1.10.2` → `1.10.3`

## Note

This doesn't fix the underlying structural issue — during the rest of the knockout stage, scores committed by the scheduled action still won't reach production without another release like this one. Worth a follow-up to move `results.json` off a build-time static import (e.g. ISR revalidation or a runtime fetch) so production stays fresh without manual releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Knockout-stage scores now update correctly instead of being skipped in some cases.
  * Match winners are now saved from the source data, improving score accuracy.
  * Production data now reflects previously registered Round of 32 scores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->