### PR TITLE
chore: prepare release v1.10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.5] - 2026-07-04
+
+### Fixed
+- **Copa do Mundo 2026 – release para publicar o placar correto dos pênaltis**: Publicada para que a produção reflita os resultados já reprocessados (Alemanha x Paraguai, Países Baixos x Marrocos, Austrália x Egito) após a correção do #222 — os dados antigos, gravados antes da correção, permaneciam com o placar somado até serem buscados novamente pela action `Update Copa Results`.
+
 ## [1.10.4] - 2026-07-04
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aquario",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aquario",
-      "version": "1.10.4",
+      "version": "1.10.5",
       "hasInstallScript": true,
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^7.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquario",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## What

Version bump and CHANGELOG entry for v1.10.5.

## Why

Publishes the reprocessed penalty-shootout results (Germany x Paraguay, Netherlands x Morocco, Australia x Egypt) to production. These matches were stored with the old summed score before #222 merged; the scheduled action (and a manual dispatch) already re-fetched and corrected them in `content/copa-resultados/results.json`, but production only rebuilds on a published release.

## Changes

- `CHANGELOG.md` — new `[1.10.5] - 2026-07-04` section
- `package.json` / `package-lock.json` — version bumped `1.10.4` → `1.10.5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the app to version 1.10.5.
  * Corrected match score results for Copa do Mundo 2026 penalty matches in production, including the affected match records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->