### PR TITLE
fix: harden backend auth and public data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Permissões de entidade**: Rotas de edição de entidades, cargos e membros agora validam apenas membresias ADMIN ativas, impedindo que admins históricos mantenham permissões.
 - **Privacidade de usuários**: Endpoints públicos/de busca de usuários retornam um DTO sanitizado sem email, papel de plataforma, status de verificação ou permissões.
 - **Cadastro em produção**: Produção sem serviço de email configurado passa a bloquear cadastro em vez de auto-verificar usuários.
+- **Cadastro em produção**: Log de bloqueio por email indisponível não registra mais o email completo do usuário.
 - **Fotos de perfil**: Upload, atualização e remoção de foto só apagam o blob antigo depois que o banco deixa de referenciá-lo.
 - **Build com migrações**: `scripts/build-with-migrations.js` agora falha o build quando `prisma migrate deploy` falha.
 - **Dependências**: Atualizadas versões de Scalar API Reference, PostHog e Vitest para remover vulnerabilidades críticas/altas reportadas pelo `npm audit`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Perfis públicos**: `/usuarios/[slug]`, `/entidade/[slug]` e `/projetos/[id]` agora deduplicam leituras server-side entre metadata e página; perfis de usuário e entidade também hidratam o React Query com `initialData`.
+
+### Fixed
+- **Permissões de entidade**: Rotas de edição de entidades, cargos e membros agora validam apenas membresias ADMIN ativas, impedindo que admins históricos mantenham permissões.
+- **Privacidade de usuários**: Endpoints públicos/de busca de usuários retornam um DTO sanitizado sem email, papel de plataforma, status de verificação ou permissões.
+- **Cadastro em produção**: Produção sem serviço de email configurado passa a bloquear cadastro em vez de auto-verificar usuários.
+- **Fotos de perfil**: Upload, atualização e remoção de foto só apagam o blob antigo depois que o banco deixa de referenciá-lo.
+- **Build com migrações**: `scripts/build-with-migrations.js` agora falha o build quando `prisma migrate deploy` falha.
+- **Dependências**: Atualizadas versões de Scalar API Reference, PostHog e Vitest para remover vulnerabilidades críticas/altas reportadas pelo `npm audit`.
+
 ## [1.11.1] - 2026-07-06
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
-        "@scalar/api-reference-react": "0.9.20",
+        "@scalar/api-reference-react": "^0.9.54",
         "@tanstack/react-query": "^5.90.5",
         "@tanstack/react-query-devtools": "^5.90.2",
         "@tiptap/extension-blockquote": "^2.10.0",
@@ -59,7 +59,7 @@
         "next": "^15.5.9",
         "next-themes": "^0.3.0",
         "pdf-parse": "^1.1.1",
-        "posthog-js": "^1.284.0",
+        "posthog-js": "^1.398.6",
         "react": "^18",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18",
@@ -88,7 +88,7 @@
         "@typescript-eslint/eslint-plugin": "^8.46.1",
         "@typescript-eslint/parser": "^8.46.1",
         "@vitejs/plugin-react": "^5.0.4",
-        "@vitest/ui": "^3.2.4",
+        "@vitest/ui": "^4.1.10",
         "dotenv-cli": "^11.0.0",
         "eslint": "^9.39.2",
         "eslint-config-next": "^15.5.9",
@@ -107,7 +107,7 @@
         "tailwindcss": "^3.4.1",
         "tsx": "^4.19.0",
         "typescript": "^5.9.3",
-        "vitest": "^3.2.4"
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -267,12 +267,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -281,9 +281,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
-      "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -291,21 +291,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
-      "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.4",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -339,13 +339,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
-      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -355,14 +355,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -382,37 +382,37 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -432,27 +432,27 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -460,26 +460,26 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -769,31 +769,31 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
-      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -801,13 +801,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -821,9 +821,9 @@
       "license": "MIT"
     },
     "node_modules/@codemirror/autocomplete": {
-      "version": "6.20.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
-      "integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
+      "version": "6.20.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+      "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
@@ -833,13 +833,13 @@
       }
     },
     "node_modules/@codemirror/commands": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
-      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.4.tgz",
+      "integrity": "sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.6.0",
+        "@codemirror/state": "^6.7.0",
         "@codemirror/view": "^6.27.0",
         "@lezer/common": "^1.1.0"
       }
@@ -929,9 +929,9 @@
       }
     },
     "node_modules/@codemirror/language": {
-      "version": "6.12.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
-      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+      "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
@@ -943,32 +943,32 @@
       }
     },
     "node_modules/@codemirror/lint": {
-      "version": "6.9.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
-      "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+      "integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.35.0",
+        "@codemirror/view": "^6.42.0",
         "crelt": "^1.0.5"
       }
     },
     "node_modules/@codemirror/state": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
-      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
+      "integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
       "license": "MIT",
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.41.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.41.1.tgz",
-      "integrity": "sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg==",
+      "version": "6.43.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.6.tgz",
+      "integrity": "sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA==",
       "license": "MIT",
       "dependencies": {
-        "@codemirror/state": "^6.6.0",
+        "@codemirror/state": "^6.7.0",
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
@@ -1353,7 +1353,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1370,7 +1369,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1387,7 +1385,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1404,7 +1401,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1421,7 +1417,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1438,7 +1433,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1455,7 +1449,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1472,7 +1465,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1489,7 +1481,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1506,7 +1497,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1523,7 +1513,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1540,7 +1529,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1557,7 +1545,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1574,7 +1561,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1591,7 +1577,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1608,7 +1593,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1625,7 +1609,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1642,7 +1625,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1659,7 +1641,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1676,7 +1657,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1693,7 +1673,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1710,7 +1689,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1727,7 +1705,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1744,7 +1721,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1761,7 +1737,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1778,7 +1753,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1833,9 +1807,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1844,9 +1818,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1907,9 +1881,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1928,9 +1902,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1975,15 +1949,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -2607,18 +2572,18 @@
       }
     },
     "node_modules/@internationalized/date": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.1.tgz",
-      "integrity": "sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ==",
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.2.tgz",
+      "integrity": "sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@internationalized/number": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.6.tgz",
-      "integrity": "sha512-iFgmQaXHE0vytNfpLZWOC2mEJCBRzcUxt53Xf/yCXG93lRvqas237i3r7X4RKMwO3txiyZD4mQjKAByFv6UGSQ==",
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.7.tgz",
+      "integrity": "sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
@@ -2713,9 +2678,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3253,9 +3218,9 @@
       "license": "MIT"
     },
     "node_modules/@lezer/css": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.3.tgz",
-      "integrity": "sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.4.tgz",
+      "integrity": "sha512-N+tn9tej2hPvyKgHEApMOQfHczDJCwxrRFS3SPn9QjYN+uwHvEDnCgKRrb3mxDYxRS8sKMM8fhC3+lc04Abz5Q==",
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.2.0",
@@ -3337,9 +3302,9 @@
       }
     },
     "node_modules/@marijn/find-cluster-break": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
-      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+      "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
       "license": "MIT"
     },
     "node_modules/@mui/core-downloads-tracker": {
@@ -3586,9 +3551,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.9",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.9.tgz",
-      "integrity": "sha512-4GlTZ+EJM7WaW2HEZcyU317tIQDjkQIyENDLxYJfSWlfqguN+dHkZgyQTV/7ykvobU7yEH5gKvreNrH4B6QgIg==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.20.tgz",
+      "integrity": "sha512-dXh51Wvddf8daEyBXryZZEe1FdVxEWx9lgaTseLZUtC1XP/W8Wri+Z+VPOElHlByk23CyqHdc2oVByX7wsTWsw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -3632,9 +3597,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.7.tgz",
-      "integrity": "sha512-IZwtxCEpI91HVU/rAUOOobWSZv4P2DeTtNaCdHqLcTJU4wdNXgAySvKa/qJCgR5m6KI8UsKDXtO2B31jcaw1Yw==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.20.tgz",
+      "integrity": "sha512-in0yXG7/pRBVjWeEl7f7ZZETpletSMFKXVS4GJgHENTPVrJFNJKPrYewa9rpZcvdjwFece5fZP0CK34G4PxowA==",
       "cpu": [
         "arm64"
       ],
@@ -3648,9 +3613,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.7.tgz",
-      "integrity": "sha512-UP6CaDBcqaCBuiq/gfCEJw7sPEoX1aIjZHnBWN9v9qYHQdMKvCKcAVs4OX1vIjeE+tC5EIuwDTVIoXpUes29lg==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.20.tgz",
+      "integrity": "sha512-0hsFshdPnTzGJdDTHeHJ+XPUShOpnyp9pUFDwDhqctsA0Cd8NcIVGRPtptYhgYY9DjkKgCDRkXxmgRc+CgT5Wg==",
       "cpu": [
         "x64"
       ],
@@ -3664,9 +3629,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.7.tgz",
-      "integrity": "sha512-NCslw3GrNIw7OgmRBxHtdWFQYhexoUCq+0oS2ccjyYLtcn1SzGzeM54jpTFonIMUjNbHmpKpziXnpxhSWLcmBA==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.20.tgz",
+      "integrity": "sha512-DMvkoBtAABOzE6pMZRW/xNm7sKqql3wzzzZJ1R/d/rp4BCxv6LykouD3tHjGY8WdQqGpZs11t+R9AtjPxvvljw==",
       "cpu": [
         "arm64"
       ],
@@ -3680,9 +3645,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.7.tgz",
-      "integrity": "sha512-nfymt+SE5cvtTrG9u1wdoxBr9bVB7mtKTcj0ltRn6gkP/2Nu1zM5ei8rwP9qKQP0Y//umK+TtkKgNtfboBxRrw==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.20.tgz",
+      "integrity": "sha512-RQmDfeYBtXV2FSId7dfA1hE6M/T6+g7wdbYnFQ47tw/gUBwV+CccLVejNmCGa9yLDitk83foeg8hl/3DjfYQ5g==",
       "cpu": [
         "arm64"
       ],
@@ -3696,9 +3661,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.7.tgz",
-      "integrity": "sha512-hvXcZvCaaEbCZcVzcY7E1uXN9xWZfFvkNHwbe/n4OkRhFWrs1J1QV+4U1BN06tXLdaS4DazEGXwgqnu/VMcmqw==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.20.tgz",
+      "integrity": "sha512-DkWLEdKajJwdGt27M3i1VEO2kelTvZrK6Pcb7JvW2BY+nofWm7FBsBNDj7g7Pr1NuQ5PLJvqEqYa20GTsBDnKQ==",
       "cpu": [
         "x64"
       ],
@@ -3712,9 +3677,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.7.tgz",
-      "integrity": "sha512-4IUO539b8FmF0odY6/SqANJdgwn1xs1GkPO5doZugwZ3ETF6JUdckk7RGmsfSf7ws8Qb2YB5It33mvNL/0acqA==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.20.tgz",
+      "integrity": "sha512-rAO5b7pKHvX+ExdmJskusDXTNbiNZfptifIPZItbUx+AOXxxTydVBsPt7Oz84DRd5mY8e0DcE8kvLj3AIfjE6w==",
       "cpu": [
         "x64"
       ],
@@ -3728,9 +3693,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.7.tgz",
-      "integrity": "sha512-CpJVTkYI3ZajQkC5vajM7/ApKJUOlm6uP4BknM3XKvJ7VXAvCqSjSLmM0LKdYzn6nBJVSjdclx8nYJSa3xlTgQ==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.20.tgz",
+      "integrity": "sha512-Hp3zFsN8N8Kj9+vY6L4vnZ9EtA9eXyATu0q4EfGbZTiocgPUNSfz8NWhym6xvaOmHpJ8EuoypuU1WejCPsTFtg==",
       "cpu": [
         "arm64"
       ],
@@ -3744,9 +3709,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.7.tgz",
-      "integrity": "sha512-gMzgBX164I6DN+9/PGA+9dQiwmTkE4TloBNx8Kv9UiGARsr9Nba7IpcBRA1iTV9vwlYnrE3Uy6I7Aj6qLjQuqw==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.20.tgz",
+      "integrity": "sha512-T/L7CXpR1M0wij/xbF3rT1+7KvSkfOLr7C+ToHHWZTG2eKmb52C5WvsyGCBNtkVvDEUESWkRUbbqSH4rSbOCYQ==",
       "cpu": [
         "x64"
       ],
@@ -3811,243 +3776,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/api-logs": {
-      "version": "0.208.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
-      "integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/core": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
-      "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
-      "version": "0.208.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.208.0.tgz",
-      "integrity": "sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.208.0",
-        "@opentelemetry/core": "2.2.0",
-        "@opentelemetry/otlp-exporter-base": "0.208.0",
-        "@opentelemetry/otlp-transformer": "0.208.0",
-        "@opentelemetry/sdk-logs": "0.208.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.208.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.208.0.tgz",
-      "integrity": "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.2.0",
-        "@opentelemetry/otlp-transformer": "0.208.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.208.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.208.0.tgz",
-      "integrity": "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.208.0",
-        "@opentelemetry/core": "2.2.0",
-        "@opentelemetry/resources": "2.2.0",
-        "@opentelemetry/sdk-logs": "0.208.0",
-        "@opentelemetry/sdk-metrics": "2.2.0",
-        "@opentelemetry/sdk-trace-base": "2.2.0",
-        "protobufjs": "^7.3.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
-      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.2.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/resources": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.0.tgz",
-      "integrity": "sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.7.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.0.tgz",
-      "integrity": "sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.208.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.208.0.tgz",
-      "integrity": "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.208.0",
-        "@opentelemetry/core": "2.2.0",
-        "@opentelemetry/resources": "2.2.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
-      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.2.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.2.0.tgz",
-      "integrity": "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.2.0",
-        "@opentelemetry/resources": "2.2.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.9.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
-      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.2.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
-      "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.2.0",
-        "@opentelemetry/resources": "2.2.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
-      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.2.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
-      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@parcel/watcher": {
@@ -4393,10 +4121,19 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@posthog/core": {
+      "version": "1.39.6",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.39.6.tgz",
+      "integrity": "sha512-o6ajIwN5zXoNP0D4H/QPmOyibNTUkSyOR6ya7AG5U2ywXx4awo72L2KnCoiZPQM5x/bXv6jPBdimH8M18Ax0aw==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "^1.392.0"
+      }
+    },
     "node_modules/@posthog/types": {
-      "version": "1.363.2",
-      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.363.2.tgz",
-      "integrity": "sha512-UcUwHEd2LXxWq4bW/I4TbwYcA+BHO/cSuHcNpGXjRCp76eJk1eOuQnm/a3MrfHtbt2X11CQu+eWpqiSgcv+X6A==",
+      "version": "1.392.1",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.392.1.tgz",
+      "integrity": "sha512-Qg6Gl7/1vlr8+gPtBi5gwnLgAgiyFoKOVmTvTtDcvya9cpTwZfna7rQmkGQ4B63CunUYNNbOlqcwiUwUDyTK6w==",
       "license": "MIT"
     },
     "node_modules/@prisma/client": {
@@ -4422,37 +4159,37 @@
       }
     },
     "node_modules/@prisma/config": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.1.tgz",
-      "integrity": "sha512-bUL/aYkGXLwxVGhJmQMtslLT7KPEfUqmRa919fKI4wQFX4bIFUKiY8Jmio/2waAjjPYrtuDHa7EsNCnJTXxiOw==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.3.tgz",
+      "integrity": "sha512-CBPT44BjlQxEt8kiMEauji2WHTDoVBOKl7UlewXmUgBPnr/oPRZC3psci5chJnYmH0ivEIog2OU9PGWoki3DLQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "c12": "3.1.0",
         "deepmerge-ts": "7.1.5",
-        "effect": "3.18.4",
+        "effect": "3.21.0",
         "empathic": "2.0.0"
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.1.tgz",
-      "integrity": "sha512-h1JImhlAd/s5nhY/e9qkAzausWldbeT+e4nZF7A4zjDYBF4BZmKDt4y0jK7EZapqOm1kW7V0e9agV/iFDy3fWw==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.3.tgz",
+      "integrity": "sha512-ljkJ+SgpXNktLG0Q/n4JGYCkKf0f8oYLyjImS2I8e2q2WCfdRRtWER062ZV/ixaNP2M2VKlWXVJiGzZaUgbKZw==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.1.tgz",
-      "integrity": "sha512-xy95dNJ7DiPf9IJ3oaVfX785nbFl7oNDzclUF+DIiJw6WdWCvPl0LPU0YqQLsrwv8N64uOQkH391ujo3wSo+Nw==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.3.tgz",
+      "integrity": "sha512-RSYxtlYFl5pJ8ZePgMv0lZ9IzVCOdTPOegrs2qcbAEFrBI1G33h6wyC9kjQvo0DnYEhEVY0X4LsuFHXLKQk88g==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.19.1",
+        "@prisma/debug": "6.19.3",
         "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
-        "@prisma/fetch-engine": "6.19.1",
-        "@prisma/get-platform": "6.19.1"
+        "@prisma/fetch-engine": "6.19.3",
+        "@prisma/get-platform": "6.19.3"
       }
     },
     "node_modules/@prisma/engines-version": {
@@ -4463,90 +4200,26 @@
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.1.tgz",
-      "integrity": "sha512-mmgcotdaq4VtAHO6keov3db+hqlBzQS6X7tR7dFCbvXjLVTxBYdSJFRWz+dq7F9p6dvWyy1X0v8BlfRixyQK6g==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.3.tgz",
+      "integrity": "sha512-tKtl/qco9Nt7LU5iKhpultD8O4vMCZcU2CHjNTnRrL1QvSUr5W/GcyFPjNL87GtRrwBc7ubXXD9xy4EvLvt8JA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.19.1",
+        "@prisma/debug": "6.19.3",
         "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
-        "@prisma/get-platform": "6.19.1"
+        "@prisma/get-platform": "6.19.3"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.1.tgz",
-      "integrity": "sha512-zsg44QUiQAnFUyh6Fbt7c9HjMXHwFTqtrgcX7DAZmRgnkPyYT7Sh8Mn8D5PuuDYNtMOYcpLGg576MLfIORsBYw==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.3.tgz",
+      "integrity": "sha512-xFj1VcJ1N3MKooOQAGO0W5tsd0W2QzIvW7DD7c/8H14Zmp4jseeWAITm+w2LLoLrlhoHdPPh0NMZ8mfL6puoHA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.19.1"
+        "@prisma/debug": "6.19.3"
       }
-    },
-    "node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/codegen": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
-      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
-      }
-    },
-    "node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/utf8": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -6642,9 +6315,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.54.0.tgz",
-      "integrity": "sha512-OywsdRHrFvCdvsewAInDKCNyR3laPA2mc9bRYJ6LBp5IyvF3fvXbbNR0bSzHlZVFtn6E0xw2oZlyjg4rKCVcng==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
       "cpu": [
         "arm"
       ],
@@ -6656,9 +6329,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.54.0.tgz",
-      "integrity": "sha512-Skx39Uv+u7H224Af+bDgNinitlmHyQX1K/atIA32JP3JQw6hVODX5tkbi2zof/E69M1qH2UoN3Xdxgs90mmNYw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
       "cpu": [
         "arm64"
       ],
