### PR TITLE
chore: prepare release v1.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.1] - 2026-07-06
+
+### Fixed
+- **Copa do Mundo 2026 – horário do Jogo 94 (EUA x Bélgica)**: Estava cadastrado às 18h no horário de Brasília; o horário oficial da FIFA é 20h ET / 17h PT em 06/07, equivalente a 21h em Brasília. Sede (Lumen Field, Seattle) já estava correta.
+
 ## [1.11.0] - 2026-07-04
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aquario",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aquario",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "hasInstallScript": true,
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^7.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquario",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## What

Version bump and CHANGELOG entry for v1.11.1.

## Why

Publishes #231 (USA x Belgium kickoff time fix) to production. Unlike `results.json`, `matches.ts` is still bundled at build time, so this needs a release to reach the live site.

## Changes

- `CHANGELOG.md` — new `[1.11.1] - 2026-07-06` section
- `package.json` / `package-lock.json` — version bumped `1.11.0` → `1.11.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)