### PR TITLE
fix(copa): trust score.winner when the API returns an unrecognized status

### DIFF
--- a/scripts/update-copa-results.ts
+++ b/scripts/update-copa-results.ts
@@ -160,12 +160,24 @@ async function main() {
       continue;
     }
 
-    if (!Object.hasOwn(STATUS_MAP, apiMatch.status)) {
+    let status: MatchStatus;
+    if (Object.hasOwn(STATUS_MAP, apiMatch.status)) {
+      status = STATUS_MAP[apiMatch.status];
+    } else if (apiMatch.score.winner) {
+      // The API has occasionally returned a malformed/unrecognized status
+      // string (observed once as a raw timestamp) for an otherwise-finished
+      // match. score.winner is only ever populated once a match has
+      // concluded, so trust it over a status value we can't even parse.
+      console.warn(
+        `⚠️ Jogo ${match.id}: status "${apiMatch.status}" não reconhecido, mas score.winner presente — tratando como "finished".`
+      );
+      status = "finished";
+    } else {
       console.warn(
         `⚠️ Jogo ${match.id}: status "${apiMatch.status}" não mapeado em STATUS_MAP — usando "scheduled".`
       );
+      status = "scheduled";
     }
-    const status = STATUS_MAP[apiMatch.status] ?? "scheduled";
     const wentToPenalties = apiMatch.score.duration === "PENALTY_SHOOTOUT";
     const penaltyHome = apiMatch.score.penalties?.home;
     const penaltyAway = apiMatch.score.penalties?.away;


### PR DESCRIPTION
## Problem

Jogo 99 (quarterfinal, Norway x winner of Jogo 92) still didn't resolve its opponent even after #236 (which added EXTRA_TIME/PENALTY_SHOOTOUT to STATUS_MAP), even though the real-world quarterfinal had already been played.

## Root cause

The warning log added in #236 caught the real culprit on the very next run:

```
⚠️ Jogo 92: status "2026-07-06 01:00:00Z" não mapeado em STATUS_MAP — usando "scheduled".
```

football-data.org returned a raw timestamp string as the match `status` for Jogo 92 (Mexico x England) — not a documented status value at all. This isn't the EXTRA_TIME/PENALTY_SHOOTOUT gap from #236; it's a data quality issue on the provider's side for this specific fixture. Since it fell through the `STATUS_MAP` fallback to `"scheduled"`, the match was written with a final score and winner but a "scheduled" status — and `resolveMatchParticipants` requires `status === "finished"` to read a knockout winner, so Jogo 99 could never resolve.

## Fix

When `apiMatch.status` isn't a recognized `STATUS_MAP` key at all (as opposed to a recognized-but-previously-unmapped live substatus, which #236 covers), fall back to checking `apiMatch.score.winner`: it's only ever populated once a match has actually concluded, so its presence is trusted as authoritative over an unparseable status string. Still defaults to `"scheduled"` if winner isn't present either (e.g. a match that's genuinely not started, with a status value we haven't seen).

## Testing

- `npx next lint` on the changed file → no errors
- Will trigger a manual `workflow_dispatch` after merge to confirm Jogo 92 flips to `"finished"` and Jogo 99 resolves its opponent and fetches its actual result

🤖 Generated with [Claude Code](https://claude.com/claude-code)