### PR TITLE
fix(copa): don't sum penalty shootout goals into the displayed score

### DIFF
--- a/scripts/update-copa-results.ts
+++ b/scripts/update-copa-results.ts
@@ -48,7 +48,12 @@ type ApiMatch = {
   awayTeam: { tla: string };
   score: {
     winner: "HOME_TEAM" | "AWAY_TEAM" | "DRAW" | null;
+    duration: "REGULAR" | "EXTRA_TIME" | "PENALTY_SHOOTOUT";
+    // When duration is PENALTY_SHOOTOUT, fullTime is regularTime + extraTime +
+    // penalties SUMMED — not the actual match score. See:
+    // https://docs.football-data.org/general/v4/overtime.html
     fullTime: { home: number | null; away: number | null };
+    penalties?: { home: number | null; away: number | null };
   };
 };
 
@@ -113,7 +118,14 @@ async function main() {
 
   const results: Record<
     string,
-    { homeScore: number; awayScore: number; status: MatchStatus; winner?: "home" | "away" }
+    {
+      homeScore: number;
+      awayScore: number;
+      status: MatchStatus;
+      winner?: "home" | "away";
+      penaltyHomeScore?: number;
+      penaltyAwayScore?: number;
+    }
   > = {};
   const unmatched: string[] = [];
 
@@ -140,17 +152,39 @@ async function main() {
     }
 
     const status = STATUS_MAP[apiMatch.status] ?? "scheduled";
-    const homeScore = apiMatch.score.fullTime.home;
-    const awayScore = apiMatch.score.fullTime.away;
+    const wentToPenalties = apiMatch.score.duration === "PENALTY_SHOOTOUT";
+    const penaltyHome = apiMatch.score.penalties?.home;
+    const penaltyAway = apiMatch.score.penalties?.away;
+    const hasPenaltyScore =
+      wentToPenalties && typeof penaltyHome === "number" && typeof penaltyAway === "number";
+
+    // When the match went to penalties, fullTime is regularTime + extraTime +
+    // penalties summed — subtract the shootout goals to get the actual match
+    // score (excluding the shootout), which is what should be displayed.
+    const homeScore = hasPenaltyScore
+      ? (apiMatch.score.fullTime.home ?? 0) - penaltyHome
+      : apiMatch.score.fullTime.home;
+    const awayScore = hasPenaltyScore
+      ? (apiMatch.score.fullTime.away ?? 0) - penaltyAway
+      : apiMatch.score.fullTime.away;
 
     if (homeScore !== null && awayScore !== null) {
       // For knockout matches, the API's top-level winner already accounts
-      // for extra time/penalties — a tied fullTime score doesn't mean a draw.
+      // for extra time/penalties — a tied score doesn't mean a draw.
       const winner =
         match.stage !== "grupos" && apiMatch.score.winner
           ? API_WINNER_TO_INTERNAL[apiMatch.score.winner]
           : undefined;
-      results[String(match.id)] = { homeScore, awayScore, status, ...(winner && { winner }) };
+      results[String(match.id)] = {
+        homeScore,
+        awayScore,
+        status,
+        ...(winner && { winner }),
+        ...(hasPenaltyScore && {
+          penaltyHomeScore: penaltyHome,
+          penaltyAwayScore: penaltyAway,
+        }),
+      };
     }
   }
 