@@ -6670,9 +6343,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.54.0.tgz",
-      "integrity": "sha512-k43D4qta/+6Fq+nCDhhv9yP2HdeKeP56QrUUTW7E6PhZP1US6NDqpJj4MY0jBHlJivVJD5P8NxrjuobZBJTCRw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
       "cpu": [
         "arm64"
       ],
@@ -6684,9 +6357,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.54.0.tgz",
-      "integrity": "sha512-cOo7biqwkpawslEfox5Vs8/qj83M/aZCSSNIWpVzfU2CYHa2G3P1UN5WF01RdTHSgCkri7XOlTdtk17BezlV3A==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
       "cpu": [
         "x64"
       ],
@@ -6698,9 +6371,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.54.0.tgz",
-      "integrity": "sha512-miSvuFkmvFbgJ1BevMa4CPCFt5MPGw094knM64W9I0giUIMMmRYcGW/JWZDriaw/k1kOBtsWh1z6nIFV1vPNtA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
       "cpu": [
         "arm64"
       ],
@@ -6712,9 +6385,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.54.0.tgz",
-      "integrity": "sha512-KGXIs55+b/ZfZsq9aR026tmr/+7tq6VG6MsnrvF4H8VhwflTIuYh+LFUlIsRdQSgrgmtM3fVATzEAj4hBQlaqQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
       "cpu": [
         "x64"
       ],
@@ -6726,9 +6399,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.54.0.tgz",
-      "integrity": "sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
       "cpu": [
         "arm"
       ],
@@ -6740,9 +6413,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.54.0.tgz",
-      "integrity": "sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
       "cpu": [
         "arm"
       ],
@@ -6754,9 +6427,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.54.0.tgz",
-      "integrity": "sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
       "cpu": [
         "arm64"
       ],
@@ -6768,9 +6441,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.54.0.tgz",
-      "integrity": "sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
       "cpu": [
         "arm64"
       ],
@@ -6782,9 +6455,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.54.0.tgz",
-      "integrity": "sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
       "cpu": [
         "loong64"
       ],
@@ -6796,9 +6483,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.54.0.tgz",
-      "integrity": "sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
       "cpu": [
         "ppc64"
       ],
@@ -6810,9 +6511,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.54.0.tgz",
-      "integrity": "sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
       "cpu": [
         "riscv64"
       ],
@@ -6824,9 +6525,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.54.0.tgz",
-      "integrity": "sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
       "cpu": [
         "riscv64"
       ],
@@ -6838,9 +6539,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.54.0.tgz",
-      "integrity": "sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
       "cpu": [
         "s390x"
       ],
@@ -6852,9 +6553,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.54.0.tgz",
-      "integrity": "sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
       "cpu": [
         "x64"
       ],
@@ -6866,9 +6567,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.54.0.tgz",
-      "integrity": "sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
       "cpu": [
         "x64"
       ],
@@ -6879,10 +6580,24 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.54.0.tgz",
-      "integrity": "sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
       "cpu": [
         "arm64"
       ],
@@ -6894,9 +6609,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.54.0.tgz",
-      "integrity": "sha512-c2V0W1bsKIKfbLMBu/WGBz6Yci8nJ/ZJdheE0EwB73N3MvHYKiKGs3mVilX4Gs70eGeDaMqEob25Tw2Gb9Nqyw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
       "cpu": [
         "arm64"
       ],
@@ -6908,9 +6623,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.54.0.tgz",
-      "integrity": "sha512-woEHgqQqDCkAzrDhvDipnSirm5vxUXtSKDYTVpZG3nUdW/VVB5VdCYA2iReSj/u3yCZzXID4kuKG7OynPnB3WQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
       "cpu": [
         "ia32"
       ],
@@ -6922,9 +6637,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.54.0.tgz",
-      "integrity": "sha512-dzAc53LOuFvHwbCEOS0rPbXp6SIhAf2txMP5p6mGyOXXw5mWY8NGGbPMPrs4P1WItkfApDathBj/NzMLUZ9rtQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
       "cpu": [
         "x64"
       ],
@@ -6936,9 +6651,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.54.0.tgz",
-      "integrity": "sha512-hYT5d3YNdSh3mbCU1gwQyPgQd3T2ne0A3KG8KSBdav5TiBg6eInVmV+TeR5uHufiIgSFg0XsOWGW5/RhNcSvPg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
       "cpu": [
         "x64"
       ],
@@ -6964,100 +6679,70 @@
       "license": "MIT"
     },
     "node_modules/@scalar/agent-chat": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@scalar/agent-chat/-/agent-chat-0.10.1.tgz",
-      "integrity": "sha512-VjGMuuqtxgdxL59eOjaTEKTc8YYiBdegwuc4wiaFMdo6LLowkUDrx4PgwfO2DBZ032uBqZyjaWQemE0DA2CsSA==",
+      "version": "0.12.18",
+      "resolved": "https://registry.npmjs.org/@scalar/agent-chat/-/agent-chat-0.12.18.tgz",
+      "integrity": "sha512-auIe3JYVm6jgoT7pa4Za+lrLFnEa3CDb4ncZA9aAYztti8C6qSFGn8nBrAtm/RarljhPTYZg5dhqeXJ7zyOu7w==",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/vue": "3.0.33",
-        "@scalar/api-client": "2.41.0",
-        "@scalar/components": "0.21.3",
-        "@scalar/helpers": "0.4.3",
-        "@scalar/icons": "0.7.2",
-        "@scalar/json-magic": "0.12.5",
-        "@scalar/openapi-types": "0.7.0",
-        "@scalar/themes": "0.15.2",
-        "@scalar/types": "0.7.6",
-        "@scalar/use-toasts": "0.10.1",
-        "@scalar/workspace-store": "0.43.1",
+        "@scalar/api-client": "3.13.3",
+        "@scalar/components": "0.27.6",
+        "@scalar/helpers": "0.9.0",
+        "@scalar/icons": "0.7.3",
+        "@scalar/json-magic": "0.12.17",
+        "@scalar/openapi-types": "0.9.1",
+        "@scalar/schemas": "0.7.2",
+        "@scalar/themes": "0.16.2",
+        "@scalar/types": "0.16.2",
+        "@scalar/use-toasts": "0.10.2",
+        "@scalar/validation": "0.6.0",
+        "@scalar/workspace-store": "0.55.3",
         "@vueuse/core": "13.9.0",
         "ai": "6.0.33",
         "js-base64": "^3.7.8",
-        "neverpanic": "0.0.7",
+        "neverpanic": "0.0.8",
         "truncate-json": "3.0.1",
-        "vue": "^3.5.30",
-        "whatwg-mimetype": "4.0.0",
-        "zod": "^4.3.5"
+        "vue": "^3.5.30"
       },
       "engines": {
         "node": ">=22"
       }
     },
-    "node_modules/@scalar/agent-chat/node_modules/whatwg-mimetype": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@scalar/agent-chat/node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@scalar/api-client": {
-      "version": "2.41.0",
-      "resolved": "https://registry.npmjs.org/@scalar/api-client/-/api-client-2.41.0.tgz",
-      "integrity": "sha512-7olL0H8zESePpKSmJwalP0u2RK00qEUHL8gHDEukIyjVF0oDZK/JCCXPSCtg94A+kWTG+e6BMtjhp0WWIqf2dg==",
+      "version": "3.13.3",
+      "resolved": "https://registry.npmjs.org/@scalar/api-client/-/api-client-3.13.3.tgz",
+      "integrity": "sha512-m+5/L71PTk474VGl7daD+7Ue2DeQA/BPsXoWJAXzDTtOR7orySlktZ9WiaI3CbZZkjiukaICaOb9AvMotDOmIQ==",
       "license": "MIT",
       "dependencies": {
         "@headlessui/tailwindcss": "^0.2.2",
         "@headlessui/vue": "1.7.23",
-        "@scalar/components": "0.21.3",
-        "@scalar/draggable": "0.4.1",
-        "@scalar/helpers": "0.4.3",
-        "@scalar/icons": "0.7.2",
-        "@scalar/import": "0.5.4",
-        "@scalar/json-magic": "0.12.5",
-        "@scalar/oas-utils": "0.10.16",
-        "@scalar/object-utils": "1.3.4",
-        "@scalar/openapi-types": "0.7.0",
-        "@scalar/postman-to-openapi": "0.6.1",
-        "@scalar/sidebar": "0.8.18",
-        "@scalar/snippetz": "0.7.8",
-        "@scalar/themes": "0.15.2",
+        "@scalar/blocks": "0.1.4",
+        "@scalar/components": "0.27.6",
+        "@scalar/helpers": "0.9.0",
+        "@scalar/icons": "0.7.3",
+        "@scalar/oas-utils": "0.19.4",
+        "@scalar/openapi-types": "0.9.1",
+        "@scalar/sidebar": "0.9.29",
+        "@scalar/snippetz": "0.9.21",
+        "@scalar/themes": "0.16.2",
         "@scalar/typebox": "^0.1.3",
-        "@scalar/types": "0.7.6",
-        "@scalar/use-codemirror": "0.14.11",
-        "@scalar/use-hooks": "0.4.2",
-        "@scalar/use-toasts": "0.10.1",
-        "@scalar/workspace-store": "0.43.1",
-        "@types/har-format": "^1.2.16",
+        "@scalar/types": "0.16.2",
+        "@scalar/use-codemirror": "0.14.12",
+        "@scalar/use-hooks": "0.4.7",
+        "@scalar/use-toasts": "0.10.2",
+        "@scalar/workspace-store": "0.55.3",
         "@vueuse/core": "13.9.0",
         "@vueuse/integrations": "13.9.0",
         "focus-trap": "^7.8.0",
         "fuse.js": "^7.1.0",
         "js-base64": "^3.7.8",
-        "microdiff": "^1.5.0",
-        "monaco-editor": "0.54.0",
-        "monaco-yaml": "5.2.3",
+        "jsonc-parser": "3.3.1",
         "nanoid": "^5.1.6",
-        "posthog-js": "1.363.2",
         "pretty-ms": "^9.3.0",
         "radix-vue": "^1.9.17",
-        "shell-quote": "^1.8.3",
-        "type-fest": "^5.3.1",
-        "vite-plugin-monaco-editor": "^1.1.0",
+        "set-cookie-parser": "3.1.0",
         "vue": "^3.5.30",
-        "vue-router": "4.6.2",
-        "whatwg-mimetype": "4.0.0",
-        "yaml": "^2.8.0",
+        "yaml": "^2.8.3",
         "zod": "^4.3.5"
       },
       "engines": {
@@ -7065,9 +6750,9 @@
       }
     },
     "node_modules/@scalar/api-client/node_modules/nanoid": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.9.tgz",
-      "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==",
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
       "funding": [
         {
           "type": "github",
@@ -7082,81 +6767,59 @@
         "node": "^18 || >=20"
       }
     },
-    "node_modules/@scalar/api-client/node_modules/type-fest": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
-      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
-      "license": "(MIT OR CC0-1.0)",
-      "dependencies": {
-        "tagged-tag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@scalar/api-client/node_modules/whatwg-mimetype": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@scalar/api-client/node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@scalar/api-reference": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/@scalar/api-reference/-/api-reference-1.51.0.tgz",
-      "integrity": "sha512-CmyvtSM9YNTPit1ZxfYhfAp7MtE+KXUxOID4sIf8+Flfr5zFOHVAu1ww1WySszugWG/8xV4BCZuJZtHGwtQyHg==",
+      "version": "1.62.5",
+      "resolved": "https://registry.npmjs.org/@scalar/api-reference/-/api-reference-1.62.5.tgz",
+      "integrity": "sha512-6VZhjtXiYygWrh6llwg/pnKN7S4eWqINOGt2Fu7TQkCdNUKwZEq7/XiOTqzZvGp/1Uu60ne/9nJK+UbQTSVpBg==",
       "license": "MIT",
       "dependencies": {
         "@headlessui/vue": "1.7.23",
-        "@scalar/agent-chat": "0.10.1",
-        "@scalar/api-client": "2.41.0",
-        "@scalar/code-highlight": "0.3.2",
-        "@scalar/components": "0.21.3",
-        "@scalar/helpers": "0.4.3",
-        "@scalar/icons": "0.7.2",
-        "@scalar/oas-utils": "0.10.16",
-        "@scalar/sidebar": "0.8.18",
-        "@scalar/snippetz": "0.7.8",
-        "@scalar/themes": "0.15.2",
-        "@scalar/types": "0.7.6",
-        "@scalar/use-hooks": "0.4.2",
-        "@scalar/use-toasts": "0.10.1",
-        "@scalar/workspace-store": "0.43.1",
+        "@scalar/agent-chat": "0.12.18",
+        "@scalar/api-client": "3.13.3",
+        "@scalar/blocks": "0.1.4",
+        "@scalar/code-highlight": "0.4.1",
+        "@scalar/components": "0.27.6",
+        "@scalar/helpers": "0.9.0",
+        "@scalar/icons": "0.7.3",
+        "@scalar/oas-utils": "0.19.4",
+        "@scalar/schemas": "0.7.2",
+        "@scalar/sidebar": "0.9.29",
+        "@scalar/snippetz": "0.9.21",
+        "@scalar/themes": "0.16.2",
+        "@scalar/types": "0.16.2",
+        "@scalar/use-hooks": "0.4.7",
+        "@scalar/use-toasts": "0.10.2",
+        "@scalar/validation": "0.6.0",
+        "@scalar/workspace-store": "0.55.3",
         "@unhead/vue": "^2.1.4",
         "@vueuse/core": "13.9.0",
         "fuse.js": "^7.1.0",
-        "github-slugger": "2.0.0",
         "microdiff": "^1.5.0",
         "nanoid": "^5.1.6",
         "vue": "^3.5.30",
-        "yaml": "^2.8.0"
+        "yaml": "^2.8.3"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/api-reference-react": {
-      "version": "0.9.20",
-      "resolved": "https://registry.npmjs.org/@scalar/api-reference-react/-/api-reference-react-0.9.20.tgz",
-      "integrity": "sha512-syiRHB1XRdKWM2a0fbzUCPNb5nQa/WHl/SLYu7pF/GBT5MBO27fYjPx8BSGvXA5Vdt218cWgZofiu/T1mVKFiw==",
+      "version": "0.9.54",
+      "resolved": "https://registry.npmjs.org/@scalar/api-reference-react/-/api-reference-react-0.9.54.tgz",
+      "integrity": "sha512-DE2a4+IPX/f4rzrXHFfMObNaXEm65JNiyHHDTk4wghetc37jA1Zxb1y/P1P/YURAjiLFNVnPdoqy2pJtZiZYFg==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/api-reference": "1.51.0",
-        "@scalar/types": "0.7.6"
+        "@scalar/api-reference": "1.62.5",
+        "@scalar/types": "0.16.2"
       },
       "engines": {
         "node": ">=22"
@@ -7166,9 +6829,9 @@
       }
     },
     "node_modules/@scalar/api-reference/node_modules/nanoid": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.9.tgz",
-      "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==",
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
       "funding": [
         {
           "type": "github",
@@ -7183,15 +6846,47 @@
         "node": "^18 || >=20"
       }
     },
+    "node_modules/@scalar/asyncapi-upgrader": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@scalar/asyncapi-upgrader/-/asyncapi-upgrader-0.1.2.tgz",
+      "integrity": "sha512-h6NUhsctrhucrbO2XHWbTXp9EWt7eL5vvlsooUEw2bB014KSPd41JrBQ6t0h/dFdmhwxdbBI7Hmg9eZa/mlCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/helpers": "0.9.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/blocks": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@scalar/blocks/-/blocks-0.1.4.tgz",
+      "integrity": "sha512-L6fN2azd56pQK0VN7YTPpgKXGFlATOJmIdTFfr8+G74ZAhpNifGa/6jtNe9gsfwCYW5TYu+yhbGy62Jd8MLhSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/components": "0.27.6",
+        "@scalar/helpers": "0.9.0",
+        "@scalar/icons": "0.7.3",
+        "@scalar/snippetz": "0.9.21",
+        "@scalar/themes": "0.16.2",
+        "@scalar/types": "0.16.2",
+        "@scalar/workspace-store": "0.55.3",
+        "@types/har-format": "^1.2.16",
+        "js-base64": "^3.7.8",
+        "vue": "^3.5.30"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/@scalar/code-highlight": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@scalar/code-highlight/-/code-highlight-0.3.2.tgz",
-      "integrity": "sha512-K9Cr3uQ0Rga4MEwAd3Jd4qvWy/pL7LPzL+xjdrpKEfdPj3C96W9oFE9Ok9wnNxuvuGqlN6JEqTw8Kjy3LYo45w==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@scalar/code-highlight/-/code-highlight-0.4.1.tgz",
+      "integrity": "sha512-pnr8gbQuvSXu4fcPPNkFNjAxxMWiJLffN57lRgVN3FCk+Q8hKHWWT01ulAT1/0Kg3/VmgtObrMHhX2qYnpM9+g==",
       "license": "MIT",
       "dependencies": {
         "hast-util-to-text": "^4.0.2",
         "highlight.js": "^11.11.1",
-        "highlightjs-curl": "^1.3.0",
         "lowlight": "^3.3.0",
         "rehype-external-links": "^3.0.0",
         "rehype-format": "^5.0.1",
@@ -7211,73 +6906,43 @@
       }
     },
     "node_modules/@scalar/components": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/@scalar/components/-/components-0.21.3.tgz",
-      "integrity": "sha512-vOQyxImr6nbMDGUkIM4vs+DF0A26l33J+zYHAV4cm1X8FQ0huPW464EPDiD7csPkg79yF9vqblhFhyqq4u2dqw==",
+      "version": "0.27.6",
+      "resolved": "https://registry.npmjs.org/@scalar/components/-/components-0.27.6.tgz",
+      "integrity": "sha512-jXTv2VgYn7/13yCAGKtc/26LCnrQSULGjcnP0LasJDqkVKDdRm1StHDG5iRniqrIzS21gJ6YcNGokksdLIrgQw==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/utils": "0.2.10",
         "@floating-ui/vue": "1.1.9",
+        "@headlessui/tailwindcss": "^0.2.2",
         "@headlessui/vue": "1.7.23",
-        "@scalar/code-highlight": "0.3.2",
-        "@scalar/helpers": "0.4.3",
-        "@scalar/icons": "0.7.2",
-        "@scalar/themes": "0.15.2",
-        "@scalar/use-hooks": "0.4.2",
+        "@scalar/code-highlight": "0.4.1",
+        "@scalar/helpers": "0.9.0",
+        "@scalar/icons": "0.7.3",
+        "@scalar/themes": "0.16.2",
+        "@scalar/use-hooks": "0.4.7",
         "@vueuse/core": "13.9.0",
         "cva": "1.0.0-beta.4",
-        "nanoid": "^5.1.6",
         "radix-vue": "^1.9.17",
         "vue": "^3.5.30",
