### PR TITLE
feat(copa): fetch results at request time instead of build time

### DIFF
--- a/src/app/copa-do-mundo/page.tsx
+++ b/src/app/copa-do-mundo/page.tsx
@@ -1,5 +1,25 @@
 import { CopaClient } from "@/components/pages/copa/copa-client";
+import { COPA_MATCHES, COPA_MATCHES_CHRONO } from "@/lib/shared/copa/matches";
+import { fetchLiveResultsFile, makeGetMatchResult, withResult } from "@/lib/shared/copa/results";
+import { createCopaResolver } from "@/lib/shared/copa/standings";
 
-export default function CopaDoMundoPage() {
-  return <CopaClient />;
+// Re-fetches content/copa-resultados/results.json from the main branch every
+// 5 minutes (Next.js ISR) instead of relying on the snapshot bundled at
+// build time — so scores committed by the scheduled Update Copa Results
+// action reach the live site without a new release.
+export const revalidate = 300;
+
+export default async function CopaDoMundoPage() {
+  const resultsFile = await fetchLiveResultsFile();
+  const getResult = makeGetMatchResult(resultsFile.results);
+  const resolveMatchParticipants = createCopaResolver(getResult);
+
+  const matches = COPA_MATCHES.map(resolveMatchParticipants).map(match =>
+    withResult(match, getResult)
+  );
+  const matchesChrono = COPA_MATCHES_CHRONO.map(resolveMatchParticipants).map(match =>
+    withResult(match, getResult)
+  );
+
+  return <CopaClient matches={matches} matchesChrono={matchesChrono} />;
 }

--- a/src/components/pages/copa/copa-client.tsx
+++ b/src/components/pages/copa/copa-client.tsx
@@ -3,9 +3,6 @@
 import { Trophy, CalendarDays, MapPin, Users } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { cn } from "@/lib/client/utils";
-import { COPA_MATCHES, COPA_MATCHES_CHRONO } from "@/lib/shared/copa/matches";
-import { withResult } from "@/lib/shared/copa/results";
-import { resolveMatchParticipants } from "@/lib/shared/copa/standings";
 import { COPA_GROUP_LETTERS, COPA_TEAMS } from "@/lib/shared/copa/teams";
 import type { CopaMatchWithResult, CopaStage } from "@/lib/shared/copa/types";
 import {
@@ -28,10 +25,6 @@ const STAGE_FILTERS: Array<{ value: StageFilter; label: string }> = [
   { value: "final", label: "Final" },
 ];
 
-const MATCHES_WITH_RESULTS = COPA_MATCHES.map(resolveMatchParticipants).map(withResult);
-const MATCHES_CHRONO_WITH_RESULTS =
-  COPA_MATCHES_CHRONO.map(resolveMatchParticipants).map(withResult);
-
 function matchesStage(match: CopaMatchWithResult, filter: StageFilter): boolean {
   if (filter === "todos") {
     return true;
@@ -45,7 +38,12 @@ function matchesStage(match: CopaMatchWithResult, filter: StageFilter): boolean 
 
 const SORTED_TEAMS = [...COPA_TEAMS].sort((a, b) => a.nome.localeCompare(b.nome, "pt-BR"));
 
-export function CopaClient() {
+type CopaClientProps = {
+  matches: CopaMatchWithResult[];
+  matchesChrono: CopaMatchWithResult[];
+};
+
+export function CopaClient({ matches, matchesChrono }: CopaClientProps) {
   const [stage, setStage] = useState<StageFilter>("todos");
   const [teamId, setTeamId] = useState<string>("");
   const [now, setNow] = useState<number | null>(null);
@@ -56,7 +54,7 @@ export function CopaClient() {
   }, []);
 
   const filteredMatches = useMemo(() => {
-    return MATCHES_WITH_RESULTS.filter(match => {
+    return matches.filter(match => {
       if (!matchesStage(match, stage)) {
         return false;
       }
@@ -65,7 +63,7 @@ export function CopaClient() {
       }
       return true;
     });
-  }, [stage, teamId]);
+  }, [matches, stage, teamId]);
 
   const matchesByDay = useMemo(() => groupMatchesByDay(filteredMatches), [filteredMatches]);
 
@@ -73,10 +71,10 @@ export function CopaClient() {
     if (now === null) {
       return [];
     }
-    return MATCHES_CHRONO_WITH_RESULTS.filter(
-      match => new Date(match.kickoff).getTime() >= now || match.matchStatus === "live"
-    ).slice(0, 3);
-  }, [now]);
+    return matchesChrono
+      .filter(match => new Date(match.kickoff).getTime() >= now || match.matchStatus === "live")
+      .slice(0, 3);
+  }, [matchesChrono, now]);
 
   return (
     <div className="container mx-auto mt-20 max-w-5xl overflow-x-hidden p-4 md:p-8">

--- a/src/lib/shared/copa/results.ts
+++ b/src/lib/shared/copa/results.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import resultsJson from "@/content/copa-resultados/results.json";
 import type { CopaMatch, CopaMatchWithResult, MatchStatus } from "./types";
 
-type StoredResult = {
+export type StoredResult = {
   homeScore: number;
   awayScore: number;
   status: MatchStatus;
@@ -27,16 +27,51 @@ const ResultsFileSchema = z.object({
   results: z.record(StoredResultSchema),
 });
 
-type ResultsFile = z.infer<typeof ResultsFileSchema>;
+export type ResultsFile = z.infer<typeof ResultsFileSchema>;
 
-const data: ResultsFile = ResultsFileSchema.parse(resultsJson);
+export type GetMatchResult = (matchId: number) => StoredResult | null;
 
-export function getMatchResult(matchId: number): StoredResult | null {
-  return data.results[String(matchId)] ?? null;
+export function makeGetMatchResult(results: ResultsFile["results"]): GetMatchResult {
+  return matchId => results[String(matchId)] ?? null;
 }
 
-export function withResult(match: CopaMatch): CopaMatchWithResult {
-  const result = getMatchResult(match.id);
+// Snapshot bundled at build time. Used by the CI script (which always runs
+// against a freshly-checked-out repo, so this is current there), by tests,
+// and as a fallback if the live fetch below fails.
+const staticData: ResultsFile = ResultsFileSchema.parse(resultsJson);
+
+/** @deprecated for page rendering — prefer fetchLiveResultsFile() + makeGetMatchResult() so the site reflects results without a new deploy. Still fine for the CI script and tests, which always run against fresh data. */
+export const getMatchResult: GetMatchResult = makeGetMatchResult(staticData.results);
+
+export const resultsUpdatedAt: string = staticData.updatedAt;
+
+const LIVE_RESULTS_URL =
+  "https://raw.githubusercontent.com/aquario-ufpb/aquario/main/content/copa-resultados/results.json";
+
+/**
+ * Fetches the current results.json from the main branch at request/build
+ * time, with Next.js ISR revalidation — so newly-committed scores reach the
+ * live site without needing a new release/deploy. Falls back to the
+ * snapshot bundled at build time if the fetch fails.
+ */
+export async function fetchLiveResultsFile(): Promise<ResultsFile> {
+  try {
+    const res = await fetch(LIVE_RESULTS_URL, { next: { revalidate: 300 } });
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+    return ResultsFileSchema.parse(await res.json());
+  } catch (err) {
+    console.error("fetchLiveResultsFile: falling back to bundled snapshot:", err);
+    return staticData;
+  }
+}
+
+export function withResult(
+  match: CopaMatch,
+  getResult: GetMatchResult = getMatchResult
+): CopaMatchWithResult {
+  const result = getResult(match.id);
   return {
     ...match,
     homeScore: result?.homeScore ?? null,
@@ -46,5 +81,3 @@ export function withResult(match: CopaMatch): CopaMatchWithResult {
     penaltyAwayScore: result?.penaltyAwayScore ?? null,
   };
 }
-
-export const resultsUpdatedAt: string = data.updatedAt;

--- a/src/lib/shared/copa/standings.ts
+++ b/src/lib/shared/copa/standings.ts
@@ -1,5 +1,5 @@
 import { COPA_MATCHES } from "./matches";
-import { getMatchResult } from "./results";
+import { getMatchResult, type GetMatchResult } from "./results";
 import { COPA_TEAMS } from "./teams";
 import type { CopaGroupLetter, CopaMatch } from "./types";
 
@@ -27,7 +27,7 @@ function compareStandings(a: TeamStanding, b: TeamStanding): number {
   return b.gf - a.gf;
 }
 
-function buildStandings(): Map<CopaGroupLetter, TeamStanding[]> {
+function buildStandings(getResult: GetMatchResult): Map<CopaGroupLetter, TeamStanding[]> {
   const map = new Map<CopaGroupLetter, Map<string, TeamStanding>>();
 
   for (const team of COPA_TEAMS) {
@@ -51,7 +51,7 @@ function buildStandings(): Map<CopaGroupLetter, TeamStanding[]> {
     if (match.stage !== "grupos" || !match.homeId || !match.awayId) {
       continue;
     }
-    const result = getMatchResult(match.id);
+    const result = getResult(match.id);
     if (!result || result.status !== "finished") {
       continue;
     }
@@ -97,11 +97,10 @@ function buildStandings(): Map<CopaGroupLetter, TeamStanding[]> {
   return result;
 }
 
-// Computed once at module load (all data is static/build-time)
-const GROUP_STANDINGS = buildStandings();
-
-function getBestThirds(): Map<CopaGroupLetter, TeamStanding> {
-  const thirds = [...GROUP_STANDINGS.values()]
+function getBestThirds(
+  groupStandings: Map<CopaGroupLetter, TeamStanding[]>
+): Map<CopaGroupLetter, TeamStanding> {
+  const thirds = [...groupStandings.values()]
     .map(s => s[2])
     .filter((t): t is TeamStanding => t !== undefined)
     .sort(compareStandings)
@@ -113,8 +112,6 @@ function getBestThirds(): Map<CopaGroupLetter, TeamStanding> {
   }
   return result;
 }
-
-const BEST_THIRDS = getBestThirds();
 
 type ThirdSlotKey = string;
 
@@ -144,7 +141,9 @@ const MATCH_ID_TO_THIRD_GROUP: Record<number, CopaGroupLetter> = {
   88: "L",
 };
 
-function buildThirdAssignments(): Map<ThirdSlotKey, string | null> {
+function buildThirdAssignments(
+  bestThirds: Map<CopaGroupLetter, TeamStanding>
+): Map<ThirdSlotKey, string | null> {
   const slots: Array<{ key: ThirdSlotKey; matchId: number; groups: CopaGroupLetter[] }> = [];
 
   for (const match of COPA_MATCHES) {
@@ -174,7 +173,7 @@ function buildThirdAssignments(): Map<ThirdSlotKey, string | null> {
 
   for (const slot of slots) {
     const preferredGroup = MATCH_ID_TO_THIRD_GROUP[slot.matchId];
-    const preferred = preferredGroup ? BEST_THIRDS.get(preferredGroup) : undefined;
+    const preferred = preferredGroup ? bestThirds.get(preferredGroup) : undefined;
     if (preferred && slot.groups.includes(preferredGroup) && !used.has(preferredGroup)) {
       result.set(slot.key, preferred.teamId);
       used.add(preferredGroup);
@@ -188,8 +187,8 @@ function buildThirdAssignments(): Map<ThirdSlotKey, string | null> {
   // eligible candidate rather than leaving the slot unresolved.
   for (const slot of unresolved) {
     const candidate = slot.groups
-      .filter(g => BEST_THIRDS.has(g) && !used.has(g))
-      .map(g => BEST_THIRDS.get(g) as TeamStanding)
+      .filter(g => bestThirds.has(g) && !used.has(g))
+      .map(g => bestThirds.get(g) as TeamStanding)
       .sort(compareStandings)[0];
     if (candidate) {
       result.set(slot.key, candidate.teamId);
@@ -202,8 +201,6 @@ function buildThirdAssignments(): Map<ThirdSlotKey, string | null> {
   return result;
 }
 
-const THIRD_ASSIGNMENTS = buildThirdAssignments();
-
 /**
  * Resolves every knockout match's participants in a single pass, processing
  * COPA_MATCHES in its declared order (group stage, then 32avos, oitavas,
@@ -212,7 +209,11 @@ const THIRD_ASSIGNMENTS = buildThirdAssignments();
  * later match is resolved, every match it depends on already has resolved
  * participants and — once played — a stored result to read the winner from.
  */
-function buildResolvedMatches(): Map<number, CopaMatch> {
+function buildResolvedMatches(
+  groupStandings: Map<CopaGroupLetter, TeamStanding[]>,
+  thirdAssignments: Map<ThirdSlotKey, string | null>,
+  getResult: GetMatchResult
+): Map<number, CopaMatch> {
   const resolved = new Map<number, CopaMatch>();
 
   function resolveLabel(match: CopaMatch, side: "home" | "away"): string | null {
@@ -225,11 +226,11 @@ function buildResolvedMatches(): Map<number, CopaMatch> {
     if (posGroup) {
       const pos = parseInt(posGroup[1]) - 1;
       const grupo = posGroup[2] as CopaGroupLetter;
-      return GROUP_STANDINGS.get(grupo)?.[pos]?.teamId ?? null;
+      return groupStandings.get(grupo)?.[pos]?.teamId ?? null;
     }
 
     if (label.match(/^3º /)) {
-      return THIRD_ASSIGNMENTS.get(`${match.id}-${side}`) ?? null;
+      return thirdAssignments.get(`${match.id}-${side}`) ?? null;
     }
 
     const outcome = label.match(/^(Vencedor|Perdedor) Jogo (\d+)$/);
@@ -239,7 +240,7 @@ function buildResolvedMatches(): Map<number, CopaMatch> {
       if (!refMatch || !refMatch.homeId || !refMatch.awayId) {
         return null;
       }
-      const result = getMatchResult(refMatch.id);
+      const result = getResult(refMatch.id);
       if (!result || result.status !== "finished" || !result.winner) {
         return null;
       }
@@ -266,12 +267,30 @@ function buildResolvedMatches(): Map<number, CopaMatch> {
   return resolved;
 }
 
-const RESOLVED_MATCHES = buildResolvedMatches();
+/**
+ * Builds a resolveMatchParticipants function bound to a specific results
+ * snapshot. Use this (with a freshly-fetched snapshot) for request-time
+ * resolution so the bracket reflects results without a new deploy.
+ */
+export function createCopaResolver(getResult: GetMatchResult): (match: CopaMatch) => CopaMatch {
+  const groupStandings = buildStandings(getResult);
+  const bestThirds = getBestThirds(groupStandings);
+  const thirdAssignments = buildThirdAssignments(bestThirds);
+  const resolvedMatches = buildResolvedMatches(groupStandings, thirdAssignments, getResult);
+
+  return function resolveMatchParticipants(match: CopaMatch): CopaMatch {
+    return resolvedMatches.get(match.id) ?? match;
+  };
+}
 
 /**
- * Returns the match with resolved homeId/awayId for knockout stages.
- * Group-stage matches are returned unchanged.
+ * Returns the match with resolved homeId/awayId for knockout stages, using
+ * the results snapshot bundled at build time.
+ *
+ * @deprecated for page rendering — prefer createCopaResolver() with a
+ * freshly-fetched results snapshot so the site reflects results without a
+ * new deploy. Still fine for the CI script and tests, which always run
+ * against fresh data.
  */
-export function resolveMatchParticipants(match: CopaMatch): CopaMatch {
-  return RESOLVED_MATCHES.get(match.id) ?? match;
-}
+export const resolveMatchParticipants: (match: CopaMatch) => CopaMatch =
+  createCopaResolver(getMatchResult);


### PR DESCRIPTION
## Problem

Production only rebuilds on a published GitHub Release. The scheduled `Update Copa Results` action (every 2h) commits straight to `main`, which only triggers a staging rebuild — never production. Throughout the Round of 32 we've had to manually publish a new release every time we wanted a score change to show up on the live site (#220, #224, #226).

## Fix

`/copa-do-mundo` now fetches `content/copa-resultados/results.json` directly from `main` at request time via Next.js ISR (`revalidate: 300`), instead of relying on the JSON snapshot bundled into the build. New results reach the live site within ~5 minutes of the scheduled action committing them — no release needed.

## Changes

- **`src/lib/shared/copa/results.ts`** — `getMatchResult`/`withResult` now accept a `GetMatchResult` accessor instead of only reading the module-level bundled snapshot. Added `fetchLiveResultsFile()`, which fetches the current `results.json` from GitHub with ISR revalidation and falls back to the bundled snapshot on failure.
- **`src/lib/shared/copa/standings.ts`** — broke the internal builder functions (`buildStandings`, `getBestThirds`, `buildThirdAssignments`, `buildResolvedMatches`) out of their module-level singletons so they can run against any results snapshot. Added `createCopaResolver()`, which builds a `resolveMatchParticipants` bound to a specific snapshot. The old `resolveMatchParticipants`/`getMatchResult` exports remain (backed by the bundled snapshot) for the CI script and tests, which always run against fresh data already — no behavior change there.
- **`src/app/copa-do-mundo/page.tsx`** — converted to an async Server Component. Fetches live results, resolves the bracket, and computes match results server-side, passing them as props to `CopaClient`.
- **`src/components/pages/copa/copa-client.tsx`** — now a purely presentational client component receiving `matches`/`matchesChrono` as props instead of computing them from static imports.

## Testing

- `npx next lint` on all four changed files → no errors
- `npx tsc --noEmit` → no new errors in copa-related files (pre-existing unrelated errors only)
- `npx jest src/lib/shared/copa/standings.test.ts` → all 4 tests pass unchanged, confirming the legacy `resolveMatchParticipants` singleton (used by the tests and the CI script) still behaves identically
- Didn't run a full local `next build` (requires DB setup unrelated to this change) — relying on this PR's Deploy Preview check to validate the Server Component/fetch flow in a real build

🤖 Generated with [Claude Code](https://claude.com/claude-code)