--- a/src/components/pages/copa/match-card.tsx
+++ b/src/components/pages/copa/match-card.tsx
@@ -62,6 +62,7 @@ export function MatchCard({ match }: { match: CopaMatchWithResult }) {
   const isFinished = match.matchStatus === "finished";
   const isLive = match.matchStatus === "live";
   const hasScore = match.homeScore !== null && match.awayScore !== null;
+  const hasPenalties = match.penaltyHomeScore !== null && match.penaltyAwayScore !== null;
 
   return (
     <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm transition-colors hover:border-sky-300 dark:border-white/10 dark:bg-white/5 dark:hover:border-sky-300/40">
@@ -94,6 +95,11 @@ export function MatchCard({ match }: { match: CopaMatchWithResult }) {
               >
                 {match.homeScore} – {match.awayScore}
               </span>
+              {hasPenalties && (
+                <span className="text-[10px] tabular-nums text-muted-foreground">
+                  pên. {match.penaltyHomeScore} – {match.penaltyAwayScore}
+                </span>
+              )}
               <span
                 className={cn(
                   "text-[10px] uppercase tracking-wide",

--- a/src/lib/shared/copa/results.ts
+++ b/src/lib/shared/copa/results.ts
@@ -8,6 +8,9 @@ type StoredResult = {
   status: MatchStatus;
   /** Knockout-stage winner (accounts for extra time/penalties). Undefined for group-stage matches. */
   winner?: "home" | "away";
+  /** Penalty shootout score. Present only when the match was decided on penalties. */
+  penaltyHomeScore?: number;
+  penaltyAwayScore?: number;
 };
 
 const StoredResultSchema = z.object({
@@ -15,6 +18,8 @@ const StoredResultSchema = z.object({
   awayScore: z.number(),
   status: z.enum(["scheduled", "live", "finished"]),
   winner: z.enum(["home", "away"]).optional(),
+  penaltyHomeScore: z.number().optional(),
+  penaltyAwayScore: z.number().optional(),
 });
 
 const ResultsFileSchema = z.object({
@@ -37,6 +42,8 @@ export function withResult(match: CopaMatch): CopaMatchWithResult {
     homeScore: result?.homeScore ?? null,
     awayScore: result?.awayScore ?? null,
     matchStatus: result?.status ?? "scheduled",
+    penaltyHomeScore: result?.penaltyHomeScore ?? null,
+    penaltyAwayScore: result?.penaltyAwayScore ?? null,
   };
 }
 

--- a/src/lib/shared/copa/types.ts
+++ b/src/lib/shared/copa/types.ts
@@ -29,6 +29,9 @@ export type CopaMatchWithResult = CopaMatch & {
   homeScore: number | null;
   awayScore: number | null;
   matchStatus: MatchStatus;
+  /** Penalty shootout score, present only when the match was decided on penalties. */
+  penaltyHomeScore: number | null;
+  penaltyAwayScore: number | null;
 };
 
 export type CopaMatch = {


### PR DESCRIPTION
## Problem

Knockout matches decided on penalties were displaying inflated, nonsensical scorelines (e.g. "4-5") on `/copa-do-mundo`.

## Root cause

Per the [football-data.org docs](https://docs.football-data.org/general/v4/overtime.html), when `score.duration` is `PENALTY_SHOOTOUT`, `score.fullTime` is `regularTime + extraTime + penalties` **summed** — not the actual match score. Example from their docs: a match tied 1-1 after extra time, decided 6-5 on penalties, reports `fullTime: { homeTeam: 7, awayTeam: 6 }`.

`scripts/update-copa-results.ts` stored `fullTime.home/away` directly as `homeScore`/`awayScore`, so any match decided on penalties displayed the normal-time score plus the shootout goals added together, instead of the actual match result.

## Fix

- **`scripts/update-copa-results.ts`** — when `score.duration === "PENALTY_SHOOTOUT"`, subtract `score.penalties` from `fullTime` to recover the actual match score, and store the shootout score separately as `penaltyHomeScore`/`penaltyAwayScore`.
- **`src/lib/shared/copa/results.ts`, `types.ts`** — thread the new optional penalty fields through the stored-result schema and `CopaMatchWithResult`.
- **`src/components/pages/copa/match-card.tsx`** — show "pên. X – Y" under the match score when the game went to penalties, so the shootout result is still visible, just not conflated with the match score.

## Testing

- `npx next lint` on all four changed files → no errors
- `npx tsc --noEmit` → no new errors (pre-existing unrelated errors only)
- `npx jest src/lib/shared/copa/standings.test.ts` → both tests pass (2/2), confirming the knockout-bracket resolution fixes from #216/#219 are unaffected

## Follow-up needed

The already-stored results for matches that went to penalties (e.g. Jogo 74, 75) still have the old, incorrect summed scores in `content/copa-resultados/results.json` — this fix only corrects newly-fetched results. After merging, the scheduled action (or a manual `workflow_dispatch`) needs to run again to overwrite them, and then a new release published so production picks up the corrected data (see the ongoing structural gap noted in #220 — production only rebuilds on release, not on every push to `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)