-        "vue-component-type-helpers": "^3.2.2"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@scalar/components/node_modules/nanoid": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.9.tgz",
-      "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      }
-    },
-    "node_modules/@scalar/draggable": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@scalar/draggable/-/draggable-0.4.1.tgz",
-      "integrity": "sha512-TvTiy0tB2ulfBL7jwrpnsf7Geqlq/tWaIopkyZLii9bZPxPX5y1o6fVJXMyjtsUo0FSzvB382kN4uPi1TK/Hww==",
-      "license": "MIT",
-      "dependencies": {
-        "vue": "^3.5.26"
+        "vue-component-type-helpers": "^3.2.6"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/helpers": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.4.3.tgz",
-      "integrity": "sha512-Gv2V7SFreLx3DltzF2lKXdaJSH5cP1LOyt9PxON1cSWGxkrs3sg93c1taEJsW24E9ckfYXkL5hjCAVLfAN3wQw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.9.0.tgz",
+      "integrity": "sha512-M34CLRCttqC1bXthI/QSzQj0s5C6nrU2PFWf/vOT3RpycbiGDGQbqR+5RfFzpOIQvRqbHfNdcRbeiZBw+vCbkQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/icons": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@scalar/icons/-/icons-0.7.2.tgz",
-      "integrity": "sha512-21L2y/D6oU7wZHHa9i6FK98cZ+XH4HX9+e69uNpvlp4awRUpz6ifNHOLlxI607bq+Yz4G313gnV0uyUHwZ/pig==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@scalar/icons/-/icons-0.7.3.tgz",
+      "integrity": "sha512-5uSUvumj6yJEAZT7/MKpgrkNl76waDXUpu0kUBBFJ83GhZirBIK+Z9SktShEvJT0+rk/j9Zaer3BHoEhYwAEBQ==",
       "license": "MIT",
       "dependencies": {
         "@phosphor-icons/core": "^2.1.1",
@@ -7301,212 +6966,84 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/@scalar/import": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@scalar/import/-/import-0.5.4.tgz",
-      "integrity": "sha512-EwqIC+cRzbGVg6w0P1tN0K/46hfb0rbHOTNwL4n7FmKxOH6zdbO5dCvlyh41rjOoc19keVGeq7oPg6o/6D6rBA==",
-      "license": "MIT",
-      "dependencies": {
-        "@scalar/helpers": "0.4.3",
-        "yaml": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
     "node_modules/@scalar/json-magic": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/@scalar/json-magic/-/json-magic-0.12.5.tgz",
-      "integrity": "sha512-MkGOjodEeQ7V7M78W6Oq+t3q1LaUR+SRLZLqFbU6s26Gc+12T+v89JXcHvd+3ug0xFVMg/kdczZ3O6miBhyNsA==",
+      "version": "0.12.17",
+      "resolved": "https://registry.npmjs.org/@scalar/json-magic/-/json-magic-0.12.17.tgz",
+      "integrity": "sha512-Vw2nrUDIjhvMP6vxFtkiiFlabJ6SyTtfn1BsOxgnr1hIB+/rkngMguiDzl5em21VjyfFGIoADia+QWKM2hdcdA==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.4.3",
+        "@scalar/helpers": "0.9.0",
         "pathe": "^2.0.3",
-        "yaml": "^2.8.0"
+        "yaml": "^2.8.3"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/oas-utils": {
-      "version": "0.10.16",
-      "resolved": "https://registry.npmjs.org/@scalar/oas-utils/-/oas-utils-0.10.16.tgz",
-      "integrity": "sha512-xez3QrGYjn4Dhl6blvcUUzbVR1IOQVQhDO54UuZJwKWbOT3brEyAeZBwzttWmWDe3uGazPF160mj7qBXlT6sDQ==",
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@scalar/oas-utils/-/oas-utils-0.19.4.tgz",
+      "integrity": "sha512-ne/Pio9NaTQTjAeJ0B7OXWNIy4ziJmMoeKRzmEvXLXJC15iDI3vJZzQJOOldg5MPVEIqHxC0NWICrwKB6nMERA==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.4.3",
-        "@scalar/json-magic": "0.12.5",
-        "@scalar/object-utils": "1.3.4",
-        "@scalar/openapi-parser": "0.25.8",
-        "@scalar/openapi-types": "0.7.0",
-        "@scalar/themes": "0.15.2",
-        "@scalar/types": "0.7.6",
-        "@scalar/workspace-store": "0.43.1",
-        "flatted": "^3.3.3",
-        "github-slugger": "2.0.0",
-        "type-fest": "^5.3.1",
+        "@scalar/helpers": "0.9.0",
+        "@scalar/themes": "0.16.2",
+        "@scalar/types": "0.16.2",
+        "@scalar/workspace-store": "0.55.3",
+        "flatted": "^3.4.0",
         "vue": "^3.5.30",
-        "yaml": "^2.8.0",
-        "zod": "^4.3.5"
+        "yaml": "^2.8.3"
       },
       "engines": {
         "node": ">=22"
-      }
-    },
-    "node_modules/@scalar/oas-utils/node_modules/type-fest": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
-      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
-      "license": "(MIT OR CC0-1.0)",
-      "dependencies": {
-        "tagged-tag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@scalar/oas-utils/node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@scalar/object-utils": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@scalar/object-utils/-/object-utils-1.3.4.tgz",
-      "integrity": "sha512-M3S6QgsMfSTgWgTQTS+m3+/pkpTlZmyWMFFUy/qWbQaD00qbR/OcftA7QIEPe6ToJgsNPHHS4+bOXzeLoJJBfQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@scalar/helpers": "0.4.3",
-        "flatted": "^3.3.3",
-        "just-clone": "^6.2.0",
-        "ts-deepmerge": "^7.0.3"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@scalar/openapi-parser": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@scalar/openapi-parser/-/openapi-parser-0.25.8.tgz",
-      "integrity": "sha512-09yGXQSMYVlxJkLIn9Nz2q7Du7/olHKhR4oU0/JgkOdcKBiixSeLmhcAm7Hmj2Z82xOYpF+ZJUTCzsh8DQv5Fg==",
-      "license": "MIT",
-      "dependencies": {
-        "@scalar/helpers": "0.4.3",
-        "@scalar/json-magic": "0.12.5",
-        "@scalar/openapi-types": "0.7.0",
-        "@scalar/openapi-upgrader": "0.2.4",
-        "ajv": "^8.17.1",
-        "ajv-draft-04": "^1.0.0",
-        "ajv-formats": "^3.0.1",
-        "jsonpointer": "^5.0.1",
-        "leven": "^4.0.0",
-        "yaml": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@scalar/openapi-parser/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@scalar/openapi-parser/node_modules/ajv-draft-04": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
-      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": "^8.5.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@scalar/openapi-parser/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
-    "node_modules/@scalar/openapi-parser/node_modules/leven": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/leven/-/leven-4.1.0.tgz",
-      "integrity": "sha512-KZ9W9nWDT7rF7Dazg8xyLHGLrmpgq2nVNFUckhqdW3szVP6YhCpp/RAnpmVExA9JvrMynjwSLVrEj3AepHR6ew==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@scalar/openapi-types": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@scalar/openapi-types/-/openapi-types-0.7.0.tgz",
-      "integrity": "sha512-kN0PwlJW0de4bwQ4ib+mBHzKJUvBCyR/gwU4zLEq6SCbj+GfgYUh+2a0/yl1WYVUiSkkwFsHjfmQ8KjhR3HK0Q==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@scalar/openapi-types/-/openapi-types-0.9.1.tgz",
+      "integrity": "sha512-gkGhSkxSzADaBiNg+ZAbJuwj+ZUmzP2Pg9CWZ7ZP+0fck2WjPeDDM7aAbouAm0aQQMF9xBjSPXSA9a/qTHYaTw==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/openapi-upgrader": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@scalar/openapi-upgrader/-/openapi-upgrader-0.2.4.tgz",
-      "integrity": "sha512-AcrF7BMxKCTHnT82SHbHun6dJO4XC9tS5gD7EJsr/7YwFkx9JtbtZCryJXtqWJ5c7i1v1KH4PRRjDga/hCULTQ==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@scalar/openapi-upgrader/-/openapi-upgrader-0.2.9.tgz",
+      "integrity": "sha512-D5b0rGLLZgmkO9mdW2j/ND1KBlH1u3RCpr87HPxv9P9ZSr6PtM5iLqFOJq0ACiaHjY2mikCrxgDmnUEhTzRpHQ==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/openapi-types": "0.7.0"
+        "@scalar/openapi-types": "0.9.1"
       },
       "engines": {
         "node": ">=22"
       }
     },
-    "node_modules/@scalar/postman-to-openapi": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@scalar/postman-to-openapi/-/postman-to-openapi-0.6.1.tgz",
-      "integrity": "sha512-YUEH33s1HCAkApSdIFNB5XUGxzp7D5U9X2kgMKlZSyN2fW+yAePonaq5S9E4wU/2swSm+PvL9B2gw02yPjecUA==",
+    "node_modules/@scalar/schemas": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@scalar/schemas/-/schemas-0.7.2.tgz",
+      "integrity": "sha512-6Ble6WcbiKgD3ypIva+wgZv1qIClmeEjXA6jrOo1bKpYUu6sh4e89LZxDK+LULa2jQl/2O5GEaa6aZ0ImlpkHg==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.4.3",
-        "@scalar/openapi-types": "0.7.0"
+        "@scalar/helpers": "0.9.0",
+        "@scalar/validation": "0.6.0"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/sidebar": {
-      "version": "0.8.18",
-      "resolved": "https://registry.npmjs.org/@scalar/sidebar/-/sidebar-0.8.18.tgz",
-      "integrity": "sha512-FtHXmSyXYXtM5Y3TPbBrVfhJgaGC3fFkJugZN/y5BzXZXQoKZyTmBMJk8jMkgaMp+0cvpEtKJfYuBJvoAxtFmA==",
+      "version": "0.9.29",
+      "resolved": "https://registry.npmjs.org/@scalar/sidebar/-/sidebar-0.9.29.tgz",
+      "integrity": "sha512-Xyq7hnkeABWYLdQ0QhxuK7EpwBKkCItyTCidmX2j8xeKw1/b/RWE95co5P09GtkjHs1g+ePU/P919WaSn80+CA==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/components": "0.21.3",
-        "@scalar/helpers": "0.4.3",
-        "@scalar/icons": "0.7.2",
-        "@scalar/themes": "0.15.2",
-        "@scalar/use-hooks": "0.4.2",
-        "@scalar/workspace-store": "0.43.1",
+        "@scalar/components": "0.27.6",
+        "@scalar/helpers": "0.9.0",
+        "@scalar/icons": "0.7.3",
+        "@scalar/themes": "0.16.2",
+        "@scalar/use-hooks": "0.4.7",
+        "@scalar/workspace-store": "0.55.3",
         "vue": "^3.5.30"
       },
       "engines": {
@@ -7514,12 +7051,13 @@
       }
     },
     "node_modules/@scalar/snippetz": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/@scalar/snippetz/-/snippetz-0.7.8.tgz",
-      "integrity": "sha512-1g037ajdeGepBKj6+At+6BGSW4OqwONq2NoonGDcpDkW01dInTJx9q8AatXT1qdVUwV1gAVOYjCHsmSxkZictw==",
+      "version": "0.9.21",
+      "resolved": "https://registry.npmjs.org/@scalar/snippetz/-/snippetz-0.9.21.tgz",
+      "integrity": "sha512-0XFKdiKh5OnBxnK/NCBxaXpva53MRpvW4o6T2SMEUd+/xVa4Xmz7oHCHoq2g86+uY4bmepG1kZ0ndapyQjg/vw==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/types": "0.7.6",
+        "@scalar/helpers": "0.9.0",
+        "@scalar/types": "0.16.2",
         "js-base64": "^3.7.8",
         "stringify-object": "^6.0.0"
       },
@@ -7528,9 +7066,9 @@
       }
     },
     "node_modules/@scalar/themes": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@scalar/themes/-/themes-0.15.2.tgz",
-      "integrity": "sha512-GA+cM2Lojv2sqwfB6yTerBAnBTfVzIzUZ3C8T4PP9snaLyy7b0CMoHtnDEqERX/NZiRfnrIWeEYGy09cDi0w4g==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@scalar/themes/-/themes-0.16.2.tgz",
+      "integrity": "sha512-4mAn7z2W5/ASi1OF06dqf04xjxTHnMzESC2E+qVMukJsEsV4kDlYSIfm/g5hwWxhqWsBMjorF9Dtlqd0ycJ92g==",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.1.6"
@@ -7540,9 +7078,9 @@
       }
     },
     "node_modules/@scalar/themes/node_modules/nanoid": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.9.tgz",
-      "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==",
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
       "funding": [
         {
           "type": "github",
@@ -7564,12 +7102,12 @@
       "license": "MIT"
     },
     "node_modules/@scalar/types": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.7.6.tgz",
-      "integrity": "sha512-n5d7neeGTY/yS36AwAv3FAyCnJbbLjMPwyuEXBLgxHcb5i8DXnNfwy1nzz8jx/EJ88i1zmQ8BuMs+207saHgNA==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.16.2.tgz",
+      "integrity": "sha512-QAlCtDVRsX/UV1N9ctLqPsKQy84eceFf4dMnTZM0JhaRfwS/Ovwp8oFf3POSpqQILNiqLFZLE6IV6p/5rNoAag==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.4.3",
+        "@scalar/helpers": "0.9.0",
         "nanoid": "^5.1.6",
         "type-fest": "^5.3.1",
         "zod": "^4.3.5"
@@ -7579,9 +7117,9 @@
       }
     },
     "node_modules/@scalar/types/node_modules/nanoid": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.9.tgz",
-      "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==",
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
       "funding": [
         {
           "type": "github",
@@ -7597,9 +7135,9 @@
       }
     },
     "node_modules/@scalar/types/node_modules/type-fest": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
-      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
         "tagged-tag": "^1.0.0"
@@ -7612,18 +7150,18 @@
       }
     },
     "node_modules/@scalar/types/node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@scalar/use-codemirror": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/@scalar/use-codemirror/-/use-codemirror-0.14.11.tgz",
-      "integrity": "sha512-5wtC4pUjzhy72j3aAueJg+fh9KflevJvXMn0YscsxiDTvqwIzeZcHe1N9VNtvzDXgLblEeBT6D0+Vs+boyExxg==",
+      "version": "0.14.12",
+      "resolved": "https://registry.npmjs.org/@scalar/use-codemirror/-/use-codemirror-0.14.12.tgz",
+      "integrity": "sha512-m+0tmVOHZVAybbcNEizR3m9RYOLtU59AStRkk29J5qaW4J+tsjrz4BDMceeTpoVawL/lxp2vDvQR+w/gKC3miQ==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.3",
@@ -7647,110 +7185,82 @@
       }
     },
     "node_modules/@scalar/use-hooks": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@scalar/use-hooks/-/use-hooks-0.4.2.tgz",
-      "integrity": "sha512-c12RFw75aqRFc2iXQDdm9cHk0E/bT8LTelgNQDR8Bhp7950Swssr10lWC61CWdOigjRth+ES61Jo8yGi5yUBwQ==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@scalar/use-hooks/-/use-hooks-0.4.7.tgz",
+      "integrity": "sha512-8zajxhnKMJuO1HF36y8TeVuSIol2pueYdRvITZTEY8TuRbnwxrvJZk25II7YpxGMORAEDr0bwNF88Dr+QUfw1w==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/use-toasts": "0.10.1",
+        "@scalar/use-toasts": "0.10.2",
+        "@scalar/validation": "0.6.0",
         "@vueuse/core": "13.9.0",
-        "cva": "1.0.0-beta.2",
-        "tailwind-merge": "3.4.0",
-        "vue": "^3.5.30",
-        "zod": "^4.3.5"
+        "cva": "1.0.0-beta.4",
+        "tailwind-merge": "3.5.0",
+        "vue": "^3.5.30"
       },
       "engines": {
         "node": ">=22"
       }
     },
-    "node_modules/@scalar/use-hooks/node_modules/cva": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/cva/-/cva-1.0.0-beta.2.tgz",
-      "integrity": "sha512-dqcOFe247I5pKxfuzqfq3seLL5iMYsTgo40Uw7+pKZAntPgFtR7Tmy59P5IVIq/XgB0NQWoIvYDt9TwHkuK8Cg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "clsx": "^2.1.1"
-      },
-      "funding": {
-        "url": "https://polar.sh/cva"
-      },
-      "peerDependencies": {
-        "typescript": ">= 4.5.5 < 6"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@scalar/use-hooks/node_modules/tailwind-merge": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
-      "integrity": "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
+      "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/dcastil"
       }
     },
