### PR TITLE
fix(copa): correct USA x Belgium kickoff time (Jogo 94)

### DIFF
--- a/src/lib/shared/copa/matches.ts
+++ b/src/lib/shared/copa/matches.ts
@@ -982,7 +982,7 @@ export const COPA_MATCHES: CopaMatch[] = [
   },
   {
     id: 94,
-    kickoff: "2026-07-06T18:00:00-03:00",
+    kickoff: "2026-07-06T21:00:00-03:00",
     stage: "oitavas",
     homeId: null,
     awayId: null,


### PR DESCRIPTION
## Problem

Jogo 94 (Round of 16, USA x Belgium at Lumen Field, Seattle) showed the wrong kickoff time on `/copa-do-mundo`.

## Root cause

Stored as `2026-07-06T18:00:00-03:00` (18:00 Brasília time). Per FIFA's official schedule, this match kicks off at 8pm ET / 5pm PT on 2026-07-06, which converts to 21:00 Brasília time (UTC-3) — not 18:00. Venue was already correct.

## Fix

- `src/lib/shared/copa/matches.ts` — corrected Jogo 94's `kickoff` to `2026-07-06T21:00:00-03:00`.

## Testing

- `npx next lint` on the changed file → no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the kickoff time for one Copa match to reflect the latest schedule.
  * Adjusted the match ordering so the chronological view stays accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->