### PR TITLE
chore: prepare release v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-07-04
+
+### Changed
+- **Copa do Mundo 2026 – resultados em tempo real sem precisar de release**: `/copa-do-mundo` passou a buscar `content/copa-resultados/results.json` diretamente do branch `main` em tempo de requisição, via ISR do Next.js (revalidação a cada 5 minutos), em vez de depender do snapshot embutido no build. A partir de agora, um placar registrado pela action `Update Copa Results` (a cada 2h) chega ao site ao vivo sozinho, em poucos minutos — sem precisar publicar uma release manual, como vínhamos fazendo repetidamente ao longo da Rodada de 32.
+
 ## [1.10.5] - 2026-07-04
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aquario",
-  "version": "1.10.5",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aquario",
-      "version": "1.10.5",
+      "version": "1.11.0",
       "hasInstallScript": true,
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^7.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquario",
-  "version": "1.10.5",
+  "version": "1.11.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## What

Version bump (minor, per semver — this is an architectural change) and CHANGELOG entry for v1.11.0.

## Why

Publishes #228 (ISR-based live results fetching) to production.

## Changes

- `CHANGELOG.md` — new `[1.11.0] - 2026-07-04` section
- `package.json` / `package-lock.json` — version bumped `1.10.5` → `1.11.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)