-    "node_modules/@scalar/use-hooks/node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@scalar/use-toasts": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@scalar/use-toasts/-/use-toasts-0.10.1.tgz",
-      "integrity": "sha512-8fsDd4efEDF+EydA+1+np/ac2KsAXPR1LdTYtTUxpv8Uj1l7lUMT/T5A7xnR+wNKmyVREihb9KnGp3pSjO2kYg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@scalar/use-toasts/-/use-toasts-0.10.2.tgz",
+      "integrity": "sha512-1iHQFbDXv0YQRp13aa63S5EcTJ5K8T0ocnLxk+nziloPrLjKt6jdRt6vOHsLSv5sm9kFKcVKNQTQgialmKCOGA==",
       "license": "MIT",
       "dependencies": {
-        "vue": "^3.5.26",
-        "vue-sonner": "^1.0.3"
+        "vue": "^3.5.30",
+        "vue-sonner": "^1.3.2"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/validation": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@scalar/validation/-/validation-0.3.0.tgz",
-      "integrity": "sha512-4X/AP3JO23DuYxs1MMjn6IlT9gyrKPCuZj8ybTB9QIjC+3tSJLpQOwZg7HEyyz2HoVwOt9jdef2jO3RXW7DqTw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@scalar/validation/-/validation-0.6.0.tgz",
+      "integrity": "sha512-tpmmG+/xRE2Kn9RpflU3AIyZv08v10+E1ZrJCx7z6+/91zHVxy0M73kC1LT4/8PbYNt85ywyC8+n+D99JdMcGA==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@scalar/workspace-store": {
-      "version": "0.43.1",
-      "resolved": "https://registry.npmjs.org/@scalar/workspace-store/-/workspace-store-0.43.1.tgz",
-      "integrity": "sha512-R0V2PXMhjbfELRtiRfn6vNaLPJalo1AKUs1AkCvJZyMaCNHrGUH14rdhwAz790ahVjebY66VKdn19Q4x1t60uA==",
+      "version": "0.55.3",
+      "resolved": "https://registry.npmjs.org/@scalar/workspace-store/-/workspace-store-0.55.3.tgz",
+      "integrity": "sha512-qqSSq8OSxx582h/DSgMYH68iqzp+M8c9B+YGB7/qi5ZQK3TzazeCM1BVakkSbFYvD+X4FanV4V4x/aAhjv6MfQ==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.4.3",
-        "@scalar/json-magic": "0.12.5",
-        "@scalar/openapi-upgrader": "0.2.4",
-        "@scalar/snippetz": "0.7.8",
+        "@scalar/asyncapi-upgrader": "0.1.2",
+        "@scalar/helpers": "0.9.0",
+        "@scalar/json-magic": "0.12.17",
+        "@scalar/openapi-upgrader": "0.2.9",
+        "@scalar/schemas": "0.7.2",
+        "@scalar/snippetz": "0.9.21",
         "@scalar/typebox": "0.1.3",
-        "@scalar/types": "0.7.6",
-        "@scalar/validation": "0.3.0",
-        "github-slugger": "2.0.0",
+        "@scalar/types": "0.16.2",
+        "@scalar/validation": "0.6.0",
         "js-base64": "^3.7.8",
         "type-fest": "^5.3.1",
         "vue": "^3.5.30",
-        "yaml": "^2.8.0"
+        "yaml": "^2.8.3"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/workspace-store/node_modules/type-fest": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
-      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
         "tagged-tag": "^1.0.0"
@@ -7884,9 +7394,9 @@
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
-      "integrity": "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==",
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.3.tgz",
+      "integrity": "sha512-8Np/TFELpI0ySuJoVmjvOrQYXH/8sTX0Biv9szhFhY39xOdAAY+smrMxjxOum/ux3eM8MUJQsEJ0/R0UpvC8dw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -7894,12 +7404,12 @@
       }
     },
     "node_modules/@tanstack/vue-virtual": {
-      "version": "3.13.24",
-      "resolved": "https://registry.npmjs.org/@tanstack/vue-virtual/-/vue-virtual-3.13.24.tgz",
-      "integrity": "sha512-A0k2qF0zFSUStXSZkGXABouXr2Tw2Ztl/cVIYG9qy84uR8W7UNjAcX3DvzBS3YnDcwvLxab8v7dbmYBZ39itDA==",
+      "version": "3.13.31",
+      "resolved": "https://registry.npmjs.org/@tanstack/vue-virtual/-/vue-virtual-3.13.31.tgz",
+      "integrity": "sha512-wZMEoSf852jQqaf3Ika1J7PiBae6341LNy/2CxmIyn0XKDQXMuK41wVX+xp6G0yx8jyR95Ef+Tdr13DK7mbJtQ==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/virtual-core": "3.14.0"
+        "@tanstack/virtual-core": "3.17.3"
       },
       "funding": {
         "type": "github",
@@ -8540,9 +8050,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
     "node_modules/@types/estree-jsx": {
@@ -8819,6 +8329,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
@@ -9076,13 +8596,13 @@
       "license": "ISC"
     },
     "node_modules/@unhead/vue": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.1.13.tgz",
-      "integrity": "sha512-HYy0shaHRnLNW9r85gppO8IiGz0ONWVV3zGdlT8CQ0tbTwixznJCIiyqV4BSV1aIF1jJIye0pd1p/k6Eab8Z/A==",
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.1.15.tgz",
+      "integrity": "sha512-SSByXfEjhzPn8gXdEdgpYqpLMPSkLUH2HVE0GxZfOtNsJ0GgOHQs0g9T67ZZ1z0kTELLKdtOtYrzrbv9+ffF7g==",
       "license": "MIT",
       "dependencies": {
         "hookable": "^6.0.1",
-        "unhead": "2.1.13"
+        "unhead": "2.1.15"
       },
       "funding": {
         "url": "https://github.com/sponsors/harlan-zw"
@@ -9361,19 +8881,65 @@
       ]
     },
     "node_modules/@vercel/blob": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.0.0.tgz",
-      "integrity": "sha512-oAj7Pdy83YKSwIaMFoM7zFeLYWRc+qUpW3PiDSblxQMnGFb43qs4bmfq7dr/+JIfwhs6PTwe1o2YBwKhyjWxXw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.6.1.tgz",
+      "integrity": "sha512-KTJytw85j1XQBxjN5d6UXI7fIWNQe1jotn4nWN+0hePqLs+Qi1B3jHdQcSKFGF0m2rsy9uhPT6GOXMtHe3qNzg==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@vercel/oidc": "^3.6.1",
         "async-retry": "^1.3.3",
         "is-buffer": "^2.0.5",
         "is-node-process": "^1.2.0",
         "throttleit": "^2.1.0",
-        "undici": "^5.28.4"
+        "undici": "^6.23.0"
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@vercel/blob/node_modules/@vercel/oidc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.8.0.tgz",
+      "integrity": "sha512-r00laGW6Pv778RoR6M2NxX91ycSj+PBwVo+fOb9Bif+F0IyUKt25zrvBzfEzQpeAzbqOgPZyQibEWDdDFApd+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/cli-config": "0.2.0",
+        "@vercel/cli-exec": "1.0.0",
+        "jose": "^5.9.6"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@vercel/cli-config": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-config/-/cli-config-0.2.0.tgz",
+      "integrity": "sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xdg-app-paths": "5",
+        "zod": "4.1.11"
+      }
+    },
+    "node_modules/@vercel/cli-config/node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@vercel/cli-exec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-exec/-/cli-exec-1.0.0.tgz",
+      "integrity": "sha512-kQF8LGie/Hbdq9/psJxLE7owRTcqMQMhgybU04gCeR7cbQAr5t8OrjefDNColJv1QSSucFt4pLwRiARVmlOnug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "execa": "5.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@vercel/oidc": {
@@ -9407,39 +8973,40 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.4",
+        "@vitest/spy": "4.1.10",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.17"
+        "magic-string": "^0.30.21"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -9451,42 +9018,42 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^2.0.0"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
-        "pathe": "^2.0.3",
-        "strip-literal": "^3.0.0"
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "magic-string": "^0.30.17",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -9494,63 +9061,67 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^4.0.3"
-      },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/ui": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.2.4.tgz",
-      "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.10.tgz",
+      "integrity": "sha512-EOUqfXHTXtpSHsyLHH40ts3Ue+hRhSGwzwzMlK0dTEOLSDYyOXLyr5JDGmHQWhN2DYI30gw6dVx3cdgM9FZl+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
+        "@vitest/utils": "4.1.10",
         "fflate": "^0.8.2",
-        "flatted": "^3.3.3",
+        "flatted": "^3.4.2",
         "pathe": "^2.0.3",
-        "sirv": "^3.0.1",
-        "tinyglobby": "^0.2.14",
-        "tinyrainbow": "^2.0.0"
+        "sirv": "^3.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "3.2.4"
+        "vitest": "4.1.10"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "loupe": "^3.1.4",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vitest/utils/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.33.tgz",
-      "integrity": "sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.39.tgz",
+      "integrity": "sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.2",
-        "@vue/shared": "3.5.33",
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.5.39",
         "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
@@ -9575,29 +9146,29 @@
       "license": "MIT"
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
-      "integrity": "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.39.tgz",
+      "integrity": "sha512-oQPigALqYbNxTNPvNgSOe+czwVExfbVF02lz8jP0S3AXJiu3jxYDygNUiqSep4ezzW8XgnubqH63My2A7JR/vg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.33",
-        "@vue/shared": "3.5.33"
+        "@vue/compiler-core": "3.5.39",
+        "@vue/shared": "3.5.39"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.33.tgz",
-      "integrity": "sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.39.tgz",
+      "integrity": "sha512-d0ki86iOyN8LoZPBmk5SJWNwHP19CnDDCfuo//+2WJa2g5Ke0Jay983PIBIcSSzldC68I8DrD5GrHV3OSDfodg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.2",
-        "@vue/compiler-core": "3.5.33",
-        "@vue/compiler-dom": "3.5.33",
-        "@vue/compiler-ssr": "3.5.33",
-        "@vue/shared": "3.5.33",
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-core": "3.5.39",
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/compiler-ssr": "3.5.39",
+        "@vue/shared": "3.5.39",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
-        "postcss": "^8.5.10",
+        "postcss": "^8.5.15",
         "source-map-js": "^1.2.1"
       }
     },
@@ -9608,69 +9179,63 @@
       "license": "MIT"
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.33.tgz",
-      "integrity": "sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.39.tgz",
+      "integrity": "sha512-Ce7/wvwMHai74bdszfXExdazFigYnlF9zgCmEQUcM1j0fOymlouZ7XilTYNo8oUjhlnjYOZbGrcYKuqjz89Ucw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.33",
-        "@vue/shared": "3.5.33"
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/shared": "3.5.39"
       }
     },
-    "node_modules/@vue/devtools-api": {
-      "version": "6.6.4",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
-      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
-      "license": "MIT"
-    },
     "node_modules/@vue/reactivity": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.33.tgz",
-      "integrity": "sha512-p8UfIqyIhb0rYGlSgSBV+lPhF2iUSBcRy7enhTmPqKWadHy9kcOFYF1AejYBP9P+avnd3OBbD49DU4pLWX/94A==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.39.tgz",
+      "integrity": "sha512-TpsuBJ9gGlZa5d23XcM2y8EXanz9dZeVDQBXRwzy46ItgvM+rWpzs+UVM0wcRLxGvcav0HE5jz2gNL53xlRAog==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.5.33"
+        "@vue/shared": "3.5.39"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.33.tgz",
-      "integrity": "sha512-UpFF45RI9//a7rvq7RdOQblb4tup7hHG9QsmIrxkFQLzQ7R8/iNQ5LE15NhLZ1/WcHMU2b47u6P33CPUelHyIQ==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.39.tgz",
+      "integrity": "sha512-9GLtNyRvPAUMbX+7ono0RC2j0guo2LXVi8LvcmAooImACUKm0oFf0jjwbX8/H0AE/t1nxhAkn8RSl9PMCzzxZw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.33",
-        "@vue/shared": "3.5.33"
+        "@vue/reactivity": "3.5.39",
+        "@vue/shared": "3.5.39"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.33.tgz",
-      "integrity": "sha512-IOxMsAOwquhfITgmOgaPYl7/j8gKUxUFoflRc+u4LxyD3+783xne8vNta1PONVCvCV9A0w7hkyEepINDqfO0tw==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.39.tgz",
+      "integrity": "sha512-7Y6aAGboKcXAZ3ECuUy7RrS5yy2r47dhTp2SKaJmYxjopImaVFaNa5Ne66NwGovsrxVAl5S5rwc7m22UG7Lmww==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.33",
-        "@vue/runtime-core": "3.5.33",
-        "@vue/shared": "3.5.33",
+        "@vue/reactivity": "3.5.39",
+        "@vue/runtime-core": "3.5.39",
+        "@vue/shared": "3.5.39",
         "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.33.tgz",
-      "integrity": "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.39.tgz",
+      "integrity": "sha512-yZSakiAGw85rZfG7UM8akMnIF+FmeiNk47uvHf2nVBBSe+dIKUhZuZq9+XgJhbV3nS5Z4ALH23/MpXofW+mbcw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.33",
-        "@vue/shared": "3.5.33"
+        "@vue/compiler-ssr": "3.5.39",
+        "@vue/shared": "3.5.39"
       },
       "peerDependencies": {
-        "vue": "3.5.33"
+        "vue": "3.5.39"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.33.tgz",
-      "integrity": "sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.39.tgz",
+      "integrity": "sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==",
       "license": "MIT"
     },
     "node_modules/@vueuse/core": {
@@ -9829,9 +9394,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9844,45 +9409,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
-    },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -10394,9 +9920,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10472,6 +9998,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/builtin-modules": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
@@ -10525,16 +10064,6 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/call-bind": {
@@ -10646,18 +10175,11 @@
       }
     },
     "node_modules/chai": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
       "engines": {
         "node": ">=18"
       }
@@ -10727,16 +10249,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
-      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -11060,9 +10572,9 @@
       "license": "MIT"
     },
     "node_modules/confbox": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
-      "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -11095,9 +10607,9 @@
       "license": "MIT"
     },
     "node_modules/core-js": {
-      "version": "3.47.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.47.0.tgz",
-      "integrity": "sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
       "hasInstallScript": true,
       "license": "MIT",
       "funding": {
@@ -11136,9 +10648,9 @@
       }
     },
     "node_modules/cosmiconfig/node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "license": "ISC",
       "engines": {
         "node": ">= 6"
@@ -11385,16 +10897,6 @@
         }
       }
     },
-    "node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -11458,9 +10960,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "license": "MIT"
     },
     "node_modules/dequal": {
@@ -11605,9 +11107,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
-      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -11717,9 +11219,9 @@
       }
     },
     "node_modules/effect": {
-      "version": "3.18.4",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-3.18.4.tgz",
-      "integrity": "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.0.tgz",
+      "integrity": "sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -11916,9 +11418,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
       "dev": true,
       "license": "MIT"
     },
@@ -12270,9 +11772,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12304,9 +11806,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -12367,9 +11869,9 @@
       }
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12378,9 +11880,9 @@
       }
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -12468,9 +11970,9 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12492,9 +11994,9 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -12621,9 +12123,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12686,9 +12188,9 @@
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -12804,9 +12306,9 @@
       "license": "MIT"
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
-      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -12816,7 +12318,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
       "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
@@ -12840,7 +12341,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/exit-x": {
@@ -12872,9 +12372,9 @@
       }
     },
     "node_modules/expect-type": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
-      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -12882,9 +12382,9 @@
       }
     },
     "node_modules/exsolve": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
-      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
+      "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -12989,22 +12489,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -13094,9 +12578,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "license": "ISC"
     },
     "node_modules/focus-trap": {
@@ -13242,9 +12726,9 @@
       }
     },
     "node_modules/fuse.js": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.3.0.tgz",
-      "integrity": "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.4.2.tgz",
+      "integrity": "sha512-LVbzjD4WA6UP5B1UnP8wuaXJiLnqMdM/E4fiJXTJ5haJ5b/MBNsK29h2fm6swEoQaVQjvYFWKLE2RanyZIoRVQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10"
@@ -13371,7 +12855,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -13428,12 +12911,6 @@
       "bin": {
         "giget": "dist/cli.mjs"
       }
-    },
-    "node_modules/github-slugger": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
-      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
-      "license": "ISC"
     },
     "node_modules/glob": {
       "version": "10.5.0",
@@ -13531,36 +13008,36 @@
       }
     },
     "node_modules/happy-dom": {
-      "version": "20.0.11",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.0.11.tgz",
-      "integrity": "sha512-QsCdAUHAmiDeKeaNojb1OHOPF7NjcWPBR7obdu3NwH2a/oyQaLg5d0aaCy/9My6CdPChYF07dvz5chaXBGaD4g==",
+      "version": "20.10.6",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.6.tgz",
+      "integrity": "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/node": "^20.0.0",
+        "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
-        "whatwg-mimetype": "^3.0.0"
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
-    "node_modules/happy-dom/node_modules/@types/node": {
-      "version": "20.19.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.27.tgz",
-      "integrity": "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==",
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
-    },
-    "node_modules/happy-dom/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -13976,12 +13453,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/highlightjs-curl": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/highlightjs-curl/-/highlightjs-curl-1.3.0.tgz",
-      "integrity": "sha512-50UEfZq1KR0Lfk2Tr6xb/MUIZH3h10oNC0OTy9g7WELcs5Fgy/mKN1vEhuKTkKbdo8vr5F9GXstu2eLhApfQ3A==",
-      "license": "Apache-2.0"
-    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -14145,7 +13616,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
@@ -14192,9 +13662,9 @@
       }
     },
     "node_modules/identifier-regex": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/identifier-regex/-/identifier-regex-1.0.1.tgz",
-      "integrity": "sha512-ZrYyM0sozNPZlvBvE7Oq9Bn44n0qKGrYu5sQ0JzMUnjIhpgWYE2JB6aBoFwEYdPjqj7jPyxXTMJiHDOxDfd8yw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/identifier-regex/-/identifier-regex-1.1.0.tgz",
+      "integrity": "sha512-SLX4H/vtcYlYnL7XqnuJKHU7Z8517TgsW9nmQiGOgMCjQ8V/deLYu6bEmbGoXe7WMMhc9+EUGyFFneHja8KabA==",
       "license": "MIT",
       "dependencies": {
         "reserved-identifiers": "^1.0.0"
@@ -14217,9 +13687,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
-      "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -14653,13 +14123,13 @@
       }
     },
     "node_modules/is-identifier": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-identifier/-/is-identifier-1.0.1.tgz",
-      "integrity": "sha512-HQ5v4rEJ7REUV54bCd2l5FaD299SGDEn2UPoVXaTHAyGviLq2menVUD2udi3trQ32uvB6LdAh/0ck2EuizrtpA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-identifier/-/is-identifier-1.1.0.tgz",
+      "integrity": "sha512-NhOds0mDx9lJu+1lBRO0xbwFo5nobA7GCk/0e5xjr6+6XugX985+0OyGX35BNrTkPAsdLcIKg02HUQJOK8D8kw==",
       "license": "MIT",
       "dependencies": {
-        "identifier-regex": "^1.0.0",
-        "super-regex": "^1.0.0"
+        "identifier-regex": "^1.1.0",
+        "super-regex": "^1.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -14821,7 +14291,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -16009,9 +15478,9 @@
       }
     },
     "node_modules/jest-util/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -16150,10 +15619,19 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-base64": {
-      "version": "3.7.8",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
-      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.8.0.tgz",
+      "integrity": "sha512-65kvbemyZhj+ExQt1PEFyBEjL5vAHysu1lJdW1AwhhChkO8ZBPizYk/m9GVrpbS2Je1hF+UYZ+6KywqtZV8mHw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/js-tokens": {
@@ -16163,10 +15641,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -16302,15 +15790,6 @@
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "license": "MIT"
     },
-    "node_modules/jsonpointer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
-      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
@@ -16348,12 +15827,6 @@
       "engines": {
         "node": ">=4.0"
       }
-    },
-    "node_modules/just-clone": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/just-clone/-/just-clone-6.2.0.tgz",
-      "integrity": "sha512-1IynUYEc/HAwxhi3WDpIpxJbZpMCvvrrmZVqvj9EhpvbH8lls7HhdhiByjL7DkAaWlLIzpC0Xc/VPvy/UxLNjA==",
-      "license": "MIT"
     },
     "node_modules/jwa": {
       "version": "2.0.1",
@@ -16458,9 +15931,19 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -16831,12 +16314,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/long": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0"
-    },
     "node_modules/longest-streak": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
@@ -16858,13 +16335,6 @@
       "bin": {
         "loose-envify": "cli.js"
       }
-    },
-    "node_modules/loupe": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/lowlight": {
       "version": "3.3.0",
