### PR TITLE
fix(copa): map EXTRA_TIME/PENALTY_SHOOTOUT match statuses

### DIFF
--- a/scripts/update-copa-results.ts
+++ b/scripts/update-copa-results.ts
@@ -29,11 +29,20 @@ function toInternalId(tla: string): string {
 
 type MatchStatus = "scheduled" | "live" | "finished";
 
+// Every value football-data.org documents for the match-level `status`
+// field: https://docs.football-data.org/general/v4/lookup_tables.html
+// EXTRA_TIME/PENALTY_SHOOTOUT were previously missing here, so a knockout
+// match still playing extra time or a shootout fell through to the
+// "scheduled" default below — hiding an in-progress match's live score and,
+// worse, blocking downstream bracket resolution for matches that depend on
+// its winner even well after it had actually finished.
 const STATUS_MAP: Record<string, MatchStatus> = {
   SCHEDULED: "scheduled",
   TIMED: "scheduled",
   IN_PLAY: "live",
   PAUSED: "live",
+  EXTRA_TIME: "live",
+  PENALTY_SHOOTOUT: "live",
   FINISHED: "finished",
   AWARDED: "finished",
   SUSPENDED: "scheduled",
@@ -151,6 +160,11 @@ async function main() {
       continue;
     }
 
+    if (!(apiMatch.status in STATUS_MAP)) {
+      console.warn(
+        `⚠️ Jogo ${match.id}: status "${apiMatch.status}" não mapeado em STATUS_MAP — usando "scheduled".`
+      );
+    }
     const status = STATUS_MAP[apiMatch.status] ?? "scheduled";
     const wentToPenalties = apiMatch.score.duration === "PENALTY_SHOOTOUT";
     const penaltyHome = apiMatch.score.penalties?.home;

--- a/scripts/update-copa-results.ts
+++ b/scripts/update-copa-results.ts
@@ -160,7 +160,7 @@ async function main() {
       continue;
     }
 
-    if (!(apiMatch.status in STATUS_MAP)) {
+    if (!Object.hasOwn(STATUS_MAP, apiMatch.status)) {
       console.warn(
         `⚠️ Jogo ${match.id}: status "${apiMatch.status}" não mapeado em STATUS_MAP — usando "scheduled".`
       );


### PR DESCRIPTION
## Problem

Jogo 99 (quarterfinal, Norway x winner of Jogo 92) was stuck showing "?" for its opponent, even though Jogo 92 (Mexico x England, Round of 16) had already finished days earlier in the real world.

## Root cause

`content/copa-resultados/results.json` had Jogo 92 stored with `status: "scheduled"` despite having a final score and winner recorded. `resolveMatchParticipants` requires `status === "finished"` to read a knockout match's winner for downstream bracket resolution — so Jogo 99's opponent could never resolve.

football-data.org's documented match-level `status` enum includes `EXTRA_TIME` and `PENALTY_SHOOTOUT` as valid in-progress values (in addition to `IN_PLAY`/`PAUSED`): https://docs.football-data.org/general/v4/lookup_tables.html. Neither was in our `STATUS_MAP`, so a match still playing extra time or a shootout at fetch time fell through to the `"scheduled"` default — and since our script only writes whatever the API's *current* status resolves to, this stuck for every run.

## Fix

- Added `EXTRA_TIME` and `PENALTY_SHOOTOUT` to `STATUS_MAP`, mapped to `"live"` (both are in-progress states, not finished).
- Added a warning log for any status string still not in the map, so a future gap surfaces in the workflow logs instead of silently defaulting to `"scheduled"`.

## Testing

- `npx next lint` on the changed file → no errors

## Follow-up

This fixes the code path going forward. The already-corrupted `content/copa-resultados/results.json` entry for Jogo 92 (`status: "scheduled"` with a final score) still needs a one-off correction — handling separately, since it's data, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * World Cup matches in extra time or penalty shootouts are now correctly shown as live.
  * Added safeguards to identify unrecognized match statuses and default them to scheduled with a warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->