@@ -16976,14 +16446,24 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -17018,18 +16498,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/marked": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
-      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {
@@ -17341,7 +16809,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/merge2": {
@@ -17939,7 +17406,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -17969,13 +17435,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -18002,103 +17468,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/monaco-editor": {
-      "version": "0.54.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.54.0.tgz",
-      "integrity": "sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==",
-      "license": "MIT",
-      "dependencies": {
-        "dompurify": "3.1.7",
-        "marked": "14.0.0"
-      }
-    },
-    "node_modules/monaco-languageserver-types": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/monaco-languageserver-types/-/monaco-languageserver-types-0.4.0.tgz",
-      "integrity": "sha512-QQ3BZiU5LYkJElGncSNb5AKoJ/LCs6YBMCJMAz9EA7v+JaOdn3kx2cXpPTcZfKA5AEsR0vc97sAw+5mdNhVBmw==",
-      "license": "MIT",
-      "dependencies": {
-        "monaco-types": "^0.1.0",
-        "vscode-languageserver-protocol": "^3.0.0",
-        "vscode-uri": "^3.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/remcohaszing"
-      }
-    },
-    "node_modules/monaco-marker-data-provider": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/monaco-marker-data-provider/-/monaco-marker-data-provider-1.2.5.tgz",
-      "integrity": "sha512-5ZdcYukhPwgYMCvlZ9H5uWs5jc23BQ8fFF5AhSIdrz5mvYLsqGZ58ZLxTv8rCX6+AxdJ8+vxg1HVSk+F2bLosg==",
-      "license": "MIT",
-      "dependencies": {
-        "monaco-types": "^0.1.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/remcohaszing"
-      }
-    },
-    "node_modules/monaco-types": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/monaco-types/-/monaco-types-0.1.2.tgz",
-      "integrity": "sha512-8LwfrlWXsedHwAL41xhXyqzPibS8IqPuIXr9NdORhonS495c2/wky+sI1PRLvMCuiI0nqC2NH1six9hdiRY4Xg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/remcohaszing"
-      }
-    },
-    "node_modules/monaco-worker-manager": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/monaco-worker-manager/-/monaco-worker-manager-2.0.1.tgz",
-      "integrity": "sha512-kdPL0yvg5qjhKPNVjJoym331PY/5JC11aPJXtCZNwWRvBr6jhkIamvYAyiY5P1AWFmNOy0aRDRoMdZfa71h8kg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "monaco-editor": ">=0.30.0"
-      }
-    },
-    "node_modules/monaco-yaml": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/monaco-yaml/-/monaco-yaml-5.2.3.tgz",
-      "integrity": "sha512-GEplKC+YYmS0TOlJdv0FzbqkDN/IG2FSwEw+95myECVxTlhty2amwERYjzvorvJXmIagP1grd3Lleq7aQEJpPg==",
-      "license": "MIT",
-      "workspaces": [
-        "examples/*"
-      ],
-      "dependencies": {
-        "jsonc-parser": "^3.0.0",
-        "monaco-languageserver-types": "^0.4.0",
-        "monaco-marker-data-provider": "^1.0.0",
-        "monaco-types": "^0.1.0",
-        "monaco-worker-manager": "^2.0.0",
-        "path-browserify": "^1.0.0",
-        "prettier": "^2.0.0",
-        "vscode-languageserver-textdocument": "^1.0.0",
-        "vscode-languageserver-types": "^3.0.0",
-        "vscode-uri": "^3.0.0",
-        "yaml": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/remcohaszing"
-      },
-      "peerDependencies": {
-        "monaco-editor": ">=0.36"
-      }
-    },
-    "node_modules/monaco-yaml/node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/motion": {
@@ -18170,9 +17539,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "funding": [
         {
           "type": "github",
@@ -18211,21 +17580,18 @@
       "license": "MIT"
     },
     "node_modules/neverpanic": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/neverpanic/-/neverpanic-0.0.7.tgz",
-      "integrity": "sha512-GFRTSX2JAEATOCQYlyFkR+9FJPl0pD24toE1foqYAsL6aPLlRKn6L0UFOtJhZCxEbDv+SUsiW4AcPs9cIFwkFw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "typescript": "5"
-      }
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/neverpanic/-/neverpanic-0.0.8.tgz",
+      "integrity": "sha512-vVdkelrLxaow/fdWDumzNBO+jwm6X8bxeLJc34THtpj70u0C5QBkcV6CRCu2X726km7XD45N0A3QtYCla4RvKw==",
+      "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.5.9",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.9.tgz",
-      "integrity": "sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.20.tgz",
+      "integrity": "sha512-cvyS3/geydan1xLtE3FA8VCgdoQ/Gg/dlOldFkFCbB5VcVYJV7090hQLBnvTW2PwT76Z/dHdzDZCsVhZpoOlUA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.9",
+        "@next/env": "15.5.20",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -18238,14 +17604,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.7",
-        "@next/swc-darwin-x64": "15.5.7",
-        "@next/swc-linux-arm64-gnu": "15.5.7",
-        "@next/swc-linux-arm64-musl": "15.5.7",
-        "@next/swc-linux-x64-gnu": "15.5.7",
-        "@next/swc-linux-x64-musl": "15.5.7",
-        "@next/swc-win32-arm64-msvc": "15.5.7",
-        "@next/swc-win32-x64-msvc": "15.5.7",
+        "@next/swc-darwin-arm64": "15.5.20",
+        "@next/swc-darwin-x64": "15.5.20",
+        "@next/swc-linux-arm64-gnu": "15.5.20",
+        "@next/swc-linux-arm64-musl": "15.5.20",
+        "@next/swc-linux-x64-gnu": "15.5.20",
+        "@next/swc-linux-x64-musl": "15.5.20",
+        "@next/swc-win32-arm64-msvc": "15.5.20",
+        "@next/swc-win32-x64-msvc": "15.5.20",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {
@@ -18385,7 +17751,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.0.0"
@@ -18402,24 +17767,29 @@
       "license": "MIT"
     },
     "node_modules/nypm": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.2.tgz",
-      "integrity": "sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.8.tgz",
+      "integrity": "sha512-Q9K4Diu6l5u6xJQogeFSs/zKtyMSgFKFtRQV+tHP4kL7KPm2grpBU0dFIwFaXwNxN0MtfKWc43VpCugAa+LPsw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "citty": "^0.1.6",
-        "consola": "^3.4.2",
+        "citty": "^0.2.2",
         "pathe": "^2.0.3",
-        "pkg-types": "^2.3.0",
-        "tinyexec": "^1.0.1"
+        "tinyexec": "^1.2.4"
       },
       "bin": {
         "nypm": "dist/cli.mjs"
       },
       "engines": {
-        "node": "^14.16.0 || >=16.10.0"
+        "node": ">=18"
       }
+    },
+    "node_modules/nypm/node_modules/citty": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+      "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -18552,6 +17922,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -18573,7 +17957,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
@@ -18617,6 +18000,15 @@
       "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
       "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
       "license": "MIT"
+    },
+    "node_modules/os-paths": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/os-paths/-/os-paths-4.4.0.tgz",
+      "integrity": "sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0"
+      }
     },
     "node_modules/own-keys": {
       "version": "1.0.1",
@@ -18804,12 +18196,6 @@
         "url": "https://ko-fi.com/killymxi"
       }
     },
-    "node_modules/path-browserify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-      "license": "MIT"
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -18884,16 +18270,6 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
     },
-    "node_modules/pathval": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.16"
-      }
-    },
     "node_modules/pdf-parse": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
@@ -18939,9 +18315,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -19038,14 +18414,14 @@
       }
     },
     "node_modules/pkg-types": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
-      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "confbox": "^0.2.2",
-        "exsolve": "^1.0.7",
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
         "pathe": "^2.0.3"
       }
     },
@@ -19070,9 +18446,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "funding": [
         {
           "type": "opencollective",
@@ -19089,7 +18465,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -19198,42 +18574,19 @@
       "license": "MIT"
     },
     "node_modules/posthog-js": {
-      "version": "1.363.2",
-      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.363.2.tgz",
-      "integrity": "sha512-4ZEWMrymlFzjgDSmh25VeJQT//2XUFbfKqEPDNUW4dxcqWiVMo1+gJFy5YhJgVYS46OAXLbMcJgmuZBCnDIgVg==",
-      "license": "SEE LICENSE IN LICENSE",
+      "version": "1.398.6",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.398.6.tgz",
+      "integrity": "sha512-T86lyZ4Eqn0d0a1CJ9dTc+c1eVNw5qQb1JeomvTueYJ23JXYLEva4m9K/epFRoMtD3iqZ7tDD1jzRoaRH7wycA==",
+      "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
-        "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/api-logs": "^0.208.0",
-        "@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
-        "@opentelemetry/resources": "^2.2.0",
-        "@opentelemetry/sdk-logs": "^0.208.0",
-        "@posthog/core": "1.24.1",
-        "@posthog/types": "1.363.2",
-        "core-js": "^3.38.1",
+        "@posthog/core": "^1.39.6",
+        "@posthog/types": "^1.392.1",
+        "core-js": "^3.49.0",
         "dompurify": "^3.3.2",
         "fflate": "^0.4.8",
-        "preact": "^10.28.2",
+        "preact": "^10.29.3",
         "query-selector-shadow-dom": "^1.0.1",
-        "web-vitals": "^5.1.0"
-      }
-    },
-    "node_modules/posthog-js/node_modules/@posthog/core": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.24.1.tgz",
-      "integrity": "sha512-e8AciAnc6MRFws89ux8lJKFAaI03yEon0ASDoUO7yS91FVqbUGXYekObUUR3LHplcg+pmyiJBI0jolY0SFbGRA==",
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.6"
-      }
-    },
-    "node_modules/posthog-js/node_modules/dompurify": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
-      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
+        "web-vitals": "^5.3.0"
       }
     },
     "node_modules/posthog-js/node_modules/fflate": {
@@ -19243,13 +18596,21 @@
       "license": "MIT"
     },
     "node_modules/preact": {
-      "version": "10.29.1",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
-      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+      "version": "10.29.7",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz",
+      "integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
       }
     },
     "node_modules/prelude-ls": {
@@ -19344,15 +18705,15 @@
       }
     },
     "node_modules/prisma": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.1.tgz",
-      "integrity": "sha512-XRfmGzh6gtkc/Vq3LqZJcS2884dQQW3UhPo6jNRoiTW95FFQkXFg8vkYEy6og+Pyv0aY7zRQ7Wn1Cvr56XjhQQ==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.3.tgz",
+      "integrity": "sha512-++ZJ0ijLrDJF6hNB4t4uxg2br3fC4H9Yc9tcbjr2fcNFP3rh/SBNrAgjhsqBU4Ght8JPrVofG/ZkXfnSfnYsFg==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "6.19.1",
-        "@prisma/engines": "6.19.1"
+        "@prisma/config": "6.19.3",
+        "@prisma/engines": "6.19.3"
       },
       "bin": {
         "prisma": "build/index.js"
@@ -19597,30 +18958,6 @@
         "prosemirror-transform": "^1.1.0"
       }
     },
-    "node_modules/protobufjs": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
-      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.1",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.1",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -19800,9 +19137,9 @@
       }
     },
     "node_modules/radix-vue/node_modules/nanoid": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.9.tgz",
-      "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==",
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
       "funding": [
         {
           "type": "github",
@@ -20417,6 +19754,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -20568,13 +19906,13 @@
       "license": "MIT"
     },
     "node_modules/rollup": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.54.0.tgz",
-      "integrity": "sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -20584,28 +19922,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.54.0",
-        "@rollup/rollup-android-arm64": "4.54.0",
-        "@rollup/rollup-darwin-arm64": "4.54.0",
-        "@rollup/rollup-darwin-x64": "4.54.0",
-        "@rollup/rollup-freebsd-arm64": "4.54.0",
-        "@rollup/rollup-freebsd-x64": "4.54.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.54.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.54.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.54.0",
-        "@rollup/rollup-linux-arm64-musl": "4.54.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.54.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.54.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.54.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.54.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.54.0",
-        "@rollup/rollup-linux-x64-gnu": "4.54.0",
-        "@rollup/rollup-linux-x64-musl": "4.54.0",
-        "@rollup/rollup-openharmony-arm64": "4.54.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.54.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.54.0",
-        "@rollup/rollup-win32-x64-gnu": "4.54.0",
-        "@rollup/rollup-win32-x64-msvc": "4.54.0",
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
         "fsevents": "~2.3.2"
       }
     },
@@ -20813,6 +20154,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/set-cookie-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
+      "license": "MIT"
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -20936,18 +20283,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {
@@ -21257,9 +20592,9 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
     },
@@ -21575,7 +20910,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -21606,26 +20940,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/strip-literal": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
-      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^9.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/strip-literal/node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/style-mod": {
       "version": "4.1.3",
@@ -21786,9 +21100,9 @@
       }
     },
     "node_modules/tabbable": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
-      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
       "license": "MIT"
     },
     "node_modules/tagged-tag": {
@@ -21987,9 +21301,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -22020,9 +21334,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -22094,9 +21408,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -22137,9 +21451,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -22148,30 +21462,10 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/tinypool": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
     "node_modules/tinyrainbow": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tinyspy": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
-      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -22353,15 +21647,6 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
-      }
-    },
-    "node_modules/ts-deepmerge": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-7.0.3.tgz",
-      "integrity": "sha512-Du/ZW2RfwV/D4cmA5rXafYjBQVuvu4qGiEEla4EmEHVHgRdx68Gftx7i66jn2bzHPwSVZY36Ae6OuDn9el4ZKA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=14.13.1"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -22550,6 +21835,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -22585,15 +21871,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
@@ -22603,9 +21886,9 @@
       "license": "MIT"
     },
     "node_modules/unhead": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.1.13.tgz",
-      "integrity": "sha512-jO9M1sI6b2h/1KpIu4Jeu+ptumLmUKboRRLxys5pYHFeT+lqTzfNHbYUX9bxVDhC1FBszAGuWcUVlmvIPsah8Q==",
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.1.15.tgz",
+      "integrity": "sha512-MCt5T90mCWyr3Z6pUCdM9lVRXoMoVBlL7z7U4CYVIiaDiuzad/UCfLuMqz5MeNmpZUgoBCQnrucJimU7EZR+XA==",
       "license": "MIT",
       "dependencies": {
         "hookable": "^6.0.1"
@@ -22925,13 +22208,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
-      "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
@@ -22999,38 +22282,6 @@
         }
       }
     },
-    "node_modules/vite-node": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.4.1",
-        "es-module-lexer": "^1.7.0",
-        "pathe": "^2.0.3",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vite-plugin-monaco-editor": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-monaco-editor/-/vite-plugin-monaco-editor-1.1.0.tgz",
-      "integrity": "sha512-IvtUqZotrRoVqwT0PBBDIZPNraya3BxN/bfcNfnxZ5rkJiGcNtO5eAOWWSgT7zullIAEqQwxMU83yL9J5k7gww==",
-      "license": "MIT",
-      "peerDependencies": {
-        "monaco-editor": ">=0.33.0"
-      }
-    },
     "node_modules/vite/node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -23050,9 +22301,9 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -23063,65 +22314,79 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "debug": "^4.4.1",
-        "expect-type": "^1.2.1",
-        "magic-string": "^0.30.17",
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
         "pathe": "^2.0.3",
-        "picomatch": "^4.0.2",
-        "std-env": "^3.9.0",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.14",
-        "tinypool": "^1.1.1",
-        "tinyrainbow": "^2.0.0",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-        "vite-node": "3.2.4",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@types/debug": "^4.1.12",
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
           "optional": true
         },
-        "@types/debug": {
+        "@opentelemetry/api": {
           "optional": true
         },
         "@types/node": {
           "optional": true
         },
-        "@vitest/browser": {
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
           "optional": true
         },
         "@vitest/ui": {
@@ -23132,13 +22397,16 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },
     "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -23148,61 +22416,17 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/vitest/node_modules/tinyexec": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/vscode-jsonrpc": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
-      "license": "MIT",
-      "dependencies": {
-        "vscode-jsonrpc": "8.2.0",
-        "vscode-languageserver-types": "3.17.5"
-      }
-    },
-    "node_modules/vscode-languageserver-textdocument": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
-      "license": "MIT"
-    },
-    "node_modules/vscode-languageserver-types": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
-      "license": "MIT"
-    },
-    "node_modules/vscode-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
-      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
-      "license": "MIT"
-    },
     "node_modules/vue": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.33.tgz",
-      "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.39.tgz",
+      "integrity": "sha512-xmZCYabFGcirU8r0fTuvl/LICc1OU620rnqepaJDL/a141ZigkG7AyaxQLdqJ02ZRYzWe6YPaDHeQx7MfknQfA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.33",
-        "@vue/compiler-sfc": "3.5.33",
-        "@vue/runtime-dom": "3.5.33",
-        "@vue/server-renderer": "3.5.33",
-        "@vue/shared": "3.5.33"
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/compiler-sfc": "3.5.39",
+        "@vue/runtime-dom": "3.5.39",
+        "@vue/server-renderer": "3.5.39",
+        "@vue/shared": "3.5.39"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -23214,25 +22438,10 @@
       }
     },
     "node_modules/vue-component-type-helpers": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.2.7.tgz",
-      "integrity": "sha512-+gPp5YGmhfsj1IN+xUo7y0fb4clfnOiiUA39y07yW1VzCRjzVgwLbtmdWlghh7mXrPsEaYc7rrIir/HT6C8vYQ==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.3.7.tgz",
+      "integrity": "sha512-Skkhw9agYSgsWqv7bxSOGJZa9SaiJbZVGdXuFWnrzKaQYHnw9qbjD630rw6RyMqDbp54nfLCLw5SZA55if7JLg==",
       "license": "MIT"
-    },
-    "node_modules/vue-router": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.2.tgz",
-      "integrity": "sha512-my83mxQKXyCms9EegBXZldehOihxBjgSjZqrZwgg4vBacNGl0oBCO+xT//wgOYpLV1RW93ZfqxrjTozd+82nbA==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/devtools-api": "^6.6.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/posva"
-      },
-      "peerDependencies": {
-        "vue": "^3.5.0"
-      }
     },
     "node_modules/vue-sonner": {
       "version": "1.3.2",
@@ -23280,9 +22489,9 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.2.0.tgz",
-      "integrity": "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
       "license": "Apache-2.0"
     },
     "node_modules/web-worker": {
@@ -23599,9 +22808,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -23618,6 +22827,31 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xdg-app-paths": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/xdg-app-paths/-/xdg-app-paths-5.5.1.tgz",
+      "integrity": "sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1",
+        "xdg-portable": "^7.2.0"
+      },
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
+    "node_modules/xdg-portable": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/xdg-portable/-/xdg-portable-7.3.0.tgz",
+      "integrity": "sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6.0"
       }
     },
     "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
-    "@scalar/api-reference-react": "0.9.20",
+    "@scalar/api-reference-react": "^0.9.54",
     "@tanstack/react-query": "^5.90.5",
     "@tanstack/react-query-devtools": "^5.90.2",
     "@tiptap/extension-blockquote": "^2.10.0",
@@ -88,7 +88,7 @@
     "next": "^15.5.9",
     "next-themes": "^0.3.0",
     "pdf-parse": "^1.1.1",
-    "posthog-js": "^1.284.0",
+    "posthog-js": "^1.398.6",
     "react": "^18",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18",
@@ -117,7 +117,7 @@
     "@typescript-eslint/eslint-plugin": "^8.46.1",
     "@typescript-eslint/parser": "^8.46.1",
     "@vitejs/plugin-react": "^5.0.4",
-    "@vitest/ui": "^3.2.4",
+    "@vitest/ui": "^4.1.10",
     "dotenv-cli": "^11.0.0",
     "eslint": "^9.39.2",
     "eslint-config-next": "^15.5.9",
@@ -136,7 +136,7 @@
     "tailwindcss": "^3.4.1",
     "tsx": "^4.19.0",
     "typescript": "^5.9.3",
-    "vitest": "^3.2.4"
+    "vitest": "^4.1.10"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"

--- a/scripts/build-with-migrations.js
+++ b/scripts/build-with-migrations.js
@@ -32,9 +32,8 @@ if (hasDatabase) {
     console.log("✅ Migrations applied successfully\n");
   } catch (_error) {
     console.error("❌ Migration failed!");
-    console.error("   This might be OK if migrations were already applied.");
-    console.error("   Continuing with build...\n");
-    // Don't fail the build if migrations fail - let the app start and show the error
+    console.error("   Aborting build because the deployed schema may be incompatible.\n");
+    process.exit(1);
   }
 } else {
   console.log("⏭️  No DATABASE_URL set, skipping migrations (frontend-only mode)\n");

--- a/src/app/api/entidades/[id]/cargos/route.ts
+++ b/src/app/api/entidades/[id]/cargos/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 export const dynamic = "force-dynamic";
 import { z } from "zod";
-import { withAuth } from "@/lib/server/services/auth/middleware";
+import { canManageEntidade, withAuth } from "@/lib/server/services/auth/middleware";
 import { getContainer } from "@/lib/server/container";
 import { ApiError, fromZodError } from "@/lib/server/errors";
 import { createCargoSchema, updateCargoSchema } from "@/lib/server/api-schemas/entidades";
@@ -41,14 +41,9 @@ export async function POST(request: Request, context: RouteContext) {
         return ApiError.entidadeNotFound();
       }
 
-      // Check if user has permission (MASTER_ADMIN or entidade ADMIN)
-      const isMasterAdmin = usuario.papelPlataforma === "MASTER_ADMIN";
-      const isEntidadeAdmin = entidade.membros?.some(
-        (m: { usuario: { id: string }; papel: string }) =>
-          m.usuario.id === usuario.id && m.papel === "ADMIN"
-      );
+      const canManage = await canManageEntidade(usuario, entidadeId);
 
-      if (!isMasterAdmin && !isEntidadeAdmin) {
+      if (!canManage) {
         return ApiError.forbidden("Você não tem permissão para criar cargos nesta entidade.");
       }
 
@@ -100,14 +95,9 @@ export async function PUT(request: Request, context: RouteContext) {
         return ApiError.entidadeNotFound();
       }
 
-      // Check if user has permission (MASTER_ADMIN or entidade ADMIN)
-      const isMasterAdmin = usuario.papelPlataforma === "MASTER_ADMIN";
-      const isEntidadeAdmin = entidade.membros?.some(
-        (m: { usuario: { id: string }; papel: string }) =>
-          m.usuario.id === usuario.id && m.papel === "ADMIN"
-      );
+      const canManage = await canManageEntidade(usuario, entidadeId);
 
-      if (!isMasterAdmin && !isEntidadeAdmin) {
+      if (!canManage) {
         return ApiError.forbidden("Você não tem permissão para atualizar cargos nesta entidade.");
       }
 
@@ -153,14 +143,9 @@ export async function DELETE(request: Request, context: RouteContext) {
         return ApiError.entidadeNotFound();
       }
 
-      // Check if user has permission (MASTER_ADMIN or entidade ADMIN)
-      const isMasterAdmin = usuario.papelPlataforma === "MASTER_ADMIN";
-      const isEntidadeAdmin = entidade.membros?.some(
-        (m: { usuario: { id: string }; papel: string }) =>
-          m.usuario.id === usuario.id && m.papel === "ADMIN"
-      );
+      const canManage = await canManageEntidade(usuario, entidadeId);
 
-      if (!isMasterAdmin && !isEntidadeAdmin) {
+      if (!canManage) {
         return ApiError.forbidden("Você não tem permissão para deletar cargos nesta entidade.");
       }
 

--- a/src/app/api/entidades/[id]/membros/[membroId]/__tests__/manage-member.test.ts
+++ b/src/app/api/entidades/[id]/membros/[membroId]/__tests__/manage-member.test.ts
@@ -6,6 +6,7 @@ import type { UsuarioWithRelations } from "@/lib/server/db/interfaces/types";
 const mockVerifyToken = jest.fn();
 const mockUserFindById = jest.fn();
 const mockEntidadeFindById = jest.fn();
+const mockFindActiveByUsuarioAndEntidade = jest.fn();
 const mockFindByEntidadeAndMembro = jest.fn();
 const mockCargoExistsInEntidade = jest.fn();
 const mockMembroUpdate = jest.fn();
@@ -20,6 +21,7 @@ jest.mock("@/lib/server/container", () => ({
     usuariosRepository: { findById: mockUserFindById },
     entidadesRepository: { findById: mockEntidadeFindById },
     membrosRepository: {
+      findActiveByUsuarioAndEntidade: mockFindActiveByUsuarioAndEntidade,
       findByEntidadeAndMembro: mockFindByEntidadeAndMembro,
       cargoExistsInEntidade: mockCargoExistsInEntidade,
       update: mockMembroUpdate,
@@ -91,6 +93,7 @@ beforeEach(() => {
   mockVerifyToken.mockReturnValue({ sub: "caller-1" });
   mockUserFindById.mockResolvedValue(makeUsuario());
   mockEntidadeFindById.mockResolvedValue(makeEntidade());
+  mockFindActiveByUsuarioAndEntidade.mockResolvedValue(null);
   mockFindByEntidadeAndMembro.mockResolvedValue(makeMembro());
   mockCargoExistsInEntidade.mockResolvedValue(true);
   mockMembroUpdate.mockResolvedValue(makeMembro());
@@ -119,9 +122,10 @@ describe("PUT /api/entidades/[id]/membros/[membroId]", () => {
   it("allows entity ADMIN to update members", async () => {
     const entityAdmin = makeUsuario({ id: "caller-1", papelPlataforma: "USER" });
     mockUserFindById.mockResolvedValue(entityAdmin);
-    mockEntidadeFindById.mockResolvedValue(
-      makeEntidade([{ usuario: { id: "caller-1" }, papel: "ADMIN" }])
-    );
+    mockFindActiveByUsuarioAndEntidade.mockResolvedValue({
+      id: "caller-membership",
+      papel: "ADMIN",
+    });
 
     const response = await PUT(
       makePutRequest({ papel: "ADMIN" }),
@@ -134,9 +138,6 @@ describe("PUT /api/entidades/[id]/membros/[membroId]", () => {
   it("returns 403 for non-admin users", async () => {
     const regularUser = makeUsuario({ id: "caller-1", papelPlataforma: "USER" });
     mockUserFindById.mockResolvedValue(regularUser);
-    mockEntidadeFindById.mockResolvedValue(
-      makeEntidade([{ usuario: { id: "caller-1" }, papel: "MEMBRO" }])
-    );
 
     const response = await PUT(
       makePutRequest({ papel: "ADMIN" }),
@@ -212,9 +213,10 @@ describe("DELETE /api/entidades/[id]/membros/[membroId]", () => {
   it("deletes membership as entity admin", async () => {
     const entityAdmin = makeUsuario({ id: "caller-1", papelPlataforma: "USER" });
     mockUserFindById.mockResolvedValue(entityAdmin);
-    mockEntidadeFindById.mockResolvedValue(
-      makeEntidade([{ usuario: { id: "caller-1" }, papel: "ADMIN" }])
-    );
+    mockFindActiveByUsuarioAndEntidade.mockResolvedValue({
+      id: "caller-membership",
+      papel: "ADMIN",
+    });
 
     const response = await DELETE(makeDeleteRequest(), makeContext("ent-1", "membro-1"));
 

--- a/src/app/api/entidades/[id]/membros/[membroId]/route.ts
+++ b/src/app/api/entidades/[id]/membros/[membroId]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 export const dynamic = "force-dynamic";
 import { z } from "zod";
-import { withAuth } from "@/lib/server/services/auth/middleware";
+import { canManageEntidade, withAuth } from "@/lib/server/services/auth/middleware";
 import { getContainer } from "@/lib/server/container";
 import { ApiError, fromZodError } from "@/lib/server/errors";
 import { updateMemberSchema } from "@/lib/server/api-schemas/entidades";
@@ -26,14 +26,9 @@ export async function PUT(request: Request, context: RouteContext) {
         return ApiError.entidadeNotFound();
       }
 
-      // Check if user has permission (MASTER_ADMIN or entidade ADMIN)
-      const isMasterAdmin = usuario.papelPlataforma === "MASTER_ADMIN";
-      const isEntidadeAdmin = entidade.membros?.some(
-        (m: { usuario: { id: string }; papel: string }) =>
-          m.usuario.id === usuario.id && m.papel === "ADMIN"
-      );
+      const canManage = await canManageEntidade(usuario, entidadeId);
 
-      if (!isMasterAdmin && !isEntidadeAdmin) {
+      if (!canManage) {
         return ApiError.forbidden("Você não tem permissão para editar membros desta entidade.");
       }
 
@@ -114,14 +109,9 @@ export async function DELETE(request: Request, context: RouteContext) {
         return ApiError.entidadeNotFound();
       }
 
-      // Check if user has permission (MASTER_ADMIN or entidade ADMIN)
-      const isMasterAdmin = usuario.papelPlataforma === "MASTER_ADMIN";
-      const isEntidadeAdmin = entidade.membros?.some(
-        (m: { usuario: { id: string }; papel: string }) =>
-          m.usuario.id === usuario.id && m.papel === "ADMIN"
-      );
+      const canManage = await canManageEntidade(usuario, entidadeId);
 
-      if (!isMasterAdmin && !isEntidadeAdmin) {
+      if (!canManage) {
         return ApiError.forbidden("Você não tem permissão para deletar membros desta entidade.");
       }
 

--- a/src/app/api/entidades/[id]/membros/__tests__/add-member.test.ts
+++ b/src/app/api/entidades/[id]/membros/__tests__/add-member.test.ts
@@ -121,9 +121,9 @@ describe("POST /api/entidades/[id]/membros", () => {
   it("adds member as entity ADMIN (not platform admin)", async () => {
     const entityAdmin = makeUsuario({ id: "caller-1", papelPlataforma: "USER" });
     mockUserFindById.mockResolvedValue(entityAdmin);
-    mockEntidadeFindById.mockResolvedValue(
-      makeEntidade([{ usuario: { id: "caller-1" }, papel: "ADMIN" }])
-    );
+    mockFindActiveByUsuarioAndEntidade
+      .mockResolvedValueOnce({ id: "caller-membership", papel: "ADMIN" })
+      .mockResolvedValueOnce(null);
 
     const response = await POST(makeRequest(validBody), makeContext("ent-1"));
 
@@ -133,9 +133,6 @@ describe("POST /api/entidades/[id]/membros", () => {
   it("returns 403 when user is neither platform admin nor entity admin", async () => {
     const regularUser = makeUsuario({ id: "caller-1", papelPlataforma: "USER" });
     mockUserFindById.mockResolvedValue(regularUser);
-    mockEntidadeFindById.mockResolvedValue(
-      makeEntidade([{ usuario: { id: "caller-1" }, papel: "MEMBRO" }])
-    );
 
     const response = await POST(makeRequest(validBody), makeContext("ent-1"));
 

--- a/src/app/api/entidades/[id]/membros/route.ts
+++ b/src/app/api/entidades/[id]/membros/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 export const dynamic = "force-dynamic";
 import { z } from "zod";
 import { getContainer } from "@/lib/server/container";
-import { withAuth } from "@/lib/server/services/auth/middleware";
+import { canManageEntidade, withAuth } from "@/lib/server/services/auth/middleware";
 import { ApiError, fromZodError } from "@/lib/server/errors";
 import { addMemberSchema } from "@/lib/server/api-schemas/entidades";
 
@@ -26,14 +26,9 @@ export async function POST(request: Request, context: RouteContext) {
         return ApiError.entidadeNotFound();
       }
 
-      // Check if user has permission (MASTER_ADMIN or entidade ADMIN)
-      const isMasterAdmin = usuario.papelPlataforma === "MASTER_ADMIN";
-      const isEntidadeAdmin = entidade.membros?.some(
-        (m: { usuario: { id: string }; papel: string }) =>
-          m.usuario.id === usuario.id && m.papel === "ADMIN"
-      );
+      const canManage = await canManageEntidade(usuario, entidadeId);
 
-      if (!isMasterAdmin && !isEntidadeAdmin) {
+      if (!canManage) {
         return ApiError.forbidden("Você não tem permissão para adicionar membros a esta entidade.");
       }
 

--- a/src/app/api/entidades/[id]/route.ts
+++ b/src/app/api/entidades/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 export const dynamic = "force-dynamic";
 import { z } from "zod";
 import { getContainer } from "@/lib/server/container";
-import { withAuth } from "@/lib/server/services/auth/middleware";
+import { canManageEntidade, withAuth } from "@/lib/server/services/auth/middleware";
 import { ApiError, fromZodError } from "@/lib/server/errors";
 import { updateEntidadeSchema } from "@/lib/server/api-schemas/entidades";
 
@@ -25,13 +25,9 @@ export function PUT(request: Request, context: RouteContext) {
         return ApiError.entidadeNotFound();
       }
 
-      // Check if user has permission to edit (admin or member of entidade)
-      const isAdmin = usuario.papelPlataforma === "MASTER_ADMIN";
-      const isMember = entidade.membros?.some(
-        m => m.usuario.id === usuario.id && m.papel === "ADMIN"
-      );
+      const canManage = await canManageEntidade(usuario, id);
 
-      if (!isAdmin && !isMember) {
+      if (!canManage) {
         return ApiError.forbidden("Você não tem permissão para editar esta entidade.");
       }
 

--- a/src/app/api/upload/photo/route.ts
+++ b/src/app/api/upload/photo/route.ts
@@ -52,15 +52,6 @@ export async function POST(request: Request) {
       const timestamp = Date.now();
       const filename = `photos/${usuario.id}-${timestamp}.${extension}`;
 
-      // Delete old photo from storage if it exists
-      if (oldPhotoUrl) {
-        try {
-          await blobStorage.delete(oldPhotoUrl);
-        } catch (error) {
-          log.warn("Could not delete old photo", { url: oldPhotoUrl, error: String(error) });
-        }
-      }
-
       // Upload new file
       uploadedUrl = await blobStorage.upload(file, filename, file.type);
 
@@ -70,15 +61,15 @@ export async function POST(request: Request) {
       // Fetch updated user to return
       const updatedUser = await usuariosRepository.findById(usuario.id);
       if (!updatedUser) {
-        // If we can't fetch the user, try to clean up the uploaded file
-        if (uploadedUrl) {
-          try {
-            await blobStorage.delete(uploadedUrl);
-          } catch (cleanupError) {
-            log.error("Failed to cleanup uploaded file after user fetch error", cleanupError);
-          }
-        }
         return ApiError.internal("Erro ao buscar usuário atualizado.");
+      }
+
+      if (oldPhotoUrl) {
+        try {
+          await blobStorage.delete(oldPhotoUrl);
+        } catch (error) {
+          log.warn("Could not delete old photo", { url: oldPhotoUrl, error: String(error) });
+        }
       }
 
       return NextResponse.json(formatUserResponse(updatedUser));

--- a/src/app/api/usuarios/me/photo/route.ts
+++ b/src/app/api/usuarios/me/photo/route.ts
@@ -22,20 +22,6 @@ export async function PATCH(request: Request) {
 
       const { usuariosRepository, blobStorage } = getContainer();
 
-      // If updating to a new photo, delete the old one if it exists
-      if (usuario.urlFotoPerfil && usuario.urlFotoPerfil !== urlFotoPerfil) {
-        // Only delete if it's from our blob storage (not external URLs)
-        try {
-          await blobStorage.delete(usuario.urlFotoPerfil);
-        } catch (error) {
-          // Ignore errors when deleting old photo (might be external URL)
-          log.warn("Could not delete old photo", {
-            url: usuario.urlFotoPerfil,
-            error: String(error),
-          });
-        }
-      }
-
       // Update user's photo URL
       await usuariosRepository.updateFotoPerfil(usuario.id, urlFotoPerfil ?? null);
 
@@ -43,6 +29,18 @@ export async function PATCH(request: Request) {
       const updatedUser = await usuariosRepository.findById(usuario.id);
       if (!updatedUser) {
         return ApiError.internal("Erro ao buscar usuário atualizado.");
+      }
+
+      // Delete the old photo only after the database no longer points to it.
+      if (usuario.urlFotoPerfil && usuario.urlFotoPerfil !== urlFotoPerfil) {
+        try {
+          await blobStorage.delete(usuario.urlFotoPerfil);
+        } catch (error) {
+          log.warn("Could not delete old photo", {
+            url: usuario.urlFotoPerfil,
+            error: String(error),
+          });
+        }
       }
 
       return NextResponse.json(formatUserResponse(updatedUser));
@@ -66,16 +64,6 @@ export async function DELETE(request: Request) {
     try {
       const { usuariosRepository, blobStorage } = getContainer();
 
-      // Delete the photo from storage if it exists
-      if (usuario.urlFotoPerfil) {
-        try {
-          await blobStorage.delete(usuario.urlFotoPerfil);
-        } catch (error) {
-          // Ignore errors when deleting (might be external URL or already deleted)
-          log.warn("Could not delete photo", { url: usuario.urlFotoPerfil, error: String(error) });
-        }
-      }
-
       // Update user's photo URL to null
       await usuariosRepository.updateFotoPerfil(usuario.id, null);
 
@@ -83,6 +71,15 @@ export async function DELETE(request: Request) {
       const updatedUser = await usuariosRepository.findById(usuario.id);
       if (!updatedUser) {
         return ApiError.internal("Erro ao buscar usuário atualizado.");
+      }
+
+      // Delete the photo from storage after the database no longer references it.
+      if (usuario.urlFotoPerfil) {
+        try {
+          await blobStorage.delete(usuario.urlFotoPerfil);
+        } catch (error) {
+          log.warn("Could not delete photo", { url: usuario.urlFotoPerfil, error: String(error) });
+        }
       }
 
       return NextResponse.json(formatUserResponse(updatedUser));

--- a/src/app/api/usuarios/route.ts
+++ b/src/app/api/usuarios/route.ts
@@ -2,39 +2,10 @@ import { NextResponse } from "next/server";
 export const dynamic = "force-dynamic";
 import { withAdmin, withAuth } from "@/lib/server/services/auth/middleware";
 import { getContainer } from "@/lib/server/container";
-
-const mapUserToResponse = (u: {
-  id: string;
-  nome: string;
-  email: string | null;
-  slug: string | null;
-  papelPlataforma: string;
-  eVerificado: boolean;
-  eFacade: boolean;
-  urlFotoPerfil: string | null;
-  centro: { id: string; nome: string; sigla: string };
-  curso: { id: string; nome: string };
-  permissoes: string[];
-}) => ({
-  id: u.id,
-  nome: u.nome,
-  email: u.email,
-  slug: u.slug,
-  papelPlataforma: u.papelPlataforma,
-  eVerificado: u.eVerificado,
-  eFacade: u.eFacade,
-  urlFotoPerfil: u.urlFotoPerfil,
-  centro: {
-    id: u.centro.id,
-    nome: u.centro.nome,
-    sigla: u.centro.sigla,
-  },
-  curso: {
-    id: u.curso.id,
-    nome: u.curso.nome,
-  },
-  permissoes: u.permissoes,
-});
+import {
+  formatPublicUserResponse,
+  formatUserResponse,
+} from "@/lib/server/utils/format-user-response";
 
 export function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -52,7 +23,7 @@ export function GET(request: Request) {
         limit: searchLimit,
       });
 
-      const mappedUsers = usuarios.map(mapUserToResponse);
+      const mappedUsers = usuarios.map(formatPublicUserResponse);
       return NextResponse.json({
         users: mappedUsers,
         pagination: {
@@ -83,7 +54,7 @@ export function GET(request: Request) {
       });
 
       return NextResponse.json({
-        users: users.map(mapUserToResponse),
+        users: users.map(formatUserResponse),
         pagination: {
           page: pageNum,
           limit: limitNum,
@@ -95,6 +66,6 @@ export function GET(request: Request) {
 
     // Default: return all users (for backward compatibility)
     const usuarios = await usuariosRepository.findMany();
-    return NextResponse.json(usuarios.map(mapUserToResponse));
+    return NextResponse.json(usuarios.map(formatUserResponse));
   });
 }

--- a/src/app/api/usuarios/slug/[slug]/route.ts
+++ b/src/app/api/usuarios/slug/[slug]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 export const dynamic = "force-dynamic";
 import { getContainer } from "@/lib/server/container";
-import { formatUserResponse } from "@/lib/server/utils/format-user-response";
+import { formatPublicUserResponse } from "@/lib/server/utils/format-user-response";
 import { ApiError } from "@/lib/server/errors";
 
 type RouteContext = {
@@ -19,7 +19,7 @@ export async function GET(_request: Request, context: RouteContext) {
       return ApiError.userNotFound();
     }
 
-    return NextResponse.json(formatUserResponse(usuario));
+    return NextResponse.json(formatPublicUserResponse(usuario));
   } catch {
     return ApiError.internal("Erro ao buscar usuário");
   }

--- a/src/app/entidade/[slug]/entidade-detail-client.tsx
+++ b/src/app/entidade/[slug]/entidade-detail-client.tsx
@@ -22,15 +22,27 @@ import { mapProjetoToCard } from "@/lib/client/mappers/projeto-mapper";
 import { Layers } from "lucide-react";
 import Link from "next/link";
 import { trackEvent } from "@/analytics/posthog-client";
+import type { Entidade } from "@/lib/shared/types";
 
-export default function EntidadeDetailClient({ slug }: { slug: string }) {
+type EntidadeDetailClientProps = {
+  slug: string;
+  initialData?: Entidade;
+};
+
+export default function EntidadeDetailClient({ slug, initialData }: EntidadeDetailClientProps) {
   const { data: user } = useCurrentUser();
   const router = useRouter();
   const queryClient = useQueryClient();
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
 
   // Use React Query hooks
-  const { data: entidade, isLoading, error: queryError } = useEntidadeBySlug(slug);
+  const {
+    data: entidade,
+    isLoading,
+    error: queryError,
+  } = useEntidadeBySlug(slug, {
+    initialData,
+  });
   const { data: allEntidades = [] } = useEntidades();
 
   // Compute other entidades of the same type

--- a/src/app/entidade/[slug]/page.tsx
+++ b/src/app/entidade/[slug]/page.tsx
@@ -1,7 +1,10 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { cache } from "react";
 import { getContainer } from "@/lib/server/container";
+import type { EntidadeWithRelations } from "@/lib/server/db/interfaces/types";
 import { jsonLdScriptContent } from "@/lib/server/utils/seo";
+import type { Entidade, TipoEntidade } from "@/lib/shared/types";
 import EntidadeDetailClient from "./entidade-detail-client";
 
 type PageProps = {
@@ -13,13 +16,109 @@ const TIPO_LABEL: Record<string, string> = {
   GRUPO: "Grupo",
   LIGA_ACADEMICA: "Liga Acadêmica",
   EMPRESA_JUNIOR: "Empresa Júnior",
+  EMPRESA: "Empresa",
+  ATLETICA: "Atlética",
   CENTRO_ACADEMICO: "Centro Acadêmico",
   OUTRO: "Entidade",
 };
 
+const VALID_TIPOS: TipoEntidade[] = [
+  "LABORATORIO",
+  "GRUPO",
+  "LIGA_ACADEMICA",
+  "CENTRO_ACADEMICO",
+  "ATLETICA",
+  "EMPRESA",
+  "OUTRO",
+];
+
+const getEntidadeBySlug = cache(async (slug: string) => {
+  return await getContainer().entidadesRepository.findBySlug(slug);
+});
+
+function mapImagePath(urlFoto: string | null | undefined): string {
+  if (!urlFoto) {
+    return "/api/content-images/assets/entidades/default.png";
+  }
+
+  if (urlFoto.startsWith("/") || urlFoto.startsWith("http")) {
+    return urlFoto;
+  }
+
+  return `/api/content-images/assets/entidades/${urlFoto}`;
+}
+
+function normalizeTipo(tipo: string): TipoEntidade {
+  return VALID_TIPOS.includes(tipo as TipoEntidade) ? (tipo as TipoEntidade) : "OUTRO";
+}
+
+function getOrder(entidade: EntidadeWithRelations): number | null {
+  const metadata = entidade.metadata;
+  if (metadata && typeof metadata === "object" && !Array.isArray(metadata) && "order" in metadata) {
+    return typeof metadata.order === "number" ? metadata.order : null;
+  }
+  return null;
+}
+
+function toClientEntidade(entidade: EntidadeWithRelations): Entidade {
+  return {
+    id: entidade.id,
+    name: entidade.nome,
+    slug: entidade.slug || entidade.nome.toLowerCase().replace(/\s+/g, "-"),
+    subtitle: entidade.subtitle,
+    description: entidade.descricao,
+    tipo: normalizeTipo(entidade.tipo),
+    imagePath: mapImagePath(entidade.urlFoto),
+    contato_email: entidade.contato || "",
+    instagram: entidade.instagram,
+    linkedin: entidade.linkedin,
+    website: entidade.website,
+    location: entidade.location,
+    founding_date: entidade.foundingDate ? entidade.foundingDate.toISOString().split("T")[0] : null,
+    order: getOrder(entidade),
+    membros: entidade.membros?.map(membro => ({
+      id: membro.id,
+      usuario: {
+        id: membro.usuario.id,
+        nome: membro.usuario.nome,
+        slug: membro.usuario.slug,
+        urlFotoPerfil: membro.usuario.urlFotoPerfil,
+        eFacade: membro.usuario.eFacade,
+        curso: membro.usuario.curso ? { nome: membro.usuario.curso.nome } : null,
+      },
+      papel: membro.papel,
+      cargo: membro.cargo
+        ? {
+            id: membro.cargo.id,
+            nome: membro.cargo.nome,
+            descricao: membro.cargo.descricao,
+            ordem: membro.cargo.ordem,
+            entidadeId: membro.cargo.entidadeId,
+          }
+        : null,
+      startedAt: membro.startedAt.toISOString(),
+      endedAt: membro.endedAt?.toISOString() ?? null,
+    })),
+    cargos: entidade.cargos?.map(cargo => ({
+      id: cargo.id,
+      nome: cargo.nome,
+      descricao: cargo.descricao,
+      ordem: cargo.ordem,
+      entidadeId: cargo.entidadeId,
+    })),
+    centro: entidade.centro
+      ? {
+          id: entidade.centro.id,
+          nome: entidade.centro.nome,
+          sigla: entidade.centro.sigla,
+        }
+      : null,
+  };
+}
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;
-  const entidade = await getContainer().entidadesRepository.findBySlug(slug);
+  const entidade = await getEntidadeBySlug(slug);
 
   if (!entidade) {
     return { title: "Entidade · Aquário", robots: { index: false, follow: false } };
@@ -56,7 +155,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function EntidadePage({ params }: PageProps) {
   const { slug } = await params;
-  const entidade = await getContainer().entidadesRepository.findBySlug(slug);
+  const entidade = await getEntidadeBySlug(slug);
 
   if (!entidade) {
     notFound();
@@ -80,7 +179,7 @@ export default async function EntidadePage({ params }: PageProps) {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: jsonLdScriptContent(jsonLd) }}
       />
-      <EntidadeDetailClient slug={slug} />
+      <EntidadeDetailClient slug={slug} initialData={toClientEntidade(entidade)} />
     </>
   );
 }

--- a/src/app/projetos/[id]/page.tsx
+++ b/src/app/projetos/[id]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { cache } from "react";
 import { getContainer } from "@/lib/server/container";
 import { jsonLdScriptContent } from "@/lib/server/utils/seo";
 import ProjetoDetailClient from "./projeto-detail-client";
@@ -8,6 +9,10 @@ type PageProps = {
   params: Promise<{ id: string }>;
 };
 
+const getProjetoBySlug = cache(async (slug: string) => {
+  return await getContainer().projetosRepository.findBySlug(slug);
+});
+
 /**
  * The `[id]` route param is a slug. Public PUBLICADO projects have full
  * server-rendered metadata + initialData; drafts/archived fall through to the
@@ -15,7 +20,7 @@ type PageProps = {
  */
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { id: slug } = await params;
-  const projeto = await getContainer().projetosRepository.findBySlug(slug);
+  const projeto = await getProjetoBySlug(slug);
 
   if (!projeto || projeto.status !== "PUBLICADO") {
     // Drafts/archived/missing: don't leak details to crawlers.
@@ -57,7 +62,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ProjetoPage({ params }: PageProps) {
   const { id: slug } = await params;
-  const projeto = await getContainer().projetosRepository.findBySlug(slug);
+  const projeto = await getProjetoBySlug(slug);
 
   if (!projeto) {
     notFound();

--- a/src/app/usuarios/[slug]/page.tsx
+++ b/src/app/usuarios/[slug]/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { cache } from "react";
 import { getContainer } from "@/lib/server/container";
+import { formatPublicUserResponse } from "@/lib/server/utils/format-user-response";
 import { jsonLdScriptContent } from "@/lib/server/utils/seo";
 import UsuarioProfileClient from "./usuario-profile-client";
 
@@ -8,9 +10,13 @@ type PageProps = {
   params: Promise<{ slug: string }>;
 };
 
+const getUsuarioBySlug = cache(async (slug: string) => {
+  return await getContainer().usuariosRepository.findBySlug(slug);
+});
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;
-  const usuario = await getContainer().usuariosRepository.findBySlug(slug);
+  const usuario = await getUsuarioBySlug(slug);
 
   if (!usuario) {
     return { title: "Usuário · Aquário", robots: { index: false, follow: false } };
@@ -53,7 +59,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function UsuarioPage({ params }: PageProps) {
   const { slug } = await params;
-  const usuario = await getContainer().usuariosRepository.findBySlug(slug);
+  const usuario = await getUsuarioBySlug(slug);
 
   if (!usuario) {
     notFound();
@@ -90,7 +96,7 @@ export default async function UsuarioPage({ params }: PageProps) {
           dangerouslySetInnerHTML={{ __html: jsonLdScriptContent(jsonLd) }}
         />
       )}
-      <UsuarioProfileClient slug={slug} />
+      <UsuarioProfileClient slug={slug} initialData={formatPublicUserResponse(usuario)} />
     </>
   );
 }

--- a/src/app/usuarios/[slug]/usuario-profile-client.tsx
+++ b/src/app/usuarios/[slug]/usuario-profile-client.tsx
@@ -24,9 +24,15 @@ import { useProjetosByUsuario, useUsuarioProjetoCounts } from "@/lib/client/hook
 import ProjectCard from "@/components/shared/project-card";
 import { mapProjetoToCard } from "@/lib/client/mappers/projeto-mapper";
 import { trackEvent } from "@/analytics/posthog-client";
+import type { PublicUser } from "@/lib/client/api/usuarios";
 
-export default function UsuarioProfileClient({ slug }: { slug: string }) {
-  const { data: user, isLoading, error: queryError } = useUsuarioBySlug(slug);
+type UsuarioProfileClientProps = {
+  slug: string;
+  initialData?: PublicUser;
+};
+
+export default function UsuarioProfileClient({ slug, initialData }: UsuarioProfileClientProps) {
+  const { data: user, isLoading, error: queryError } = useUsuarioBySlug(slug, { initialData });
   const { data: currentUser, isLoading: isCurrentUserLoading } = useCurrentUser();
   const { data: memberships, isLoading: membershipsLoading } = useUserMemberships(user?.id || "");
   const uploadPhotoMutation = useUploadPhoto();
@@ -285,11 +291,11 @@ export default function UsuarioProfileClient({ slug }: { slug: string }) {
             {user.centro.sigla} — {user.centro.nome}
           </p>
           <p className="text-base text-muted-foreground">{user.curso.nome}</p>
-          {isOwnProfile && user.email && (
-            <p className="text-sm text-muted-foreground">{user.email}</p>
+          {isOwnProfile && currentUser?.email && (
+            <p className="text-sm text-muted-foreground">{currentUser.email}</p>
           )}
 
-          {isOwnProfile && user.papelPlataforma === "MASTER_ADMIN" && (
+          {isOwnProfile && currentUser?.papelPlataforma === "MASTER_ADMIN" && (
             <div className="flex justify-center md:justify-start mt-2">
               <Link href="/admin">
                 <Button className="rounded-full">Painel de Administração</Button>

--- a/src/components/pages/entidades/add-member-form.tsx
+++ b/src/components/pages/entidades/add-member-form.tsx
@@ -169,7 +169,7 @@ function AddMemberFormContent({ onMemberAdded }: { onMemberAdded?: () => void })
             <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-muted-foreground" />
             <Input
               id="user-search"
-              placeholder="Digite o nome, email, centro ou curso..."
+              placeholder="Digite o nome, centro ou curso..."
               value={searchQuery}
               onChange={e => setSearchQuery(e.target.value)}
               className="pl-10"
@@ -210,9 +210,6 @@ function AddMemberFormContent({ onMemberAdded }: { onMemberAdded?: () => void })
                               </Badge>
                             )}
                           </div>
-                          {user.email && (
-                            <p className="text-sm text-muted-foreground truncate">{user.email}</p>
-                          )}
                           <p className="text-xs text-muted-foreground">
                             {user.centro?.sigla} • {user.curso?.nome}
                           </p>

--- a/src/components/shared/co-autores-picker.tsx
+++ b/src/components/shared/co-autores-picker.tsx
@@ -110,7 +110,9 @@ export function CoAutoresPicker({
                 </div>
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-medium truncate">{u.nome}</p>
-                  <p className="text-xs text-muted-foreground truncate">{u.email}</p>
+                  <p className="text-xs text-muted-foreground truncate">
+                    {u.centro?.sigla} · {u.curso?.nome}
+                  </p>
                 </div>
                 <Badge variant="outline" className="text-[10px] shrink-0">
                   Usuário

--- a/src/lib/client/api/__tests__/usuarios.test.ts
+++ b/src/lib/client/api/__tests__/usuarios.test.ts
@@ -174,14 +174,19 @@ describe("usuariosService", () => {
   describe("searchUsers", () => {
     it("should search users with query", async () => {
       const mockUsers = [mockUser];
+      const mockResponse = {
+        users: mockUsers,
+        pagination: { page: 1, limit: 10, total: 1, totalPages: 1 },
+      };
       (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce({
         ok: true,
-        json: async () => mockUsers,
+        json: async () => mockResponse,
       } as Response);
 
       const result = await usuariosService.searchUsers("token-123", "test");
 
-      expect(result).toEqual(mockUsers);
+      expect(result).toEqual(mockResponse);
+      expect(result.users).toEqual(mockUsers);
       expect(global.fetch).toHaveBeenCalledWith(
         expect.stringContaining("search=test"),
         expect.any(Object)
@@ -191,7 +196,10 @@ describe("usuariosService", () => {
     it("should include limit when provided", async () => {
       (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce({
         ok: true,
-        json: async () => [],
+        json: async () => ({
+          users: [],
+          pagination: { page: 1, limit: 5, total: 0, totalPages: 1 },
+        }),
       } as Response);
 
       await usuariosService.searchUsers("token-123", "test", 5);

--- a/src/lib/client/api/usuarios.ts
+++ b/src/lib/client/api/usuarios.ts
@@ -3,16 +3,12 @@ import { apiClient } from "./api-client";
 import { throwApiError } from "@/lib/client/errors";
 import type { OnboardingMetadata } from "@/lib/shared/types";
 
-export type User = {
+type BaseUserProfile = {
   id: string;
   nome: string;
-  email: string | null;
   slug?: string | null;
-  papelPlataforma: "USER" | "MASTER_ADMIN";
-  eVerificado: boolean;
   eFacade?: boolean;
   urlFotoPerfil?: string | null;
-  periodoAtual?: string | null;
   centro: {
     id: string;
     nome: string;
@@ -22,6 +18,15 @@ export type User = {
     id: string;
     nome: string;
   };
+};
+
+export type PublicUser = BaseUserProfile;
+
+export type User = BaseUserProfile & {
+  email: string | null;
+  papelPlataforma: "USER" | "MASTER_ADMIN";
+  eVerificado: boolean;
+  periodoAtual?: string | null;
   permissoes: string[];
 };
 
@@ -90,7 +95,7 @@ export const usuariosService = {
     return response.json();
   },
 
-  getBySlug: async (slug: string): Promise<User> => {
+  getBySlug: async (slug: string): Promise<PublicUser> => {
     const response = await apiClient(`${ENDPOINTS.USUARIO_BY_SLUG(slug)}`, {
       method: "GET",
     });
@@ -140,7 +145,7 @@ export const usuariosService = {
     query: string,
     limit?: number
   ): Promise<{
-    users: User[];
+    users: PublicUser[];
     pagination: { page: number; limit: number; total: number; totalPages: number };
   }> => {
     const params = new URLSearchParams();

--- a/src/lib/client/hooks/use-entidades.ts
+++ b/src/lib/client/hooks/use-entidades.ts
@@ -2,6 +2,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { entidadesService } from "@/lib/client/api/entidades";
 import { queryKeys } from "@/lib/client/query-keys";
 import { useAuth } from "@/contexts/auth-context";
+import type { Entidade } from "@/lib/shared/types";
 
 const FIVE_MINUTES = 5 * 60 * 1000;
 
@@ -13,11 +14,12 @@ export const useEntidades = () => {
   });
 };
 
-export const useEntidadeBySlug = (slug: string) => {
+export const useEntidadeBySlug = (slug: string, options?: { initialData?: Entidade | null }) => {
   return useQuery({
     queryKey: queryKeys.entidades.bySlug(slug),
     queryFn: () => entidadesService.getBySlug(slug),
     enabled: !!slug,
+    initialData: options?.initialData,
     staleTime: FIVE_MINUTES,
   });
 };

--- a/src/lib/client/hooks/use-usuarios.ts
+++ b/src/lib/client/hooks/use-usuarios.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   usuariosService,
+  type PublicUser,
   type UpdateUserInfoRequest,
   type CreateOwnMembershipRequest,
   type UpdateOwnMembershipRequest,
@@ -31,11 +32,12 @@ export const useCurrentUser = () => {
 /**
  * Hook to get a user by slug
  */
-export const useUsuarioBySlug = (slug: string) => {
+export const useUsuarioBySlug = (slug: string, options?: { initialData?: PublicUser }) => {
   return useQuery({
     queryKey: queryKeys.usuarios.bySlug(slug),
     queryFn: () => usuariosService.getBySlug(slug),
     enabled: !!slug,
+    initialData: options?.initialData,
     staleTime: 5 * 60 * 1000, // 5 minutes - user profile data doesn't change often
   });
 };

--- a/src/lib/server/config/env.ts
+++ b/src/lib/server/config/env.ts
@@ -45,8 +45,8 @@ export const MASTER_ADMIN_EMAILS = (process.env.MASTER_ADMIN_EMAILS || "")
 // Environment
 // =============================================================================
 
-const NODE_ENV = process.env.NODE_ENV || "development";
-const IS_PROD = NODE_ENV === "production";
+export const NODE_ENV = process.env.NODE_ENV || "development";
+export const IS_PROD = NODE_ENV === "production";
 
 // =============================================================================
 // Email (Resend)

--- a/src/lib/server/openapi/paths/usuarios.ts
+++ b/src/lib/server/openapi/paths/usuarios.ts
@@ -62,6 +62,31 @@ const userProfileSchema = z
   })
   .openapi("UserProfile");
 
+const publicUserProfileSchema = z
+  .object({
+    id: z.string().uuid().openapi({ example: "550e8400-e29b-41d4-a716-446655440000" }),
+    nome: z.string().openapi({ example: "João Silva" }),
+    slug: z.string().nullable().openapi({ example: "joao-silva" }),
+    eFacade: z.boolean().openapi({
+      description: "Indica se este é um usuário facade (placeholder criado por admin, sem login).",
+      example: false,
+    }),
+    urlFotoPerfil: z
+      .string()
+      .nullable()
+      .openapi({ example: "https://blob.vercel-storage.com/photos/550e8400-1712668800.webp" }),
+    centro: z.object({
+      id: z.string().uuid(),
+      nome: z.string().openapi({ example: "Centro de Informática" }),
+      sigla: z.string().openapi({ example: "CI" }),
+    }),
+    curso: z.object({
+      id: z.string().uuid(),
+      nome: z.string().openapi({ example: "Ciência da Computação" }),
+    }),
+  })
+  .openapi("PublicUserProfile");
+
 /**
  * Shape estendido de usuário que inclui o flag `eFacade`. Retornado pelos
  * endpoints exclusivos de admin (GET /usuarios, POST /facade) para que admins
@@ -179,6 +204,13 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
       pagination: PaginationMetaSchema,
     })
     .openapi("PaginatedUsersResponse");
+
+  const paginatedPublicUsersResponseSchema = z
+    .object({
+      users: z.array(publicUserProfileSchema),
+      pagination: PaginationMetaSchema,
+    })
+    .openapi("PaginatedPublicUsersResponse");
   // ============================================================================
   // GET /usuarios — listagem em três modos (ver documentação de edge cases)
   // ============================================================================
@@ -211,7 +243,11 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
           "Usuários (envelope nos modos search/paginado, array no modo de listagem completa).",
         content: {
           "application/json": {
-            schema: z.union([paginatedUsersResponseSchema, z.array(adminUserResponseSchema)]),
+            schema: z.union([
+              paginatedPublicUsersResponseSchema,
+              paginatedUsersResponseSchema,
+              z.array(adminUserResponseSchema),
+            ]),
           },
         },
       },
@@ -422,7 +458,7 @@ export function registerUsuariosPaths(registry: OpenAPIRegistry, schemas: Common
     responses: {
       200: {
         description: "Perfil do usuário.",
-        content: { "application/json": { schema: userProfileSchema } },
+        content: { "application/json": { schema: publicUserProfileSchema } },
       },
       ...errorResponses([404], {
         404: { message: "Usuário não encontrado", code: "USER_NOT_FOUND" },

--- a/src/lib/server/services/auth/__tests__/register.production.test.ts
+++ b/src/lib/server/services/auth/__tests__/register.production.test.ts
@@ -1,0 +1,91 @@
+import type { RegisterDependencies } from "../register";
+import type { Centro, Curso, UsuarioWithRelations } from "@/lib/server/db/interfaces/types";
+
+const mockCentro: Centro = {
+  id: "centro-1",
+  nome: "CI",
+  sigla: "CI",
+  descricao: null,
+  campusId: "campus-1",
+};
+
+const mockCurso = {
+  id: "curso-1",
+  nome: "Ciencia da Computacao",
+  centroId: "centro-1",
+  criadoEm: new Date(),
+  atualizadoEm: new Date(),
+} as Curso;
+
+const mockCreatedUser = {
+  id: "new-user-id",
+  nome: "Test User",
+  email: "test@academico.ufpb.br",
+  centro: mockCentro,
+  curso: mockCurso,
+} as UsuarioWithRelations;
+
+function makeDeps(): RegisterDependencies {
+  return {
+    usuariosRepository: {
+      findByEmail: jest.fn().mockResolvedValue(null),
+      create: jest.fn().mockResolvedValue(mockCreatedUser),
+    } as unknown as RegisterDependencies["usuariosRepository"],
+    centrosRepository: {
+      findById: jest.fn().mockResolvedValue(mockCentro),
+    } as unknown as RegisterDependencies["centrosRepository"],
+    cursosRepository: {
+      findById: jest.fn().mockResolvedValue(mockCurso),
+    } as unknown as RegisterDependencies["cursosRepository"],
+    tokenVerificacaoRepository: {
+      create: jest.fn().mockResolvedValue({ id: "token-1" }),
+    } as unknown as RegisterDependencies["tokenVerificacaoRepository"],
+    emailService: {
+      sendVerificationEmail: jest.fn().mockResolvedValue(undefined),
+      sendPasswordResetEmail: jest.fn(),
+    },
+  };
+}
+
+const validInput = {
+  nome: "Test User",
+  email: "test@academico.ufpb.br",
+  senha: "password123",
+  centroId: "centro-1",
+  cursoId: "curso-1",
+};
+
+describe("register production email configuration", () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.dontMock("@/lib/server/config/env");
+    jest.dontMock("bcryptjs");
+    jest.dontMock("@/lib/server/utils/logger");
+  });
+
+  it("does not auto-verify or create users in production when email is unavailable", async () => {
+    jest.doMock("bcryptjs", () => ({
+      hash: jest.fn().mockResolvedValue("hashed-password"),
+    }));
+    jest.doMock("@/lib/server/config/env", () => ({
+      MASTER_ADMIN_EMAILS: [],
+      EMAIL_ENABLED: false,
+      IS_PROD: true,
+    }));
+    jest.doMock("@/lib/server/utils/logger", () => ({
+      createLogger: () => ({
+        error: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        debug: jest.fn(),
+      }),
+    }));
+
+    const { register } = await import("../register");
+    const deps = makeDeps();
+
+    await expect(register(validInput, deps)).rejects.toThrow("servico de email");
+    expect(deps.usuariosRepository.create).not.toHaveBeenCalled();
+    expect(deps.tokenVerificacaoRepository.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/server/services/auth/__tests__/register.production.test.ts
+++ b/src/lib/server/services/auth/__tests__/register.production.test.ts
@@ -64,6 +64,8 @@ describe("register production email configuration", () => {
   });
 
   it("does not auto-verify or create users in production when email is unavailable", async () => {
+    const mockLogError = jest.fn();
+
     jest.doMock("bcryptjs", () => ({
       hash: jest.fn().mockResolvedValue("hashed-password"),
     }));
@@ -74,7 +76,7 @@ describe("register production email configuration", () => {
     }));
     jest.doMock("@/lib/server/utils/logger", () => ({
       createLogger: () => ({
-        error: jest.fn(),
+        error: mockLogError,
         info: jest.fn(),
         warn: jest.fn(),
         debug: jest.fn(),
@@ -87,5 +89,11 @@ describe("register production email configuration", () => {
     await expect(register(validInput, deps)).rejects.toThrow("servico de email");
     expect(deps.usuariosRepository.create).not.toHaveBeenCalled();
     expect(deps.tokenVerificacaoRepository.create).not.toHaveBeenCalled();
+    expect(mockLogError).toHaveBeenCalledWith(
+      "Registration blocked because email is not configured in production",
+      undefined,
+      { emailDomain: "academico.ufpb.br" }
+    );
+    expect(JSON.stringify(mockLogError.mock.calls)).not.toContain(validInput.email);
   });
 });

--- a/src/lib/server/services/auth/__tests__/register.test.ts
+++ b/src/lib/server/services/auth/__tests__/register.test.ts
@@ -10,6 +10,7 @@ jest.mock("bcryptjs", () => ({
 jest.mock("@/lib/server/config/env", () => ({
   MASTER_ADMIN_EMAILS: ["admin@gmail.com"],
   EMAIL_ENABLED: false,
+  IS_PROD: false,
 }));
 
 // Mock logger

--- a/src/lib/server/services/auth/middleware.ts
+++ b/src/lib/server/services/auth/middleware.ts
@@ -85,10 +85,10 @@ export async function getOptionalUser(request: Request): Promise<UsuarioWithRela
 }
 
 /**
- * Check if user can create or delete a vaga for the given entidade.
+ * Check if user can manage resources owned by the given entidade.
  * Allowed: MASTER_ADMIN or ADMIN of that entidade (active membership).
  */
-export async function canManageVagaForEntidade(
+export async function canManageEntidade(
   usuario: UsuarioWithRelations,
   entidadeId: string
 ): Promise<boolean> {
@@ -99,6 +99,8 @@ export async function canManageVagaForEntidade(
   const membership = await membrosRepository.findActiveByUsuarioAndEntidade(usuario.id, entidadeId);
   return membership?.papel === "ADMIN";
 }
+
+export const canManageVagaForEntidade = canManageEntidade;
 
 /**
  * Check if user can manage a projeto (edit/delete/publish/replace authors).

--- a/src/lib/server/services/auth/register.ts
+++ b/src/lib/server/services/auth/register.ts
@@ -82,7 +82,7 @@ export async function register(
 
   if (IS_PROD && !EMAIL_ENABLED) {
     log.error("Registration blocked because email is not configured in production", undefined, {
-      email: normalizedEmail,
+      emailDomain: normalizedEmail.split("@")[1] ?? "unknown",
     });
     throw new Error("Cadastro indisponivel: servico de email nao configurado.");
   }

--- a/src/lib/server/services/auth/register.ts
+++ b/src/lib/server/services/auth/register.ts
@@ -5,7 +5,7 @@ import type { ICentrosRepository } from "@/lib/server/db/interfaces/centros-repo
 import type { ICursosRepository } from "@/lib/server/db/interfaces/cursos-repository.interface";
 import type { ITokenVerificacaoRepository } from "@/lib/server/db/interfaces/token-verificacao-repository.interface";
 import type { IEmailService } from "@/lib/server/services/email/email-service.interface";
-import { MASTER_ADMIN_EMAILS, EMAIL_ENABLED } from "@/lib/server/config/env";
+import { MASTER_ADMIN_EMAILS, EMAIL_ENABLED, IS_PROD } from "@/lib/server/config/env";
 import { createLogger } from "@/lib/server/utils/logger";
 
 const log = createLogger("Auth");
@@ -59,11 +59,11 @@ function generateToken(): string {
 }
 
 /**
- * Auto-verify users when email service is not configured (no RESEND_API_KEY)
- * This allows local development without setting up email
+ * Auto-verify users only outside production when email service is not configured.
+ * This allows local development without setting up email while production fails closed.
  */
 function shouldAutoVerify(): boolean {
-  return !EMAIL_ENABLED;
+  return !IS_PROD && !EMAIL_ENABLED;
 }
 
 /**
@@ -78,6 +78,13 @@ export async function register(
   // Validate email domain (allow MASTER_ADMIN emails regardless of domain)
   if (!isAllowedEmailDomain(normalizedEmail) && !isMasterAdminEmail(normalizedEmail)) {
     throw new Error("Apenas e-mails institucionais da UFPB são permitidos.");
+  }
+
+  if (IS_PROD && !EMAIL_ENABLED) {
+    log.error("Registration blocked because email is not configured in production", undefined, {
+      email: normalizedEmail,
+    });
+    throw new Error("Cadastro indisponivel: servico de email nao configurado.");
   }
 
   // Check if email is already registered

--- a/src/lib/server/utils/__tests__/format-user-response.test.ts
+++ b/src/lib/server/utils/__tests__/format-user-response.test.ts
@@ -1,0 +1,76 @@
+import type { UsuarioWithRelations } from "@/lib/server/db/interfaces/types";
+import { formatPublicUserResponse, formatUserResponse } from "../format-user-response";
+
+function makeUsuario(): UsuarioWithRelations {
+  return {
+    id: "user-1",
+    nome: "Test User",
+    email: "test@academico.ufpb.br",
+    slug: "test-user",
+    papelPlataforma: "MASTER_ADMIN",
+    eVerificado: true,
+    eFacade: false,
+    senhaHash: "hash",
+    permissoes: ["entidade:admin:ent-1"],
+    urlFotoPerfil: null,
+    periodoAtual: "5",
+    matricula: null,
+    onboardingMetadata: null,
+    centroId: "centro-1",
+    cursoId: "curso-1",
+    criadoEm: new Date("2026-01-01T00:00:00.000Z"),
+    atualizadoEm: new Date("2026-01-01T00:00:00.000Z"),
+    centro: {
+      id: "centro-1",
+      nome: "Centro de Informatica",
+      sigla: "CI",
+      descricao: null,
+      campusId: "campus-1",
+    },
+    curso: {
+      id: "curso-1",
+      nome: "Ciencia da Computacao",
+      centroId: "centro-1",
+      criadoEm: new Date("2026-01-01T00:00:00.000Z"),
+      atualizadoEm: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  } as UsuarioWithRelations;
+}
+
+describe("format-user-response", () => {
+  it("keeps private fields in the full user response", () => {
+    const result = formatUserResponse(makeUsuario());
+
+    expect(result).toMatchObject({
+      email: "test@academico.ufpb.br",
+      papelPlataforma: "MASTER_ADMIN",
+      eVerificado: true,
+      permissoes: ["entidade:admin:ent-1"],
+    });
+  });
+
+  it("omits private fields from the public user response", () => {
+    const result = formatPublicUserResponse(makeUsuario());
+
+    expect(result).toEqual({
+      id: "user-1",
+      nome: "Test User",
+      slug: "test-user",
+      eFacade: false,
+      urlFotoPerfil: null,
+      centro: {
+        id: "centro-1",
+        nome: "Centro de Informatica",
+        sigla: "CI",
+      },
+      curso: {
+        id: "curso-1",
+        nome: "Ciencia da Computacao",
+      },
+    });
+    expect(result).not.toHaveProperty("email");
+    expect(result).not.toHaveProperty("papelPlataforma");
+    expect(result).not.toHaveProperty("eVerificado");
+    expect(result).not.toHaveProperty("permissoes");
+  });
+});

--- a/src/lib/server/utils/format-user-response.ts
+++ b/src/lib/server/utils/format-user-response.ts
@@ -1,5 +1,22 @@
 import type { UsuarioWithRelations } from "@/lib/server/db/interfaces/types";
 
+export type PublicUserResponse = {
+  id: string;
+  nome: string;
+  slug: string | null;
+  eFacade: boolean;
+  urlFotoPerfil: string | null;
+  centro: {
+    id: string;
+    nome: string;
+    sigla: string;
+  };
+  curso: {
+    id: string;
+    nome: string;
+  };
+};
+
 /**
  * Format a user object for API responses
  * Ensures consistent user data structure across all endpoints
@@ -24,5 +41,29 @@ export function formatUserResponse(user: UsuarioWithRelations) {
       nome: user.curso.nome,
     },
     permissoes: user.permissoes,
+  };
+}
+
+/**
+ * Format a user object for public profile/search responses.
+ * Omits private account and authorization fields such as email, role,
+ * verification status, and explicit permissions.
+ */
+export function formatPublicUserResponse(user: UsuarioWithRelations): PublicUserResponse {
+  return {
+    id: user.id,
+    nome: user.nome,
+    slug: user.slug,
+    eFacade: user.eFacade,
+    urlFotoPerfil: user.urlFotoPerfil,
+    centro: {
+      id: user.centro.id,
+      nome: user.centro.nome,
+      sigla: user.centro.sigla,
+    },
+    curso: {
+      id: user.curso.id,
+      nome: user.curso.nome,
+    },
   };
 }

--- a/src/lib/shared/types/__tests__/membro.types.test.ts
+++ b/src/lib/shared/types/__tests__/membro.types.test.ts
@@ -1,0 +1,19 @@
+import { isUserAdminOfEntidade, type Membro } from "../membro.types";
+
+const activeAdmin: Membro = {
+  id: "membro-1",
+  usuario: { id: "user-1", nome: "User" },
+  papel: "ADMIN",
+  cargo: null,
+  startedAt: "2026-01-01T00:00:00.000Z",
+  endedAt: null,
+};
+
+describe("isUserAdminOfEntidade", () => {
+  it("requires an active admin membership", () => {
+    expect(isUserAdminOfEntidade("user-1", [activeAdmin])).toBe(true);
+    expect(
+      isUserAdminOfEntidade("user-1", [{ ...activeAdmin, endedAt: "2026-02-01T00:00:00.000Z" }])
+    ).toBe(false);
+  });
+});

--- a/src/lib/shared/types/membro.types.ts
+++ b/src/lib/shared/types/membro.types.ts
@@ -50,5 +50,5 @@ export function isUserAdminOfEntidade(userId: string, membros: Membro[] | undefi
   if (!membros) {
     return false;
   }
-  return membros.some(m => m.usuario.id === userId && isAdminPapel(m.papel));
+  return membros.some(m => m.usuario.id === userId && isAdminPapel(m.papel) && !m.endedAt);
 }


### PR DESCRIPTION
﻿## Summary
- Require active entidade admin membership for entidade/cargo/member mutations and matching client permission checks.
- Sanitize public user profile/search responses and hydrate public pages with cached initial data.
- Fail closed for production registration without email, make profile-photo blob cleanup DB-safe, and fail builds on migration deploy errors.
- Update audit-sensitive dependencies (Scalar, PostHog, Vitest) and OpenAPI/changelog/tests.

## Validation
- npm test -- --runInBand
- npm run test:integration
- npm run type-check
- npx next lint --file ...changed TS/TSX files...
- npx prettier --check ...changed files...
- npm audit --audit-level=high
- npm audit --omit=dev --audit-level=high
- npx next build --no-lint

## Notes
- npm run check-all and full npm run build hit the existing Windows checkout CRLF/prettier lint problem in unmodified files (Delete CR). Focused lint/format on this PR passed, and next build --no-lint completed.
- npm audit still reports a moderate PostCSS advisory under Next; npm's forced fix would downgrade Next to 9.3.3, so this PR leaves it as a residual upstream/transitive item.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Public user and entity pages now load faster by reusing pre-fetched data.
  * Search and profile views now show a cleaner public-facing user format.

* **Bug Fixes**
  * Tightened entity/admin permissions so only active admin memberships can manage content.
  * Hidden sensitive fields from public user search and profile responses.
  * Improved photo updates so old images are removed only after records are safely updated.
  * Registration now fails clearly if email service setup is missing in production.
  * Build now stops when database migrations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->