### PR TITLE
feat: add SIGAA V1 persistence foundation

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -10,11 +10,12 @@ on:
       - "tsconfig.json"
       - ".github/workflows/code-quality.yml"
   pull_request:
-    branches: [main, develop]
     paths:
       - "src/**"
       - "prisma/**"
+      - "scripts/verify-sigaa-boundary.mjs"
       - "package.json"
+      - "package-lock.json"
       - "tsconfig.json"
       - ".github/workflows/code-quality.yml"
 
@@ -40,6 +41,9 @@ jobs:
 
       - name: Generate Prisma Client
         run: npm run db:generate
+
+      - name: Verify SIGAA persistence boundary
+        run: npm run verify:sigaa-boundary
 
       - name: Check code formatting
         run: npm run format:check

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -2,7 +2,6 @@ name: Preview Deployment
 
 on:
   pull_request:
-    branches: [main]
     types: [opened, synchronize, reopened, closed]
 
 permissions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,11 +9,13 @@ on:
       - "package.json"
       - ".github/workflows/tests.yml"
   pull_request:
-    branches: [main]
     paths:
       - "src/**"
       - "prisma/**"
+      - "scripts/run-sigaa-db-tests.mjs"
+      - "scripts/verify-sigaa-boundary.mjs"
       - "package.json"
+      - "package-lock.json"
       - ".github/workflows/tests.yml"
 
 jobs:
@@ -61,7 +63,7 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password
-          POSTGRES_DB: aquario_test
+          POSTGRES_DB: aquario_sigaa_test
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -71,7 +73,7 @@ jobs:
           - 5432:5432
 
     env:
-      DATABASE_URL: postgresql://postgres:password@localhost:5432/aquario_test
+      DATABASE_URL: postgresql://postgres:password@localhost:5432/aquario_sigaa_test
       NODE_ENV: test
       JWT_SECRET: test-jwt-secret-key-minimum-32-characters-long
       RESEND_API_KEY: test-resend-api-key
@@ -97,10 +99,18 @@ jobs:
         run: npm run db:generate
 
       - name: Run database migrations
-        run: npx prisma db push
+        run: npm run db:migrate:deploy
+
+      - name: Verify SIGAA persistence boundary
+        run: npm run verify:sigaa-boundary
+
+      - name: Run SIGAA database tests
+        run: npm run test:sigaa-db
+        env:
+          SIGAA_TEST_DATABASE_URL: postgresql://postgres:password@localhost:5432/aquario_sigaa_test
 
       - name: Run integration tests
-        run: npm run test:integration -- --run --reporter=verbose
+        run: npm run test:integration -- --run --reporter=verbose --exclude src/lib/server/db/implementations/prisma/__tests__/prisma-sigaa-repository.integration.test.ts
 
       - name: Upload integration test results
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Persistência SIGAA V1**: Novo agregado transacional com conexão por usuário, snapshot acadêmico JSON validado, tentativas idempotentes com lease por geração, proveniência da matrícula, limite distribuído por operação e retenção segura. A suíte agora aplica as migrações versionadas e testa as invariantes em PostgreSQL descartável.
 - **Grade curricular – seleção em lote por período**: No modo seleção, o cabeçalho de cada período vira um botão que marca de uma vez todas as obrigatórias daquele período e, num segundo clique, as tira da seleção (tooltip "Marcar/Desmarcar todas as obrigatórias" no desktop, botão equivalente na lista mobile). Vale tanto para `/grades-curriculares` quanto para os passos "Disciplinas Concluídas" e "Cursando" do onboarding.
 - **Admin Audit Logs**: Nova tabela `AuditLog`, API interna `GET /api/admin/audit-logs` e tela `/admin/audit-logs` para `MASTER_ADMIN` acompanhar ações administrativas sensíveis. Mutações administrativas de usuários agora registram criação/mescla de facade, alteração de role, edição de centro/curso/slug e deleção.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Persistência SIGAA V1**: Novo agregado transacional com conexão por usuário, snapshot acadêmico JSON validado, tentativas idempotentes com lease por geração, proveniência da matrícula, limite distribuído por operação e retenção segura. A suíte agora aplica as migrações versionadas e testa as invariantes em PostgreSQL descartável.
+- **Persistência SIGAA V1**: Novo agregado transacional com conexão por usuário, snapshot acadêmico JSON validado, tentativas idempotentes com lease por geração, proveniência da matrícula, limite distribuído por operação e retenção segura. A suíte agora aplica as migrações versionadas, testa as invariantes e prova a reversão exata do write-set SIGAA sem alterar identidades preexistentes em PostgreSQL descartável.
 - **Grade curricular – seleção em lote por período**: No modo seleção, o cabeçalho de cada período vira um botão que marca de uma vez todas as obrigatórias daquele período e, num segundo clique, as tira da seleção (tooltip "Marcar/Desmarcar todas as obrigatórias" no desktop, botão equivalente na lista mobile). Vale tanto para `/grades-curriculares` quanto para os passos "Disciplinas Concluídas" e "Cursando" do onboarding.
 - **Admin Audit Logs**: Nova tabela `AuditLog`, API interna `GET /api/admin/audit-logs` e tela `/admin/audit-logs` para `MASTER_ADMIN` acompanhar ações administrativas sensíveis. Mutações administrativas de usuários agora registram criação/mescla de facade, alteração de role, edição de centro/curso/slug e deleção.
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "test:integration": "vitest",
     "test:integration:ui": "vitest --ui",
     "test:integration:watch": "vitest --watch",
+    "test:sigaa-db": "node scripts/run-sigaa-db-tests.mjs",
+    "verify:sigaa-boundary": "node scripts/verify-sigaa-boundary.mjs",
     "test:all": "npm run test && npm run test:integration",
     "db:generate": "prisma generate",
     "db:migrate": "dotenv -e .env -- prisma migrate dev",

--- a/prisma/migrations/20260821090000_add_sigaa_persistence/migration.sql
+++ b/prisma/migrations/20260821090000_add_sigaa_persistence/migration.sql
@@ -1,0 +1,191 @@
+-- CreateEnum
+CREATE TYPE "MatriculaOrigem" AS ENUM ('LEGACY', 'MANUAL', 'SIGAA');
+
+-- CreateEnum
+CREATE TYPE "SigaaConnectionStatus" AS ENUM ('PENDING', 'CONNECTED', 'DISCONNECTED');
+
+-- CreateEnum
+CREATE TYPE "SigaaSyncRunStatus" AS ENUM ('RUNNING', 'SUCCEEDED', 'FAILED', 'SUPERSEDED');
+
+-- CreateEnum
+CREATE TYPE "SigaaSyncFailureCode" AS ENUM (
+    'SIGAA_AUTH_FAILED',
+    'SIGAA_IDENTITY_INVALID',
+    'SIGAA_IDENTITY_MISMATCH',
+    'SIGAA_TIMEOUT',
+    'SIGAA_UNAVAILABLE',
+    'SIGAA_RESPONSE_INVALID',
+    'CONNECTOR_UNAVAILABLE',
+    'CONNECTOR_MISCONFIGURED',
+    'COURSE_MISMATCH',
+    'LEASE_LOST',
+    'INTERNAL_ERROR'
+);
+
+-- CreateEnum
+CREATE TYPE "SigaaRateLimitOperation" AS ENUM ('REAUTH', 'SYNC', 'DISCONNECT', 'DELETE_IMPORTED_DATA');
+
+-- AlterTable
+ALTER TABLE "Usuario"
+ADD COLUMN "matriculaOrigem" "MatriculaOrigem",
+ADD COLUMN "matriculaVerificadaPeloSigaaEm" TIMESTAMP(3);
+
+UPDATE "Usuario"
+SET "matriculaOrigem" = 'LEGACY'
+WHERE "matricula" IS NOT NULL;
+
+ALTER TABLE "Usuario"
+ADD CONSTRAINT "Usuario_matricula_provenance_check"
+CHECK (
+    ("matricula" IS NULL AND "matriculaOrigem" IS NULL AND "matriculaVerificadaPeloSigaaEm" IS NULL)
+    OR ("matricula" IS NOT NULL AND "matriculaOrigem" IS NOT NULL)
+);
+
+-- CreateTable
+CREATE TABLE "SigaaConnection" (
+    "usuarioId" TEXT NOT NULL,
+    "status" "SigaaConnectionStatus" NOT NULL DEFAULT 'PENDING',
+    "consentVersion" VARCHAR(64),
+    "consentedAt" TIMESTAMP(3),
+    "connectedAt" TIMESTAMP(3),
+    "disconnectedAt" TIMESTAMP(3),
+    "leaseGeneration" BIGINT NOT NULL DEFAULT 0,
+    "leaseRunId" TEXT,
+    "leaseTokenDigest" CHAR(64),
+    "leaseExpiresAt" TIMESTAMP(3),
+    "criadoEm" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "atualizadoEm" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SigaaConnection_pkey" PRIMARY KEY ("usuarioId"),
+    CONSTRAINT "SigaaConnection_consent_check" CHECK (
+        ("consentVersion" IS NULL AND "consentedAt" IS NULL)
+        OR ("consentVersion" IS NOT NULL AND "consentedAt" IS NOT NULL)
+    ),
+    CONSTRAINT "SigaaConnection_lease_check" CHECK (
+        ("leaseRunId" IS NULL AND "leaseTokenDigest" IS NULL AND "leaseExpiresAt" IS NULL)
+        OR ("leaseRunId" IS NOT NULL AND "leaseTokenDigest" IS NOT NULL AND "leaseExpiresAt" IS NOT NULL)
+    ),
+    CONSTRAINT "SigaaConnection_lease_digest_check" CHECK (
+        "leaseTokenDigest" IS NULL OR "leaseTokenDigest" ~ '^[0-9a-f]{64}$'
+    ),
+    CONSTRAINT "SigaaConnection_generation_check" CHECK ("leaseGeneration" >= 0)
+);
+
+-- CreateTable
+CREATE TABLE "SigaaSyncRun" (
+    "id" TEXT NOT NULL,
+    "usuarioId" TEXT NOT NULL,
+    "idempotencyKey" VARCHAR(64) NOT NULL,
+    "status" "SigaaSyncRunStatus" NOT NULL DEFAULT 'RUNNING',
+    "leaseGeneration" BIGINT NOT NULL,
+    "leaseExpiresAt" TIMESTAMP(3) NOT NULL,
+    "courseIdentityToken" CHAR(64) NOT NULL,
+    "consentVersion" VARCHAR(64) NOT NULL,
+    "failureCode" "SigaaSyncFailureCode",
+    "connectorRequestId" VARCHAR(64),
+    "contractVersion" VARCHAR(16),
+    "upstreamCommit" CHAR(40),
+    "componentCount" INTEGER,
+    "gradeCount" INTEGER,
+    "classCount" INTEGER,
+    "iniciadoEm" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "finalizadoEm" TIMESTAMP(3),
+    "retentionExpiresAt" TIMESTAMP(3),
+
+    CONSTRAINT "SigaaSyncRun_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "SigaaSyncRun_idempotency_key_check" CHECK (char_length("idempotencyKey") > 0),
+    CONSTRAINT "SigaaSyncRun_generation_check" CHECK ("leaseGeneration" > 0),
+    CONSTRAINT "SigaaSyncRun_course_token_check" CHECK ("courseIdentityToken" ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT "SigaaSyncRun_upstream_commit_check" CHECK (
+        "upstreamCommit" IS NULL OR "upstreamCommit" ~ '^[0-9a-f]{40}$'
+    ),
+    CONSTRAINT "SigaaSyncRun_counts_check" CHECK (
+        ("componentCount" IS NULL OR "componentCount" >= 0)
+        AND ("gradeCount" IS NULL OR "gradeCount" >= 0)
+        AND ("classCount" IS NULL OR "classCount" >= 0)
+    ),
+    CONSTRAINT "SigaaSyncRun_lifecycle_check" CHECK (
+        ("status" = 'RUNNING' AND "failureCode" IS NULL AND "finalizadoEm" IS NULL AND "retentionExpiresAt" IS NULL)
+        OR ("status" = 'SUCCEEDED' AND "failureCode" IS NULL AND "finalizadoEm" IS NOT NULL AND "retentionExpiresAt" IS NOT NULL)
+        OR ("status" IN ('FAILED', 'SUPERSEDED') AND "failureCode" IS NOT NULL AND "finalizadoEm" IS NOT NULL AND "retentionExpiresAt" IS NOT NULL)
+    )
+);
+
+-- CreateTable
+CREATE TABLE "SigaaAcademicSnapshot" (
+    "usuarioId" TEXT NOT NULL,
+    "contractVersion" VARCHAR(16) NOT NULL,
+    "connectorObservedAt" TIMESTAMP(3) NOT NULL,
+    "synchronizedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "upstreamCommit" CHAR(40) NOT NULL,
+    "installedByRunId" TEXT,
+    "payload" JSONB NOT NULL,
+
+    CONSTRAINT "SigaaAcademicSnapshot_pkey" PRIMARY KEY ("usuarioId"),
+    CONSTRAINT "SigaaAcademicSnapshot_upstream_commit_check" CHECK ("upstreamCommit" ~ '^[0-9a-f]{40}$'),
+    CONSTRAINT "SigaaAcademicSnapshot_payload_check" CHECK (jsonb_typeof("payload") = 'object')
+);
+
+-- CreateTable
+CREATE TABLE "SigaaRateLimitBucket" (
+    "usuarioId" TEXT NOT NULL,
+    "operation" "SigaaRateLimitOperation" NOT NULL,
+    "count" INTEGER NOT NULL,
+    "windowStartedAt" TIMESTAMP(3) NOT NULL,
+    "resetAt" TIMESTAMP(3) NOT NULL,
+    "criadoEm" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "atualizadoEm" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SigaaRateLimitBucket_pkey" PRIMARY KEY ("usuarioId", "operation"),
+    CONSTRAINT "SigaaRateLimitBucket_window_check" CHECK ("count" > 0 AND "resetAt" > "windowStartedAt")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SigaaConnection_usuarioId_leaseRunId_key" ON "SigaaConnection"("usuarioId", "leaseRunId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SigaaAcademicSnapshot_usuarioId_installedByRunId_key" ON "SigaaAcademicSnapshot"("usuarioId", "installedByRunId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SigaaSyncRun_usuarioId_idempotencyKey_key" ON "SigaaSyncRun"("usuarioId", "idempotencyKey");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SigaaSyncRun_usuarioId_id_key" ON "SigaaSyncRun"("usuarioId", "id");
+
+-- CreateIndex
+CREATE INDEX "SigaaSyncRun_usuarioId_iniciadoEm_idx" ON "SigaaSyncRun"("usuarioId", "iniciadoEm");
+
+-- CreateIndex
+CREATE INDEX "SigaaSyncRun_status_leaseExpiresAt_idx" ON "SigaaSyncRun"("status", "leaseExpiresAt");
+
+-- CreateIndex
+CREATE INDEX "SigaaSyncRun_status_retentionExpiresAt_idx" ON "SigaaSyncRun"("status", "retentionExpiresAt");
+
+-- CreateIndex
+CREATE INDEX "SigaaRateLimitBucket_resetAt_idx" ON "SigaaRateLimitBucket"("resetAt");
+
+-- AddForeignKey
+ALTER TABLE "SigaaConnection" ADD CONSTRAINT "SigaaConnection_usuarioId_fkey"
+FOREIGN KEY ("usuarioId") REFERENCES "Usuario"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SigaaSyncRun" ADD CONSTRAINT "SigaaSyncRun_usuarioId_fkey"
+FOREIGN KEY ("usuarioId") REFERENCES "SigaaConnection"("usuarioId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SigaaConnection" ADD CONSTRAINT "SigaaConnection_usuarioId_leaseRunId_fkey"
+FOREIGN KEY ("usuarioId", "leaseRunId") REFERENCES "SigaaSyncRun"("usuarioId", "id")
+ON DELETE NO ACTION ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SigaaAcademicSnapshot" ADD CONSTRAINT "SigaaAcademicSnapshot_usuarioId_fkey"
+FOREIGN KEY ("usuarioId") REFERENCES "SigaaConnection"("usuarioId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SigaaAcademicSnapshot" ADD CONSTRAINT "SigaaAcademicSnapshot_usuarioId_installedByRunId_fkey"
+FOREIGN KEY ("usuarioId", "installedByRunId") REFERENCES "SigaaSyncRun"("usuarioId", "id")
+ON DELETE NO ACTION ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SigaaRateLimitBucket" ADD CONSTRAINT "SigaaRateLimitBucket_usuarioId_fkey"
+FOREIGN KEY ("usuarioId") REFERENCES "Usuario"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -79,6 +79,46 @@ enum StatusProjeto {
   ARQUIVADO
 }
 
+enum MatriculaOrigem {
+  LEGACY
+  MANUAL
+  SIGAA
+}
+
+enum SigaaConnectionStatus {
+  PENDING
+  CONNECTED
+  DISCONNECTED
+}
+
+enum SigaaSyncRunStatus {
+  RUNNING
+  SUCCEEDED
+  FAILED
+  SUPERSEDED
+}
+
+enum SigaaSyncFailureCode {
+  SIGAA_AUTH_FAILED
+  SIGAA_IDENTITY_INVALID
+  SIGAA_IDENTITY_MISMATCH
+  SIGAA_TIMEOUT
+  SIGAA_UNAVAILABLE
+  SIGAA_RESPONSE_INVALID
+  CONNECTOR_UNAVAILABLE
+  CONNECTOR_MISCONFIGURED
+  COURSE_MISMATCH
+  LEASE_LOST
+  INTERNAL_ERROR
+}
+
+enum SigaaRateLimitOperation {
+  REAUTH
+  SYNC
+  DISCONNECT
+  DELETE_IMPORTED_DATA
+}
+
 // ============================================================================
 // CAMPUS & CENTRO & CURSO (Core organizational structure)
 // ============================================================================
@@ -123,6 +163,8 @@ model Usuario {
   nome              String
   email             String?          @unique
   matricula         String?          @unique
+  matriculaOrigem   MatriculaOrigem?
+  matriculaVerificadaPeloSigaaEm DateTime?
   slug              String?          @unique
   senhaHash         String?
   permissoes        String[]         @default([])
@@ -148,11 +190,96 @@ model Usuario {
   vagasCriadas           Vaga[]
   projetosAutor          ProjetoAutor[]
   auditLogs              AuditLog[] @relation("AuditLogActor")
+  sigaaConnection       SigaaConnection?
+  sigaaRateLimitBuckets SigaaRateLimitBucket[]
 
   @@index([email])
   @@index([matricula])
   @@index([eFacade])
   @@index([slug])
+}
+
+model SigaaConnection {
+  usuarioId        String                @id
+  status           SigaaConnectionStatus @default(PENDING)
+  consentVersion   String?               @db.VarChar(64)
+  consentedAt      DateTime?
+  connectedAt      DateTime?
+  disconnectedAt   DateTime?
+  leaseGeneration  BigInt                @default(0)
+  leaseRunId       String?
+  leaseTokenDigest String?               @db.Char(64)
+  leaseExpiresAt   DateTime?
+  criadoEm         DateTime              @default(now())
+  atualizadoEm     DateTime              @updatedAt
+
+  usuario        Usuario                @relation(fields: [usuarioId], references: [id], onDelete: Cascade)
+  snapshot       SigaaAcademicSnapshot?
+  runs           SigaaSyncRun[]         @relation("ConnectionRuns")
+  activeLeaseRun SigaaSyncRun?          @relation("ActiveLease", fields: [usuarioId, leaseRunId], references: [usuarioId, id], onDelete: NoAction)
+
+  @@unique([usuarioId, leaseRunId])
+}
+
+model SigaaAcademicSnapshot {
+  usuarioId           String   @id
+  contractVersion     String   @db.VarChar(16)
+  connectorObservedAt DateTime
+  synchronizedAt      DateTime @default(now())
+  upstreamCommit      String   @db.Char(40)
+  installedByRunId    String?
+  payload             Json
+
+  connection     SigaaConnection @relation(fields: [usuarioId], references: [usuarioId], onDelete: Cascade)
+  installedByRun SigaaSyncRun?   @relation(fields: [usuarioId, installedByRunId], references: [usuarioId, id], onDelete: NoAction)
+
+  @@unique([usuarioId, installedByRunId])
+}
+
+model SigaaSyncRun {
+  id                  String                @id @default(uuid())
+  usuarioId           String
+  idempotencyKey      String                @db.VarChar(64)
+  status              SigaaSyncRunStatus    @default(RUNNING)
+  leaseGeneration     BigInt
+  leaseExpiresAt      DateTime
+  courseIdentityToken String                @db.Char(64)
+  consentVersion      String                @db.VarChar(64)
+  failureCode         SigaaSyncFailureCode?
+  connectorRequestId  String?               @db.VarChar(64)
+  contractVersion     String?               @db.VarChar(16)
+  upstreamCommit      String?               @db.Char(40)
+  componentCount      Int?
+  gradeCount          Int?
+  classCount          Int?
+  iniciadoEm          DateTime              @default(now())
+  finalizadoEm        DateTime?
+  retentionExpiresAt  DateTime?
+
+  connection        SigaaConnection        @relation("ConnectionRuns", fields: [usuarioId], references: [usuarioId], onDelete: Cascade)
+  activeFor         SigaaConnection?       @relation("ActiveLease")
+  installedSnapshot SigaaAcademicSnapshot?
+
+  @@unique([usuarioId, idempotencyKey])
+  @@unique([usuarioId, id])
+  @@index([usuarioId, iniciadoEm])
+  @@index([status, leaseExpiresAt])
+  @@index([status, retentionExpiresAt])
+}
+
+model SigaaRateLimitBucket {
+  usuarioId       String
+  operation       SigaaRateLimitOperation
+  count           Int
+  windowStartedAt DateTime
+  resetAt         DateTime
+  criadoEm        DateTime                @default(now())
+  atualizadoEm    DateTime                @updatedAt
+
+  usuario Usuario @relation(fields: [usuarioId], references: [id], onDelete: Cascade)
+
+  @@id([usuarioId, operation])
+  @@index([resetAt])
 }
 
 model AuditLog {

--- a/scripts/run-sigaa-db-tests.mjs
+++ b/scripts/run-sigaa-db-tests.mjs
@@ -1,0 +1,116 @@
+import { randomBytes } from "node:crypto";
+import { spawnSync } from "node:child_process";
+
+const databaseNamePattern = /^aquario_sigaa_test(?:_[a-z0-9]+)?$/;
+let containerName = null;
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    stdio: options.capture ? "pipe" : "inherit",
+    env: options.env ?? process.env,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    const output = options.capture ? `${result.stdout ?? ""}${result.stderr ?? ""}` : "";
+    throw new Error(`${command} exited with ${result.status}${output ? `\n${output}` : ""}`);
+  }
+  return result.stdout?.trim() ?? "";
+}
+
+function assertDisposableDatabase(databaseUrl) {
+  const parsed = new URL(databaseUrl);
+  const databaseName = parsed.pathname.slice(1).split("?")[0];
+  const isLocal = parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1";
+  if (!isLocal || !databaseNamePattern.test(databaseName)) {
+    throw new Error(
+      "Refusing SIGAA DB tests outside a local disposable database named aquario_sigaa_test[_suffix]."
+    );
+  }
+}
+
+function startPostgres() {
+  const suffix = randomBytes(6).toString("hex");
+  containerName = `aquario-sigaa-test-${suffix}`;
+  const password = randomBytes(18).toString("hex");
+  run("docker", [
+    "run",
+    "--rm",
+    "--detach",
+    "--name",
+    containerName,
+    "--env",
+    `POSTGRES_PASSWORD=${password}`,
+    "--env",
+    "POSTGRES_DB=aquario_sigaa_test",
+    "--publish",
+    "127.0.0.1::5432",
+    "postgres:16-alpine",
+  ]);
+
+  let ready = false;
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    const probe = spawnSync("docker", ["exec", containerName, "pg_isready", "-U", "postgres"], {
+      stdio: "ignore",
+    });
+    if (probe.status === 0) {
+      ready = true;
+      break;
+    }
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1000);
+  }
+  if (!ready) {
+    throw new Error("Disposable PostgreSQL did not become ready within 30 seconds.");
+  }
+
+  const portOutput = run("docker", ["port", containerName, "5432/tcp"], { capture: true });
+  const port = portOutput.match(/:(\d+)$/)?.[1];
+  if (!port) {
+    throw new Error("Could not resolve the disposable PostgreSQL port.");
+  }
+  return `postgresql://postgres:${password}@127.0.0.1:${port}/aquario_sigaa_test`;
+}
+
+try {
+  const databaseUrl = process.env.SIGAA_TEST_DATABASE_URL || startPostgres();
+  assertDisposableDatabase(databaseUrl);
+  const environment = {
+    ...process.env,
+    DATABASE_URL: databaseUrl,
+    NODE_ENV: "test",
+  };
+
+  run(process.execPath, ["node_modules/prisma/build/index.js", "migrate", "deploy"], {
+    env: environment,
+  });
+  run(
+    process.execPath,
+    [
+      "node_modules/prisma/build/index.js",
+      "migrate",
+      "diff",
+      "--from-url",
+      databaseUrl,
+      "--to-schema-datamodel",
+      "prisma/schema.prisma",
+      "--exit-code",
+    ],
+    { env: environment }
+  );
+  run(
+    process.execPath,
+    [
+      "node_modules/vitest/vitest.mjs",
+      "--run",
+      "src/lib/server/db/implementations/prisma/__tests__/prisma-sigaa-repository.integration.test.ts",
+      "--reporter=verbose",
+    ],
+    { env: environment }
+  );
+} finally {
+  if (containerName) {
+    spawnSync("docker", ["rm", "--force", containerName], { stdio: "ignore" });
+  }
+}

--- a/scripts/run-sigaa-db-tests.mjs
+++ b/scripts/run-sigaa-db-tests.mjs
@@ -3,6 +3,7 @@ import { spawnSync } from "node:child_process";
 
 const databaseNamePattern = /^aquario_sigaa_test(?:_[a-z0-9]+)?$/;
 let containerName = null;
+const prismaCli = "node_modules/prisma/build/index.js";
 
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, {
@@ -73,22 +74,15 @@ function startPostgres() {
   return `postgresql://postgres:${password}@127.0.0.1:${port}/aquario_sigaa_test`;
 }
 
-try {
-  const databaseUrl = process.env.SIGAA_TEST_DATABASE_URL || startPostgres();
-  assertDisposableDatabase(databaseUrl);
-  const environment = {
-    ...process.env,
-    DATABASE_URL: databaseUrl,
-    NODE_ENV: "test",
-  };
+function deployMigrations(environment) {
+  run(process.execPath, [prismaCli, "migrate", "deploy"], { env: environment });
+}
 
-  run(process.execPath, ["node_modules/prisma/build/index.js", "migrate", "deploy"], {
-    env: environment,
-  });
+function assertNoSchemaDrift(databaseUrl, environment) {
   run(
     process.execPath,
     [
-      "node_modules/prisma/build/index.js",
+      prismaCli,
       "migrate",
       "diff",
       "--from-url",
@@ -99,6 +93,9 @@ try {
     ],
     { env: environment }
   );
+}
+
+function runRepositoryTests(environment) {
   run(
     process.execPath,
     [
@@ -109,6 +106,36 @@ try {
     ],
     { env: environment }
   );
+}
+
+try {
+  const databaseUrl = process.env.SIGAA_TEST_DATABASE_URL || startPostgres();
+  assertDisposableDatabase(databaseUrl);
+  const environment = {
+    ...process.env,
+    DATABASE_URL: databaseUrl,
+    NODE_ENV: "test",
+  };
+
+  deployMigrations(environment);
+  assertNoSchemaDrift(databaseUrl, environment);
+  runRepositoryTests(environment);
+  run(
+    process.execPath,
+    [
+      prismaCli,
+      "db",
+      "execute",
+      "--url",
+      databaseUrl,
+      "--file",
+      "scripts/sql/verify-sigaa-persistence-reversal.sql",
+    ],
+    { env: environment }
+  );
+  deployMigrations(environment);
+  assertNoSchemaDrift(databaseUrl, environment);
+  runRepositoryTests(environment);
 } finally {
   if (containerName) {
     spawnSync("docker", ["rm", "--force", containerName], { stdio: "ignore" });

--- a/scripts/sql/verify-sigaa-persistence-reversal.sql
+++ b/scripts/sql/verify-sigaa-persistence-reversal.sql
@@ -1,0 +1,105 @@
+BEGIN;
+
+CREATE TEMPORARY TABLE "_SigaaReversalBaseline" ON COMMIT DROP AS
+SELECT
+    COUNT(*) AS "usuarioCount",
+    MD5(
+        COALESCE(
+            JSONB_AGG(JSONB_BUILD_ARRAY("id", "matricula") ORDER BY "id")::TEXT,
+            '[]'
+        )
+    ) AS "usuarioFingerprint"
+FROM "Usuario";
+
+ALTER TABLE "SigaaConnection"
+DROP CONSTRAINT "SigaaConnection_usuarioId_leaseRunId_fkey";
+
+ALTER TABLE "SigaaAcademicSnapshot"
+DROP CONSTRAINT "SigaaAcademicSnapshot_usuarioId_installedByRunId_fkey";
+
+DROP TABLE "SigaaAcademicSnapshot";
+DROP TABLE "SigaaSyncRun";
+DROP TABLE "SigaaConnection";
+DROP TABLE "SigaaRateLimitBucket";
+
+ALTER TABLE "Usuario"
+DROP CONSTRAINT "Usuario_matricula_provenance_check",
+DROP COLUMN "matriculaVerificadaPeloSigaaEm",
+DROP COLUMN "matriculaOrigem";
+
+DROP TYPE "SigaaRateLimitOperation";
+DROP TYPE "SigaaSyncFailureCode";
+DROP TYPE "SigaaSyncRunStatus";
+DROP TYPE "SigaaConnectionStatus";
+DROP TYPE "MatriculaOrigem";
+
+DO $$
+DECLARE
+    baseline RECORD;
+    current_count BIGINT;
+    current_fingerprint TEXT;
+    deleted_migration_count BIGINT;
+BEGIN
+    SELECT * INTO STRICT baseline FROM "_SigaaReversalBaseline";
+    SELECT
+        COUNT(*),
+        MD5(
+            COALESCE(
+                JSONB_AGG(JSONB_BUILD_ARRAY("id", "matricula") ORDER BY "id")::TEXT,
+                '[]'
+            )
+        )
+    INTO current_count, current_fingerprint
+    FROM "Usuario";
+
+    IF current_count <> baseline."usuarioCount"
+        OR current_fingerprint <> baseline."usuarioFingerprint" THEN
+        RAISE EXCEPTION 'SIGAA reversal changed pre-existing Usuario identity data';
+    END IF;
+
+    IF TO_REGCLASS('"AuditLog"') IS NULL THEN
+        RAISE EXCEPTION 'SIGAA reversal removed a pre-existing table';
+    END IF;
+
+    IF TO_REGCLASS('"SigaaConnection"') IS NOT NULL
+        OR TO_REGCLASS('"SigaaSyncRun"') IS NOT NULL
+        OR TO_REGCLASS('"SigaaAcademicSnapshot"') IS NOT NULL
+        OR TO_REGCLASS('"SigaaRateLimitBucket"') IS NOT NULL THEN
+        RAISE EXCEPTION 'SIGAA reversal left persistence tables behind';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE "table_schema" = 'public'
+          AND "table_name" = 'Usuario'
+          AND "column_name" IN ('matriculaOrigem', 'matriculaVerificadaPeloSigaaEm')
+    ) THEN
+        RAISE EXCEPTION 'SIGAA reversal left Usuario columns behind';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM PG_TYPE
+        WHERE "typname" IN (
+            'MatriculaOrigem',
+            'SigaaConnectionStatus',
+            'SigaaSyncRunStatus',
+            'SigaaSyncFailureCode',
+            'SigaaRateLimitOperation'
+        )
+    ) THEN
+        RAISE EXCEPTION 'SIGAA reversal left enum types behind';
+    END IF;
+
+    DELETE FROM "_prisma_migrations"
+    WHERE "migration_name" = '20260821090000_add_sigaa_persistence';
+    GET DIAGNOSTICS deleted_migration_count = ROW_COUNT;
+
+    IF deleted_migration_count <> 1 THEN
+        RAISE EXCEPTION 'SIGAA reversal expected one exact migration history record, deleted %',
+            deleted_migration_count;
+    END IF;
+END $$;
+
+COMMIT;

--- a/scripts/verify-sigaa-boundary.mjs
+++ b/scripts/verify-sigaa-boundary.mjs
@@ -1,0 +1,58 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { extname, join } from "node:path";
+
+const schema = readFileSync("prisma/schema.prisma", "utf8");
+const sigaaModels = [...schema.matchAll(/model (Sigaa\w+) \{([\s\S]*?)\n\}/g)];
+const forbiddenField =
+  /password|senha|username|cookie|html|pdf|viewstate|raw(?:body|error|response)|requestbody|responsebody|bearer/i;
+
+if (sigaaModels.length !== 4) {
+  throw new Error(`Expected four SIGAA persistence models, found ${sigaaModels.length}.`);
+}
+
+for (const [, modelName, body] of sigaaModels) {
+  const fields = body
+    .split("\n")
+    .map(line => line.trim().split(/\s+/)[0])
+    .filter(field => field && !field.startsWith("@@") && !field.startsWith("//"));
+  const forbidden = fields.find(field => forbiddenField.test(field));
+  if (forbidden) {
+    throw new Error(`${modelName}.${forbidden} violates the SIGAA persistence boundary.`);
+  }
+  if (/DisciplinaConcluida|DisciplinaSemestre/.test(body)) {
+    throw new Error(`${modelName} must not own manual academic rows.`);
+  }
+}
+
+const jsonFields = sigaaModels.flatMap(([, modelName, body]) =>
+  body
+    .split("\n")
+    .filter(line => /\sJson\??(?:\s|$)/.test(line))
+    .map(line => `${modelName}.${line.trim().split(/\s+/)[0]}`)
+);
+if (jsonFields.join(",") !== "SigaaAcademicSnapshot.payload") {
+  throw new Error(`Unexpected SIGAA JSON fields: ${jsonFields.join(", ") || "none"}.`);
+}
+
+if (!/matriculaOrigem\s+MatriculaOrigem\?/.test(schema)) {
+  throw new Error("Usuario.matriculaOrigem is required by the SIGAA provenance boundary.");
+}
+
+function sourceFiles(root) {
+  return readdirSync(root, { withFileTypes: true }).flatMap(entry => {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) return sourceFiles(path);
+    return [".ts", ".tsx"].includes(extname(entry.name)) ? [path] : [];
+  });
+}
+
+for (const root of ["src/lib/client", "src/lib/shared", "src/components"]) {
+  for (const path of sourceFiles(root)) {
+    const source = readFileSync(path, "utf8");
+    if (/from ["']@\/lib\/server\/(?:services\/sigaa|db\/interfaces\/sigaa)/.test(source)) {
+      throw new Error(`${path} imports the server-only SIGAA persistence boundary.`);
+    }
+  }
+}
+
+console.log("SIGAA persistence boundary verified.");

--- a/src/lib/server/container/index.ts
+++ b/src/lib/server/container/index.ts
@@ -124,6 +124,9 @@ function createPrismaContainer(): Container {
   const {
     PrismaAuditLogsRepository,
   } = require("@/lib/server/db/implementations/prisma/prisma-audit-logs-repository");
+  const {
+    PrismaSigaaRepository,
+  } = require("@/lib/server/db/implementations/prisma/prisma-sigaa-repository");
 
   return {
     usuariosRepository: new PrismaUsuariosRepository(),
@@ -146,6 +149,7 @@ function createPrismaContainer(): Container {
     searchRepository: new PrismaSearchRepository(),
     projetosRepository: new PrismaProjetosRepository(),
     auditLogsRepository: new PrismaAuditLogsRepository(),
+    sigaaRepository: new PrismaSigaaRepository(),
     emailService: getEmailService(),
     blobStorage: getBlobStorage(),
   };

--- a/src/lib/server/container/types.ts
+++ b/src/lib/server/container/types.ts
@@ -20,6 +20,7 @@ import type { IDisciplinaRepository } from "@/lib/server/db/interfaces/disciplin
 import type { IDisciplinaConcluidaRepository } from "@/lib/server/db/interfaces/disciplina-concluida-repository.interface";
 import type { ISearchRepository } from "@/lib/server/db/interfaces/search-repository.interface";
 import type { IAuditLogsRepository } from "@/lib/server/db/interfaces/audit-logs-repository.interface";
+import type { ISigaaRepository } from "@/lib/server/db/interfaces/sigaa-repository.interface";
 import type { IEmailService } from "@/lib/server/services/email/email-service.interface";
 import type { IBlobStorage } from "@/lib/server/services/blob/blob-storage.interface";
 
@@ -51,6 +52,7 @@ export type Container = {
   disciplinaConcluidaRepository: IDisciplinaConcluidaRepository;
   searchRepository: ISearchRepository;
   auditLogsRepository: IAuditLogsRepository;
+  sigaaRepository: ISigaaRepository;
 
   // Services
   emailService: IEmailService;

--- a/src/lib/server/db/implementations/prisma/__tests__/prisma-sigaa-repository.integration.test.ts
+++ b/src/lib/server/db/implementations/prisma/__tests__/prisma-sigaa-repository.integration.test.ts
@@ -1,0 +1,652 @@
+import { randomUUID } from "crypto";
+import { PrismaClient } from "@prisma/client";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { PrismaSigaaRepository } from "@/lib/server/db/implementations/prisma/prisma-sigaa-repository";
+import { PrismaUsuariosRepository } from "@/lib/server/db/implementations/prisma/prisma-usuarios-repository";
+import { prisma as sharedPrisma } from "@/lib/server/db/prisma";
+import {
+  idempotencyKeySchema,
+  leaseSecretSchema,
+  sigaaSnapshotCandidateSchema,
+  usuarioIdSchema,
+  type SigaaSnapshotCandidate,
+  type UsuarioId,
+} from "@/lib/server/services/sigaa/storage.types";
+
+const database = new PrismaClient();
+const repository = new PrismaSigaaRepository(database);
+
+type OwnerOptions = {
+  matricula?: string;
+  matriculaOrigem?: "LEGACY" | "MANUAL";
+  courseName?: string;
+};
+
+async function createOwner(options: OwnerOptions = {}): Promise<UsuarioId> {
+  const campus = await database.campus.create({ data: { nome: `Campus ${randomUUID()}` } });
+  const centro = await database.centro.create({
+    data: {
+      nome: `Centro ${randomUUID()}`,
+      sigla: `C${randomUUID().slice(0, 7)}`,
+      campusId: campus.id,
+    },
+  });
+  const curso = await database.curso.create({
+    data: {
+      nome: options.courseName ?? `Ciência da Computação ${randomUUID()}`,
+      centroId: centro.id,
+    },
+  });
+  const owner = await database.usuario.create({
+    data: {
+      nome: "Usuário de teste",
+      email: `${randomUUID()}@example.com`,
+      centroId: centro.id,
+      cursoId: curso.id,
+      matricula: options.matricula,
+      matriculaOrigem: options.matricula ? (options.matriculaOrigem ?? "MANUAL") : null,
+    },
+  });
+  return usuarioIdSchema.parse(owner.id);
+}
+
+async function ownerCourse(ownerId: UsuarioId): Promise<string> {
+  const owner = await database.usuario.findUniqueOrThrow({
+    where: { id: ownerId },
+    select: { curso: { select: { nome: true } } },
+  });
+  return owner.curso.nome;
+}
+
+function candidate(matricula: string, courseName: string, marker = "A"): SigaaSnapshotCandidate {
+  return sigaaSnapshotCandidateSchema.parse({
+    contractVersion: "1.0",
+    connectorObservedAt: new Date(),
+    connectorRequestId: randomUUID(),
+    upstreamCommit: marker.toLowerCase().repeat(40),
+    identity: {
+      matricula,
+      sourceCourse: courseName,
+      sourceSemester: "2026.1",
+    },
+    curriculum: {
+      code: "2026.1",
+      maximumCompletionTerm: "2031.2",
+      semesterWorkload: { minimum: 240, maximum: 480 },
+      cra: { value: "8.50", source: "academic_transcript" },
+      progress: [
+        {
+          description: "Total",
+          completedHours: 120,
+          totalHours: 300,
+          remainingHours: 180,
+          completedPercent: 40,
+        },
+      ],
+      components: [
+        {
+          code: `DCC10${marker}`,
+          name: `Componente ${marker}`,
+          integrationType: "OB",
+          period: 1,
+          workloadHours: 60,
+          required: true,
+          status: "completed",
+          prerequisite: null,
+          corequisite: null,
+        },
+      ],
+    },
+    grades: [],
+    classes: [],
+  });
+}
+
+async function reserve(ownerId: UsuarioId, key = randomUUID()) {
+  const result = await repository.reserveAttempt({
+    ownerId,
+    idempotencyKey: idempotencyKeySchema.parse(key),
+    consentVersion: "sigaa-v1-2026-08",
+  });
+  expect(result.kind).toBe("reserved");
+  if (result.kind !== "reserved") {
+    throw new Error(`Expected reservation, received ${result.kind}`);
+  }
+  return result.lease;
+}
+
+beforeEach(async () => {
+  await database.$executeRawUnsafe('TRUNCATE TABLE "Campus" CASCADE');
+});
+
+afterAll(async () => {
+  await Promise.all([database.$disconnect(), sharedPrisma.$disconnect()]);
+});
+
+describe("PrismaSigaaRepository on PostgreSQL", () => {
+  it("enforces provenance, lease, lifecycle, and secret-column constraints", async () => {
+    const ownerId = await createOwner();
+    await expect(
+      database.$executeRawUnsafe(
+        'UPDATE "Usuario" SET "matricula" = $1 WHERE "id" = $2',
+        "20260000001",
+        ownerId
+      )
+    ).rejects.toThrow();
+
+    await database.sigaaConnection.create({ data: { usuarioId: ownerId } });
+    await expect(
+      database.$executeRawUnsafe(
+        'UPDATE "SigaaConnection" SET "leaseTokenDigest" = $1 WHERE "usuarioId" = $2',
+        "a".repeat(64),
+        ownerId
+      )
+    ).rejects.toThrow();
+    await expect(
+      database.$executeRawUnsafe(
+        `INSERT INTO "SigaaSyncRun"
+          ("id", "usuarioId", "idempotencyKey", "leaseGeneration", "leaseExpiresAt", "courseIdentityToken", "consentVersion", "finalizadoEm")
+         VALUES ($1, $2, $3, 1, clock_timestamp() + interval '4 minutes', $4, $5, clock_timestamp())`,
+        randomUUID(),
+        ownerId,
+        randomUUID(),
+        "a".repeat(64),
+        "sigaa-v1-2026-08"
+      )
+    ).rejects.toThrow();
+
+    const columns = await database.$queryRaw<Array<{ table_name: string; column_name: string }>>`
+      SELECT table_name, column_name
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name LIKE 'Sigaa%'
+    `;
+    expect(
+      columns.filter(({ column_name }) =>
+        /password|senha|username|cookie|html|pdf|viewstate|rawbody|rawerror|bearer/i.test(
+          column_name
+        )
+      )
+    ).toEqual([]);
+  });
+
+  it("enforces owner-scoped run references and repository isolation across users", async () => {
+    const firstOwner = await createOwner();
+    const secondOwner = await createOwner();
+    const firstLease = await reserve(firstOwner);
+    const secondLease = await reserve(secondOwner);
+
+    await expect(
+      database.$executeRaw`
+        UPDATE "SigaaConnection"
+        SET "leaseRunId" = ${secondLease.runId}
+        WHERE "usuarioId" = ${firstOwner}
+      `
+    ).rejects.toThrow();
+    await expect(
+      repository.commitLatest({
+        ownerId: secondOwner,
+        lease: firstLease,
+        candidate: candidate("20260000011", await ownerCourse(secondOwner)),
+      })
+    ).rejects.toThrow("SIGAA_ATTEMPT_NOT_FOUND");
+    expect(
+      await database.sigaaSyncRun.findUniqueOrThrow({ where: { id: firstLease.runId } })
+    ).toMatchObject({ status: "RUNNING", failureCode: null });
+
+    await repository.commitLatest({
+      ownerId: firstOwner,
+      lease: firstLease,
+      candidate: candidate("20260000012", await ownerCourse(firstOwner), "c"),
+    });
+    await repository.commitLatest({
+      ownerId: secondOwner,
+      lease: secondLease,
+      candidate: candidate("20260000013", await ownerCourse(secondOwner), "d"),
+    });
+    await expect(
+      database.$executeRaw`
+        UPDATE "SigaaAcademicSnapshot"
+        SET "installedByRunId" = ${secondLease.runId}
+        WHERE "usuarioId" = ${firstOwner}
+      `
+    ).rejects.toThrow();
+    expect((await repository.readImportedState(firstOwner)).matricula.value).toBe("20260000012");
+    expect((await repository.readImportedState(secondOwner)).matricula.value).toBe("20260000013");
+  });
+
+  it("checks idempotency before charging the synchronization budget", async () => {
+    const ownerId = await createOwner();
+    const key = randomUUID();
+    const [first, replay] = await Promise.all(
+      Array.from({ length: 2 }, () =>
+        repository.reserveAttempt({
+          ownerId,
+          idempotencyKey: idempotencyKeySchema.parse(key),
+          consentVersion: "sigaa-v1-2026-08",
+        })
+      )
+    );
+
+    expect([first.kind, replay.kind].sort()).toEqual(["replay", "reserved"]);
+    expect(
+      await database.sigaaRateLimitBucket.findUniqueOrThrow({
+        where: { usuarioId_operation: { usuarioId: ownerId, operation: "SYNC" } },
+      })
+    ).toMatchObject({ count: 1 });
+  });
+
+  it("supersedes expired generations and rejects their late commits", async () => {
+    const ownerId = await createOwner();
+    const courseName = await ownerCourse(ownerId);
+    const firstLease = await reserve(ownerId);
+
+    await database.sigaaConnection.update({
+      where: { usuarioId: ownerId },
+      data: { leaseExpiresAt: new Date(Date.now() - 60_000) },
+    });
+    const secondLease = await reserve(ownerId);
+
+    const stale = await repository.commitLatest({
+      ownerId,
+      lease: firstLease,
+      candidate: candidate("20260000001", courseName, "a"),
+    });
+    expect(stale).toMatchObject({ kind: "rejected", failure: "LEASE_LOST" });
+
+    const latest = await repository.commitLatest({
+      ownerId,
+      lease: secondLease,
+      candidate: candidate("20260000001", courseName, "b"),
+    });
+    expect(latest.kind).toBe("committed");
+    expect((await repository.readImportedState(ownerId)).snapshot?.upstreamCommit).toBe(
+      "b".repeat(40)
+    );
+    expect(
+      await database.sigaaSyncRun.findUniqueOrThrow({ where: { id: firstLease.runId } })
+    ).toMatchObject({
+      status: "SUPERSEDED",
+      failureCode: "LEASE_LOST",
+    });
+  });
+
+  it("closes an authenticated attempt when the run lease expires without a replacement", async () => {
+    const ownerId = await createOwner();
+    const lease = await reserve(ownerId);
+    await database.sigaaSyncRun.update({
+      where: { id: lease.runId },
+      data: { leaseExpiresAt: new Date(Date.now() - 60_000) },
+    });
+
+    expect(
+      await repository.commitLatest({
+        ownerId,
+        lease,
+        candidate: candidate("20260000014", await ownerCourse(ownerId)),
+      })
+    ).toMatchObject({
+      kind: "rejected",
+      failure: "LEASE_LOST",
+      run: { status: "SUPERSEDED", failureCode: "LEASE_LOST" },
+    });
+    expect(
+      await database.sigaaSyncRun.findUniqueOrThrow({ where: { id: lease.runId } })
+    ).toMatchObject({
+      status: "SUPERSEDED",
+      failureCode: "LEASE_LOST",
+      finalizadoEm: expect.any(Date),
+      retentionExpiresAt: expect.any(Date),
+    });
+    expect(
+      await database.sigaaConnection.findUniqueOrThrow({ where: { usuarioId: ownerId } })
+    ).toMatchObject({ leaseRunId: null, leaseTokenDigest: null, leaseExpiresAt: null });
+    expect(
+      await database.sigaaAcademicSnapshot.findUnique({ where: { usuarioId: ownerId } })
+    ).toBeNull();
+  });
+
+  it("closes an authenticated attempt when the connection lease expires without a replacement", async () => {
+    const ownerId = await createOwner();
+    const lease = await reserve(ownerId);
+    await database.sigaaConnection.update({
+      where: { usuarioId: ownerId },
+      data: { leaseExpiresAt: new Date(Date.now() - 60_000) },
+    });
+
+    expect(
+      await repository.commitLatest({
+        ownerId,
+        lease,
+        candidate: candidate("20260000018", await ownerCourse(ownerId)),
+      })
+    ).toMatchObject({
+      kind: "rejected",
+      failure: "LEASE_LOST",
+      run: { status: "SUPERSEDED", failureCode: "LEASE_LOST" },
+    });
+    expect(
+      await database.sigaaConnection.findUniqueOrThrow({ where: { usuarioId: ownerId } })
+    ).toMatchObject({ leaseRunId: null, leaseTokenDigest: null, leaseExpiresAt: null });
+  });
+
+  it("does not mutate an attempt when a supplied lease authentication token is invalid", async () => {
+    const ownerId = await createOwner();
+    const lease = await reserve(ownerId);
+    const invalidLease = { ...lease, secret: leaseSecretSchema.parse("f".repeat(64)) };
+
+    expect(
+      await repository.commitLatest({
+        ownerId,
+        lease: invalidLease,
+        candidate: candidate("20260000015", await ownerCourse(ownerId)),
+      })
+    ).toMatchObject({ kind: "rejected", failure: "LEASE_LOST", run: { status: "RUNNING" } });
+    expect(
+      await repository.commitLatest({
+        ownerId,
+        lease: { ...lease, courseIdentityToken: "0".repeat(64) },
+        candidate: candidate("20260000015", await ownerCourse(ownerId)),
+      })
+    ).toMatchObject({ kind: "rejected", failure: "LEASE_LOST", run: { status: "RUNNING" } });
+    expect(
+      await database.sigaaSyncRun.findUniqueOrThrow({ where: { id: lease.runId } })
+    ).toMatchObject({
+      status: "RUNNING",
+      failureCode: null,
+      finalizadoEm: null,
+      retentionExpiresAt: null,
+    });
+    expect(
+      await database.sigaaConnection.findUniqueOrThrow({ where: { usuarioId: ownerId } })
+    ).toMatchObject({ leaseRunId: lease.runId });
+  });
+
+  it("keeps consent unchanged when a live attempt makes a new reservation busy", async () => {
+    const ownerId = await createOwner();
+    await reserve(ownerId);
+    const before = await database.sigaaConnection.findUniqueOrThrow({
+      where: { usuarioId: ownerId },
+    });
+
+    expect(
+      await repository.reserveAttempt({
+        ownerId,
+        idempotencyKey: idempotencyKeySchema.parse(randomUUID()),
+        consentVersion: "sigaa-v2-should-not-stick",
+      })
+    ).toMatchObject({ kind: "busy" });
+    expect(
+      await database.sigaaConnection.findUniqueOrThrow({ where: { usuarioId: ownerId } })
+    ).toMatchObject({
+      consentVersion: before.consentVersion,
+      consentedAt: before.consentedAt,
+      leaseRunId: before.leaseRunId,
+    });
+  });
+
+  it("rejects a commit when the reserved course identity changed", async () => {
+    const ownerId = await createOwner();
+    const reservedCourse = await ownerCourse(ownerId);
+    const lease = await reserve(ownerId);
+    const owner = await database.usuario.findUniqueOrThrow({
+      where: { id: ownerId },
+      select: { cursoId: true },
+    });
+    await database.curso.update({
+      where: { id: owner.cursoId },
+      data: { nome: `Curso alterado ${randomUUID()}` },
+    });
+
+    expect(
+      await repository.commitLatest({
+        ownerId,
+        lease,
+        candidate: candidate("20260000006", reservedCourse),
+      })
+    ).toMatchObject({ kind: "rejected", failure: "COURSE_MISMATCH" });
+    expect(
+      await database.sigaaAcademicSnapshot.findUnique({ where: { usuarioId: ownerId } })
+    ).toBeNull();
+  });
+
+  it("claims matricula atomically and rejects ownership conflicts without a snapshot", async () => {
+    const claimedOwner = await createOwner();
+    const claimedCourse = await ownerCourse(claimedOwner);
+    const claimedLease = await reserve(claimedOwner);
+    expect(
+      await repository.commitLatest({
+        ownerId: claimedOwner,
+        lease: claimedLease,
+        candidate: candidate("20260000002", claimedCourse),
+      })
+    ).toMatchObject({ kind: "committed" });
+    expect(await database.usuario.findUniqueOrThrow({ where: { id: claimedOwner } })).toMatchObject(
+      {
+        matricula: "20260000002",
+        matriculaOrigem: "SIGAA",
+      }
+    );
+
+    const conflictingOwner = await createOwner();
+    const conflictingCourse = await ownerCourse(conflictingOwner);
+    const conflictingLease = await reserve(conflictingOwner);
+    expect(
+      await repository.commitLatest({
+        ownerId: conflictingOwner,
+        lease: conflictingLease,
+        candidate: candidate("20260000002", conflictingCourse),
+      })
+    ).toMatchObject({ kind: "rejected", failure: "SIGAA_IDENTITY_MISMATCH" });
+    expect(
+      await database.usuario.findUniqueOrThrow({ where: { id: conflictingOwner } })
+    ).toMatchObject({
+      matricula: null,
+      matriculaOrigem: null,
+    });
+    expect(
+      await database.sigaaAcademicSnapshot.findUnique({ where: { usuarioId: conflictingOwner } })
+    ).toBeNull();
+  });
+
+  it("serializes a SIGAA claim against a real manual Usuario writer", async () => {
+    const sigaaOwner = await createOwner();
+    const profile = await database.usuario.findUniqueOrThrow({
+      where: { id: sigaaOwner },
+      select: { centroId: true, cursoId: true },
+    });
+    const lease = await reserve(sigaaOwner);
+    const matricula = "20260000016";
+    const usuariosRepository = new PrismaUsuariosRepository();
+
+    const [sigaaResult, manualResult] = await Promise.allSettled([
+      repository.commitLatest({
+        ownerId: sigaaOwner,
+        lease,
+        candidate: candidate(matricula, await ownerCourse(sigaaOwner)),
+      }),
+      usuariosRepository.create({
+        nome: "Manual concorrente",
+        email: `${randomUUID()}@example.com`,
+        centroId: profile.centroId,
+        cursoId: profile.cursoId,
+        matricula,
+      }),
+    ]);
+
+    expect(sigaaResult.status).toBe("fulfilled");
+    if (sigaaResult.status === "fulfilled") {
+      expect(sigaaResult.value).toMatchObject(
+        manualResult.status === "fulfilled"
+          ? { kind: "rejected", failure: "SIGAA_IDENTITY_MISMATCH" }
+          : { kind: "committed" }
+      );
+    }
+    if (manualResult.status === "rejected") {
+      expect(manualResult.reason).toBeInstanceOf(Error);
+      expect((manualResult.reason as Error).message).toBe("MATRICULA_ALREADY_IN_USE");
+      expect((manualResult.reason as Error).message).not.toContain("P2002");
+    }
+    expect(await database.usuario.count({ where: { matricula } })).toBe(1);
+  });
+
+  it("preserves connectedAt across refreshes and resets it only after disconnect", async () => {
+    const ownerId = await createOwner();
+    const courseName = await ownerCourse(ownerId);
+    const firstLease = await reserve(ownerId);
+    await repository.commitLatest({
+      ownerId,
+      lease: firstLease,
+      candidate: candidate("20260000017", courseName, "e"),
+    });
+    const firstConnectedAt = (
+      await database.sigaaConnection.findUniqueOrThrow({ where: { usuarioId: ownerId } })
+    ).connectedAt;
+    expect(firstConnectedAt).not.toBeNull();
+
+    await database.$queryRaw`SELECT 1::integer AS "ready" FROM pg_sleep(0.02)`;
+    const refreshLease = await reserve(ownerId);
+    await repository.commitLatest({
+      ownerId,
+      lease: refreshLease,
+      candidate: candidate("20260000017", courseName, "f"),
+    });
+    expect(
+      (await database.sigaaConnection.findUniqueOrThrow({ where: { usuarioId: ownerId } }))
+        .connectedAt
+    ).toEqual(firstConnectedAt);
+
+    await repository.disconnect(ownerId);
+    await database.$queryRaw`SELECT 1::integer AS "ready" FROM pg_sleep(0.02)`;
+    const reconnectLease = await reserve(ownerId);
+    await repository.commitLatest({
+      ownerId,
+      lease: reconnectLease,
+      candidate: candidate("20260000017", courseName, "0"),
+    });
+    const reconnectedAt = (
+      await database.sigaaConnection.findUniqueOrThrow({ where: { usuarioId: ownerId } })
+    ).connectedAt;
+    expect(reconnectedAt?.getTime()).toBeGreaterThan(firstConnectedAt?.getTime() ?? 0);
+  });
+
+  it("preserves manual matricula and academic rows through disconnect and imported-data deletion", async () => {
+    const ownerId = await createOwner({
+      matricula: "20260000003",
+      matriculaOrigem: "MANUAL",
+    });
+    const owner = await database.usuario.findUniqueOrThrow({ where: { id: ownerId } });
+    const discipline = await database.disciplina.create({
+      data: { codigo: `D${randomUUID()}`, nome: "Disciplina manual" },
+    });
+    const semester = await database.semestreLetivo.create({
+      data: {
+        nome: `2026.1-${randomUUID()}`,
+        dataInicio: new Date("2026-01-01T00:00:00Z"),
+        dataFim: new Date("2026-06-30T00:00:00Z"),
+      },
+    });
+    await database.disciplinaConcluida.create({
+      data: { usuarioId: ownerId, disciplinaId: discipline.id },
+    });
+    await database.disciplinaSemestre.create({
+      data: {
+        usuarioId: ownerId,
+        disciplinaId: discipline.id,
+        semestreLetivoId: semester.id,
+      },
+    });
+
+    const lease = await reserve(ownerId);
+    await repository.commitLatest({
+      ownerId,
+      lease,
+      candidate: candidate("20260000003", await ownerCourse(ownerId)),
+    });
+    await repository.disconnect(ownerId);
+    expect((await repository.readImportedState(ownerId)).snapshot).not.toBeNull();
+
+    expect(await repository.deleteImportedData(ownerId)).toMatchObject({
+      kind: "deleted",
+      matriculaCleared: false,
+    });
+    expect(await database.usuario.findUniqueOrThrow({ where: { id: owner.id } })).toMatchObject({
+      matricula: "20260000003",
+      matriculaOrigem: "MANUAL",
+      matriculaVerificadaPeloSigaaEm: null,
+    });
+    expect(await database.disciplinaConcluida.count({ where: { usuarioId: ownerId } })).toBe(1);
+    expect(await database.disciplinaSemestre.count({ where: { usuarioId: ownerId } })).toBe(1);
+    expect(await database.sigaaConnection.findUnique({ where: { usuarioId: ownerId } })).toBeNull();
+    expect(await database.sigaaRateLimitBucket.count({ where: { usuarioId: ownerId } })).toBe(3);
+  });
+
+  it("serializes concurrent limiter consumption without extending rejected windows", async () => {
+    const ownerId = await createOwner();
+    const decisions = await Promise.all(
+      Array.from({ length: 10 }, () =>
+        repository.consumeRateLimit({ ownerId, operation: "REAUTH" })
+      )
+    );
+    expect(decisions.filter(({ kind }) => kind === "allowed")).toHaveLength(5);
+    expect(decisions.filter(({ kind }) => kind === "rate_limited")).toHaveLength(5);
+
+    const rejectedTimes = decisions
+      .filter(decision => decision.kind === "rate_limited")
+      .map(decision => decision.retryAt.getTime());
+    expect(new Set(rejectedTimes)).toHaveLength(1);
+    expect(
+      await database.sigaaRateLimitBucket.findUniqueOrThrow({
+        where: { usuarioId_operation: { usuarioId: ownerId, operation: "REAUTH" } },
+      })
+    ).toMatchObject({ count: 5 });
+  });
+
+  it("cascades owner deletion through every SIGAA persistence table", async () => {
+    const ownerId = await createOwner();
+    const lease = await reserve(ownerId);
+    await repository.commitLatest({
+      ownerId,
+      lease,
+      candidate: candidate("20260000004", await ownerCourse(ownerId)),
+    });
+
+    await database.usuario.delete({ where: { id: ownerId } });
+    expect(await database.sigaaConnection.count({ where: { usuarioId: ownerId } })).toBe(0);
+    expect(await database.sigaaAcademicSnapshot.count({ where: { usuarioId: ownerId } })).toBe(0);
+    expect(await database.sigaaSyncRun.count({ where: { usuarioId: ownerId } })).toBe(0);
+    expect(await database.sigaaRateLimitBucket.count({ where: { usuarioId: ownerId } })).toBe(0);
+  });
+
+  it("deletes only expired terminal runs and preserves the installed snapshot", async () => {
+    const ownerId = await createOwner();
+    const lease = await reserve(ownerId);
+    await repository.commitLatest({
+      ownerId,
+      lease,
+      candidate: candidate("20260000005", await ownerCourse(ownerId)),
+    });
+    await database.sigaaSyncRun.update({
+      where: { id: lease.runId },
+      data: { retentionExpiresAt: new Date(Date.now() - 60_000) },
+    });
+
+    expect(await repository.deleteExpiredRuns()).toEqual({ deleted: 1 });
+    expect(await database.sigaaSyncRun.findUnique({ where: { id: lease.runId } })).toBeNull();
+    expect(
+      await database.sigaaAcademicSnapshot.findUniqueOrThrow({ where: { usuarioId: ownerId } })
+    ).toMatchObject({
+      installedByRunId: null,
+    });
+
+    const activeLease = await reserve(ownerId);
+    await database.$executeRaw`
+      UPDATE "SigaaSyncRun"
+      SET "iniciadoEm" = clock_timestamp() - interval '120 days'
+      WHERE "id" = ${activeLease.runId}
+    `;
+    expect(await repository.deleteExpiredRuns()).toEqual({ deleted: 0 });
+    expect(
+      await database.sigaaSyncRun.findUnique({ where: { id: activeLease.runId } })
+    ).not.toBeNull();
+  });
+});

--- a/src/lib/server/db/implementations/prisma/prisma-sigaa-repository.ts
+++ b/src/lib/server/db/implementations/prisma/prisma-sigaa-repository.ts
@@ -1,0 +1,824 @@
+import { createHash, randomBytes, randomUUID, timingSafeEqual } from "crypto";
+import { Prisma, PrismaClient } from "@prisma/client";
+import type {
+  CommitLatestResult,
+  DeleteImportedDataResult,
+  DisconnectResult,
+  ImportedAcademicState,
+  ISigaaRepository,
+  LeaseGrant,
+  RateLimitDecision,
+  ReserveAttemptResult,
+  SigaaRateLimitOperation,
+  SigaaRunReceipt,
+  SigaaSyncFailureCode,
+} from "@/lib/server/db/interfaces/sigaa-repository.interface";
+import { prisma } from "@/lib/server/db/prisma";
+import {
+  leaseSecretSchema,
+  matriculaSchema,
+  parseSigaaAcademicSnapshotPayload,
+  parseSigaaSnapshotCandidate,
+  sigaaMatriculaLockKey,
+  sigaaRunIdSchema,
+  toSigaaAcademicSnapshotPayload,
+  type SigaaSnapshotCandidate,
+  type UsuarioId,
+} from "@/lib/server/services/sigaa/storage.types";
+
+const LEASE_SECONDS = 240;
+const RETENTION_SECONDS = 90 * 24 * 60 * 60;
+
+const RATE_LIMIT_POLICIES = {
+  REAUTH: { limit: 5, windowSeconds: 15 * 60 },
+  SYNC: { limit: 3, windowSeconds: 15 * 60 },
+  DISCONNECT: { limit: 5, windowSeconds: 60 * 60 },
+  DELETE_IMPORTED_DATA: { limit: 3, windowSeconds: 24 * 60 * 60 },
+} as const satisfies Record<SigaaRateLimitOperation, { limit: number; windowSeconds: number }>;
+
+type Transaction = Prisma.TransactionClient;
+
+type RunRow = {
+  id: string;
+  status: "RUNNING" | "SUCCEEDED" | "FAILED" | "SUPERSEDED";
+  failureCode: SigaaSyncFailureCode | null;
+  connectorRequestId: string | null;
+  iniciadoEm: Date;
+  finalizadoEm: Date | null;
+};
+
+type DatabaseTimes = {
+  now: Date;
+  leaseExpiresAt: Date;
+  retentionExpiresAt: Date;
+};
+
+const digest = (value: string): string => createHash("sha256").update(value).digest("hex");
+
+const normalizeCourseIdentity = (value: string): string =>
+  value.normalize("NFKC").trim().replace(/\s+/g, " ").toLocaleUpperCase("pt-BR");
+
+const courseIdentityToken = (cursoId: string, courseName: string): string =>
+  digest(`${cursoId}\u0000${normalizeCourseIdentity(courseName)}`);
+
+const secretsEqual = (first: string, second: string): boolean => {
+  const firstBuffer = Buffer.from(first, "hex");
+  const secondBuffer = Buffer.from(second, "hex");
+  return firstBuffer.length === secondBuffer.length && timingSafeEqual(firstBuffer, secondBuffer);
+};
+
+const toRunReceipt = (run: RunRow): SigaaRunReceipt => ({
+  id: sigaaRunIdSchema.parse(run.id),
+  status: run.status,
+  failureCode: run.failureCode,
+  connectorRequestId: run.connectorRequestId,
+  startedAt: run.iniciadoEm,
+  finishedAt: run.finalizadoEm,
+});
+
+const isMatriculaUniqueViolation = (error: unknown): boolean => {
+  if (!(error instanceof Prisma.PrismaClientKnownRequestError) || error.code !== "P2002") {
+    return false;
+  }
+  const target = error.meta?.target;
+  return Array.isArray(target)
+    ? target.some(field => field === "matricula")
+    : typeof target === "string" && target.includes("matricula");
+};
+
+export class PrismaSigaaRepository implements ISigaaRepository {
+  constructor(
+    private readonly database: PrismaClient = prisma,
+    private readonly courseMatches: (profileCourse: string, sigaaCourse: string) => boolean = (
+      profileCourse,
+      sigaaCourse
+    ) => normalizeCourseIdentity(profileCourse) === normalizeCourseIdentity(sigaaCourse)
+  ) {}
+
+  consumeRateLimit(input: {
+    ownerId: UsuarioId;
+    operation: SigaaRateLimitOperation;
+  }): Promise<RateLimitDecision> {
+    return this.database.$transaction(async transaction => {
+      await this.lockRateLimit(transaction, input.ownerId, input.operation);
+      return this.consumeRateLimitInTransaction(transaction, input.ownerId, input.operation);
+    });
+  }
+
+  reserveAttempt(input: {
+    ownerId: UsuarioId;
+    idempotencyKey: string;
+    consentVersion: string;
+  }): Promise<ReserveAttemptResult> {
+    return this.database.$transaction(async transaction => {
+      await this.lockAggregate(transaction, input.ownerId);
+
+      const existing = await transaction.sigaaSyncRun.findUnique({
+        where: {
+          usuarioId_idempotencyKey: {
+            usuarioId: input.ownerId,
+            idempotencyKey: input.idempotencyKey,
+          },
+        },
+      });
+
+      if (existing) {
+        return { kind: "replay", run: toRunReceipt(existing) };
+      }
+
+      await this.lockRateLimit(transaction, input.ownerId, "SYNC");
+      const limit = await this.consumeRateLimitInTransaction(transaction, input.ownerId, "SYNC");
+      if (limit.kind === "rate_limited") {
+        return limit;
+      }
+
+      await this.lockUsuario(transaction, input.ownerId);
+      const owner = await transaction.usuario.findUnique({
+        where: { id: input.ownerId },
+        select: { matricula: true, curso: { select: { id: true, nome: true } } },
+      });
+      if (!owner) {
+        throw new Error("SIGAA_OWNER_NOT_FOUND");
+      }
+
+      const times = await this.databaseTimes(transaction);
+      const existingConnection = await transaction.sigaaConnection.findUnique({
+        where: { usuarioId: input.ownerId },
+      });
+
+      if (
+        existingConnection?.leaseRunId &&
+        existingConnection.leaseExpiresAt &&
+        existingConnection.leaseExpiresAt > times.now
+      ) {
+        return { kind: "busy", retryAt: existingConnection.leaseExpiresAt };
+      }
+
+      const connection = await transaction.sigaaConnection.upsert({
+        where: { usuarioId: input.ownerId },
+        create: {
+          usuarioId: input.ownerId,
+          consentVersion: input.consentVersion,
+          consentedAt: times.now,
+        },
+        update: {
+          consentVersion: input.consentVersion,
+          consentedAt: times.now,
+        },
+      });
+
+      if (connection.leaseRunId) {
+        await transaction.sigaaSyncRun.updateMany({
+          where: { id: connection.leaseRunId, status: "RUNNING" },
+          data: {
+            status: "SUPERSEDED",
+            failureCode: "LEASE_LOST",
+            finalizadoEm: times.now,
+            retentionExpiresAt: times.retentionExpiresAt,
+          },
+        });
+      }
+
+      const runId = sigaaRunIdSchema.parse(randomUUID());
+      const secret = leaseSecretSchema.parse(randomBytes(32).toString("hex"));
+      const generation = connection.leaseGeneration + BigInt(1);
+      const identityToken = courseIdentityToken(owner.curso.id, owner.curso.nome);
+
+      await transaction.sigaaSyncRun.create({
+        data: {
+          id: runId,
+          usuarioId: input.ownerId,
+          idempotencyKey: input.idempotencyKey,
+          leaseGeneration: generation,
+          leaseExpiresAt: times.leaseExpiresAt,
+          courseIdentityToken: identityToken,
+          consentVersion: input.consentVersion,
+        },
+      });
+      await transaction.sigaaConnection.update({
+        where: { usuarioId: input.ownerId },
+        data: {
+          status: connection.status === "DISCONNECTED" ? "PENDING" : connection.status,
+          leaseGeneration: generation,
+          leaseRunId: runId,
+          leaseTokenDigest: digest(secret),
+          leaseExpiresAt: times.leaseExpiresAt,
+        },
+      });
+
+      return {
+        kind: "reserved",
+        lease: {
+          runId,
+          generation,
+          secret,
+          expiresAt: times.leaseExpiresAt,
+          courseIdentityToken: identityToken,
+          expectedMatricula: owner.matricula ? matriculaSchema.parse(owner.matricula) : null,
+        },
+      };
+    });
+  }
+
+  async commitLatest(input: {
+    ownerId: UsuarioId;
+    lease: LeaseGrant;
+    candidate: SigaaSnapshotCandidate;
+  }): Promise<CommitLatestResult> {
+    const candidate = parseSigaaSnapshotCandidate(input.candidate);
+    const payload = toSigaaAcademicSnapshotPayload(candidate);
+
+    try {
+      return await this.database.$transaction(async transaction => {
+        await this.lockAggregate(transaction, input.ownerId);
+        await this.lockUsuario(transaction, input.ownerId);
+        await this.lockConnection(transaction, input.ownerId);
+
+        const [owner, connection, run] = await Promise.all([
+          transaction.usuario.findUnique({
+            where: { id: input.ownerId },
+            select: {
+              matricula: true,
+              matriculaOrigem: true,
+              curso: { select: { id: true, nome: true } },
+            },
+          }),
+          transaction.sigaaConnection.findUnique({ where: { usuarioId: input.ownerId } }),
+          transaction.sigaaSyncRun.findFirst({
+            where: { id: input.lease.runId, usuarioId: input.ownerId },
+          }),
+        ]);
+
+        if (!owner || !connection || !run) {
+          throw new Error("SIGAA_ATTEMPT_NOT_FOUND");
+        }
+
+        const times = await this.databaseTimes(transaction);
+        const ownsAuthenticatedLease =
+          run.status === "RUNNING" &&
+          connection.leaseRunId === run.id &&
+          connection.leaseGeneration === input.lease.generation &&
+          run.leaseGeneration === input.lease.generation &&
+          input.lease.courseIdentityToken === run.courseIdentityToken &&
+          connection.leaseTokenDigest !== null &&
+          secretsEqual(connection.leaseTokenDigest, digest(input.lease.secret));
+
+        if (!ownsAuthenticatedLease) {
+          return { kind: "rejected", run: toRunReceipt(run), failure: "LEASE_LOST" };
+        }
+
+        if (
+          connection.leaseExpiresAt === null ||
+          connection.leaseExpiresAt <= times.now ||
+          run.leaseExpiresAt <= times.now
+        ) {
+          const superseded = await this.supersedeCurrentAttempt(
+            transaction,
+            input.ownerId,
+            run.id,
+            input.lease.generation,
+            times
+          );
+          return { kind: "rejected", run: superseded, failure: "LEASE_LOST" };
+        }
+
+        const currentCourseToken = courseIdentityToken(owner.curso.id, owner.curso.nome);
+        if (
+          currentCourseToken !== run.courseIdentityToken ||
+          candidate.identity.sourceCourse === null ||
+          !this.courseMatches(owner.curso.nome, candidate.identity.sourceCourse)
+        ) {
+          const rejected = await this.rejectCurrentAttempt(
+            transaction,
+            input.ownerId,
+            run.id,
+            input.lease.generation,
+            "COURSE_MISMATCH",
+            times
+          );
+          return { kind: "rejected", run: rejected, failure: "COURSE_MISMATCH" };
+        }
+
+        await this.lockMatricula(transaction, candidate.identity.matricula);
+        const conflictingOwner = await transaction.usuario.findFirst({
+          where: {
+            matricula: candidate.identity.matricula,
+            id: { not: input.ownerId },
+          },
+          select: { id: true },
+        });
+        if (
+          conflictingOwner ||
+          (owner.matricula !== null && owner.matricula !== candidate.identity.matricula)
+        ) {
+          const rejected = await this.rejectCurrentAttempt(
+            transaction,
+            input.ownerId,
+            run.id,
+            input.lease.generation,
+            "SIGAA_IDENTITY_MISMATCH",
+            times
+          );
+          return { kind: "rejected", run: rejected, failure: "SIGAA_IDENTITY_MISMATCH" };
+        }
+
+        await transaction.usuario.update({
+          where: { id: input.ownerId },
+          data: {
+            matricula: candidate.identity.matricula,
+            matriculaOrigem: owner.matricula === null ? "SIGAA" : owner.matriculaOrigem,
+            matriculaVerificadaPeloSigaaEm: times.now,
+          },
+        });
+
+        const snapshot = await transaction.sigaaAcademicSnapshot.upsert({
+          where: { usuarioId: input.ownerId },
+          create: {
+            usuarioId: input.ownerId,
+            contractVersion: candidate.contractVersion,
+            connectorObservedAt: candidate.connectorObservedAt,
+            synchronizedAt: times.now,
+            upstreamCommit: candidate.upstreamCommit,
+            installedByRunId: run.id,
+            payload,
+          },
+          update: {
+            contractVersion: candidate.contractVersion,
+            connectorObservedAt: candidate.connectorObservedAt,
+            synchronizedAt: times.now,
+            upstreamCommit: candidate.upstreamCommit,
+            installedByRunId: run.id,
+            payload,
+          },
+        });
+
+        const completedRun = await transaction.sigaaSyncRun.update({
+          where: { id: run.id },
+          data: {
+            status: "SUCCEEDED",
+            failureCode: null,
+            connectorRequestId: candidate.connectorRequestId,
+            contractVersion: candidate.contractVersion,
+            upstreamCommit: candidate.upstreamCommit,
+            componentCount: candidate.curriculum.components.length,
+            gradeCount: candidate.grades.length,
+            classCount: candidate.classes.length,
+            finalizadoEm: times.now,
+            retentionExpiresAt: times.retentionExpiresAt,
+          },
+        });
+        await transaction.sigaaConnection.update({
+          where: { usuarioId: input.ownerId },
+          data: {
+            status: "CONNECTED",
+            connectedAt:
+              connection.status === "CONNECTED" ? (connection.connectedAt ?? times.now) : times.now,
+            disconnectedAt: null,
+            leaseRunId: null,
+            leaseTokenDigest: null,
+            leaseExpiresAt: null,
+          },
+        });
+
+        return {
+          kind: "committed",
+          run: toRunReceipt(completedRun),
+          synchronizedAt: snapshot.synchronizedAt,
+        };
+      });
+    } catch (error) {
+      if (isMatriculaUniqueViolation(error)) {
+        return this.closeMatriculaConflict(input.ownerId, input.lease);
+      }
+      throw error;
+    }
+  }
+
+  finishAttempt(input: {
+    ownerId: UsuarioId;
+    lease: LeaseGrant;
+    failure: SigaaSyncFailureCode;
+    connectorRequestId?: string;
+  }): Promise<SigaaRunReceipt> {
+    return this.database.$transaction(async transaction => {
+      await this.lockAggregate(transaction, input.ownerId);
+      await this.lockConnection(transaction, input.ownerId);
+
+      const [connection, run] = await Promise.all([
+        transaction.sigaaConnection.findUnique({ where: { usuarioId: input.ownerId } }),
+        transaction.sigaaSyncRun.findFirst({
+          where: { id: input.lease.runId, usuarioId: input.ownerId },
+        }),
+      ]);
+      if (!connection || !run) {
+        throw new Error("SIGAA_ATTEMPT_NOT_FOUND");
+      }
+      if (run.status !== "RUNNING") {
+        return toRunReceipt(run);
+      }
+
+      const ownsCurrentLease =
+        connection.leaseRunId === run.id && connection.leaseGeneration === input.lease.generation;
+      if (
+        ownsCurrentLease &&
+        (!connection.leaseTokenDigest ||
+          !secretsEqual(connection.leaseTokenDigest, digest(input.lease.secret)))
+      ) {
+        throw new Error("SIGAA_LEASE_TOKEN_INVALID");
+      }
+
+      const times = await this.databaseTimes(transaction);
+      const completedRun = await transaction.sigaaSyncRun.update({
+        where: { id: run.id },
+        data: {
+          status: input.failure === "LEASE_LOST" ? "SUPERSEDED" : "FAILED",
+          failureCode: input.failure,
+          connectorRequestId: input.connectorRequestId,
+          finalizadoEm: times.now,
+          retentionExpiresAt: times.retentionExpiresAt,
+        },
+      });
+
+      if (ownsCurrentLease) {
+        await transaction.sigaaConnection.update({
+          where: { usuarioId: input.ownerId },
+          data: { leaseRunId: null, leaseTokenDigest: null, leaseExpiresAt: null },
+        });
+      }
+
+      return toRunReceipt(completedRun);
+    });
+  }
+
+  async readImportedState(ownerId: UsuarioId): Promise<ImportedAcademicState> {
+    const owner = await this.database.usuario.findUnique({
+      where: { id: ownerId },
+      select: {
+        matricula: true,
+        matriculaOrigem: true,
+        matriculaVerificadaPeloSigaaEm: true,
+        sigaaConnection: {
+          include: { snapshot: true },
+        },
+      },
+    });
+    if (!owner) {
+      throw new Error("SIGAA_OWNER_NOT_FOUND");
+    }
+
+    const connection = owner.sigaaConnection;
+    return {
+      matricula: {
+        value: owner.matricula,
+        origin: owner.matriculaOrigem,
+        verifiedAt: owner.matriculaVerificadaPeloSigaaEm,
+      },
+      connection: connection
+        ? {
+            status: connection.status,
+            consentVersion: connection.consentVersion,
+            consentedAt: connection.consentedAt,
+            connectedAt: connection.connectedAt,
+            disconnectedAt: connection.disconnectedAt,
+          }
+        : null,
+      snapshot: connection?.snapshot
+        ? {
+            contractVersion: connection.snapshot.contractVersion,
+            connectorObservedAt: connection.snapshot.connectorObservedAt,
+            synchronizedAt: connection.snapshot.synchronizedAt,
+            upstreamCommit: connection.snapshot.upstreamCommit,
+            installedByRunId: connection.snapshot.installedByRunId,
+            payload: parseSigaaAcademicSnapshotPayload(connection.snapshot.payload),
+          }
+        : null,
+    };
+  }
+
+  disconnect(ownerId: UsuarioId): Promise<DisconnectResult> {
+    return this.database.$transaction(async transaction => {
+      await this.lockAggregate(transaction, ownerId);
+      await this.lockRateLimit(transaction, ownerId, "DISCONNECT");
+      const limit = await this.consumeRateLimitInTransaction(transaction, ownerId, "DISCONNECT");
+      if (limit.kind === "rate_limited") {
+        return limit;
+      }
+
+      await this.lockConnection(transaction, ownerId);
+      const times = await this.databaseTimes(transaction);
+      const connection = await transaction.sigaaConnection.findUnique({
+        where: { usuarioId: ownerId },
+      });
+      if (!connection) {
+        return { kind: "disconnected", disconnectedAt: times.now };
+      }
+
+      if (connection.leaseRunId) {
+        await transaction.sigaaSyncRun.updateMany({
+          where: { id: connection.leaseRunId, status: "RUNNING" },
+          data: {
+            status: "SUPERSEDED",
+            failureCode: "LEASE_LOST",
+            finalizadoEm: times.now,
+            retentionExpiresAt: times.retentionExpiresAt,
+          },
+        });
+      }
+      await transaction.sigaaConnection.update({
+        where: { usuarioId: ownerId },
+        data: {
+          status: "DISCONNECTED",
+          disconnectedAt: times.now,
+          leaseRunId: null,
+          leaseTokenDigest: null,
+          leaseExpiresAt: null,
+        },
+      });
+
+      return { kind: "disconnected", disconnectedAt: times.now };
+    });
+  }
+
+  deleteImportedData(ownerId: UsuarioId): Promise<DeleteImportedDataResult> {
+    return this.database.$transaction(async transaction => {
+      await this.lockAggregate(transaction, ownerId);
+      await this.lockRateLimit(transaction, ownerId, "DELETE_IMPORTED_DATA");
+      const limit = await this.consumeRateLimitInTransaction(
+        transaction,
+        ownerId,
+        "DELETE_IMPORTED_DATA"
+      );
+      if (limit.kind === "rate_limited") {
+        return limit;
+      }
+
+      await this.lockUsuario(transaction, ownerId);
+      await this.lockConnection(transaction, ownerId);
+      const owner = await transaction.usuario.findUnique({
+        where: { id: ownerId },
+        select: {
+          matricula: true,
+          matriculaOrigem: true,
+          sigaaConnection: { include: { snapshot: true } },
+        },
+      });
+      if (!owner) {
+        throw new Error("SIGAA_OWNER_NOT_FOUND");
+      }
+
+      const snapshotPayload = owner.sigaaConnection?.snapshot
+        ? parseSigaaAcademicSnapshotPayload(owner.sigaaConnection.snapshot.payload)
+        : null;
+      const matriculaCleared =
+        owner.matriculaOrigem === "SIGAA" &&
+        owner.matricula !== null &&
+        snapshotPayload?.identity.matricula === owner.matricula;
+
+      if (matriculaCleared) {
+        await transaction.usuario.update({
+          where: { id: ownerId },
+          data: {
+            matricula: null,
+            matriculaOrigem: null,
+            matriculaVerificadaPeloSigaaEm: null,
+          },
+        });
+      } else if (owner.matricula !== null) {
+        await transaction.usuario.update({
+          where: { id: ownerId },
+          data: { matriculaVerificadaPeloSigaaEm: null },
+        });
+      }
+
+      const deleted = await transaction.sigaaConnection.deleteMany({
+        where: { usuarioId: ownerId },
+      });
+      return {
+        kind: "deleted",
+        hadImportedData: deleted.count > 0,
+        matriculaCleared,
+      };
+    });
+  }
+
+  deleteExpiredRuns(): Promise<{ deleted: number }> {
+    return this.database.$transaction(async transaction => {
+      const expired = await transaction.$queryRaw<Array<{ id: string }>>`
+        SELECT "id"
+        FROM "SigaaSyncRun"
+        WHERE "status" <> 'RUNNING'::"SigaaSyncRunStatus"
+          AND "retentionExpiresAt" <= clock_timestamp()
+        FOR UPDATE
+      `;
+      const expiredIds = expired.map(({ id }) => id);
+      if (expiredIds.length === 0) {
+        return { deleted: 0 };
+      }
+
+      await transaction.sigaaAcademicSnapshot.updateMany({
+        where: { installedByRunId: { in: expiredIds } },
+        data: { installedByRunId: null },
+      });
+      const deleted = await transaction.sigaaSyncRun.deleteMany({
+        where: { id: { in: expiredIds } },
+      });
+      return { deleted: deleted.count };
+    });
+  }
+
+  private async rejectCurrentAttempt(
+    transaction: Transaction,
+    ownerId: UsuarioId,
+    runId: string,
+    generation: bigint,
+    failure: "COURSE_MISMATCH" | "SIGAA_IDENTITY_MISMATCH",
+    times: DatabaseTimes
+  ): Promise<SigaaRunReceipt> {
+    const run = await transaction.sigaaSyncRun.update({
+      where: { id: runId },
+      data: {
+        status: "FAILED",
+        failureCode: failure,
+        finalizadoEm: times.now,
+        retentionExpiresAt: times.retentionExpiresAt,
+      },
+    });
+    await transaction.sigaaConnection.updateMany({
+      where: { usuarioId: ownerId, leaseRunId: runId, leaseGeneration: generation },
+      data: { leaseRunId: null, leaseTokenDigest: null, leaseExpiresAt: null },
+    });
+    return toRunReceipt(run);
+  }
+
+  private async supersedeCurrentAttempt(
+    transaction: Transaction,
+    ownerId: UsuarioId,
+    runId: string,
+    generation: bigint,
+    times: DatabaseTimes
+  ): Promise<SigaaRunReceipt> {
+    const run = await transaction.sigaaSyncRun.update({
+      where: { id: runId },
+      data: {
+        status: "SUPERSEDED",
+        failureCode: "LEASE_LOST",
+        finalizadoEm: times.now,
+        retentionExpiresAt: times.retentionExpiresAt,
+      },
+    });
+    await transaction.sigaaConnection.updateMany({
+      where: { usuarioId: ownerId, leaseRunId: runId, leaseGeneration: generation },
+      data: { leaseRunId: null, leaseTokenDigest: null, leaseExpiresAt: null },
+    });
+    return toRunReceipt(run);
+  }
+
+  private closeMatriculaConflict(
+    ownerId: UsuarioId,
+    lease: LeaseGrant
+  ): Promise<CommitLatestResult> {
+    return this.database.$transaction(async transaction => {
+      await this.lockAggregate(transaction, ownerId);
+      await this.lockUsuario(transaction, ownerId);
+      await this.lockConnection(transaction, ownerId);
+      const [connection, run] = await Promise.all([
+        transaction.sigaaConnection.findUnique({ where: { usuarioId: ownerId } }),
+        transaction.sigaaSyncRun.findFirst({ where: { id: lease.runId, usuarioId: ownerId } }),
+      ]);
+      if (!connection || !run) {
+        throw new Error("SIGAA_ATTEMPT_NOT_FOUND");
+      }
+
+      const authenticated =
+        run.status === "RUNNING" &&
+        connection.leaseRunId === run.id &&
+        connection.leaseGeneration === lease.generation &&
+        run.leaseGeneration === lease.generation &&
+        lease.courseIdentityToken === run.courseIdentityToken &&
+        connection.leaseTokenDigest !== null &&
+        secretsEqual(connection.leaseTokenDigest, digest(lease.secret));
+      if (!authenticated) {
+        return { kind: "rejected", run: toRunReceipt(run), failure: "LEASE_LOST" };
+      }
+
+      const times = await this.databaseTimes(transaction);
+      if (
+        connection.leaseExpiresAt === null ||
+        connection.leaseExpiresAt <= times.now ||
+        run.leaseExpiresAt <= times.now
+      ) {
+        const superseded = await this.supersedeCurrentAttempt(
+          transaction,
+          ownerId,
+          run.id,
+          lease.generation,
+          times
+        );
+        return { kind: "rejected", run: superseded, failure: "LEASE_LOST" };
+      }
+
+      const rejected = await this.rejectCurrentAttempt(
+        transaction,
+        ownerId,
+        run.id,
+        lease.generation,
+        "SIGAA_IDENTITY_MISMATCH",
+        times
+      );
+      return { kind: "rejected", run: rejected, failure: "SIGAA_IDENTITY_MISMATCH" };
+    });
+  }
+
+  private async consumeRateLimitInTransaction(
+    transaction: Transaction,
+    ownerId: UsuarioId,
+    operation: SigaaRateLimitOperation
+  ): Promise<RateLimitDecision> {
+    const policy = RATE_LIMIT_POLICIES[operation];
+    const [databaseTime] = await transaction.$queryRaw<Array<{ now: Date; resetAt: Date }>>`
+      SELECT
+        clock_timestamp() AS "now",
+        clock_timestamp() + make_interval(secs => ${policy.windowSeconds}) AS "resetAt"
+    `;
+    const bucket = await transaction.sigaaRateLimitBucket.findUnique({
+      where: { usuarioId_operation: { usuarioId: ownerId, operation } },
+    });
+
+    if (!bucket || bucket.resetAt <= databaseTime.now) {
+      await transaction.sigaaRateLimitBucket.upsert({
+        where: { usuarioId_operation: { usuarioId: ownerId, operation } },
+        create: {
+          usuarioId: ownerId,
+          operation,
+          count: 1,
+          windowStartedAt: databaseTime.now,
+          resetAt: databaseTime.resetAt,
+        },
+        update: {
+          count: 1,
+          windowStartedAt: databaseTime.now,
+          resetAt: databaseTime.resetAt,
+        },
+      });
+      return { kind: "allowed", remaining: policy.limit - 1, resetAt: databaseTime.resetAt };
+    }
+
+    if (bucket.count >= policy.limit) {
+      return { kind: "rate_limited", retryAt: bucket.resetAt };
+    }
+
+    const updated = await transaction.sigaaRateLimitBucket.update({
+      where: { usuarioId_operation: { usuarioId: ownerId, operation } },
+      data: { count: { increment: 1 } },
+    });
+    return {
+      kind: "allowed",
+      remaining: policy.limit - updated.count,
+      resetAt: updated.resetAt,
+    };
+  }
+
+  private async databaseTimes(transaction: Transaction): Promise<DatabaseTimes> {
+    const [times] = await transaction.$queryRaw<DatabaseTimes[]>`
+      SELECT
+        clock_timestamp() AS "now",
+        clock_timestamp() + make_interval(secs => ${LEASE_SECONDS}) AS "leaseExpiresAt",
+        clock_timestamp() + make_interval(secs => ${RETENTION_SECONDS}) AS "retentionExpiresAt"
+    `;
+    return times;
+  }
+
+  private async lockAggregate(transaction: Transaction, ownerId: UsuarioId): Promise<void> {
+    await transaction.$executeRaw`
+      SELECT pg_advisory_xact_lock(hashtextextended(${`sigaa:aggregate:${ownerId}`}, 0))
+    `;
+  }
+
+  private async lockRateLimit(
+    transaction: Transaction,
+    ownerId: UsuarioId,
+    operation: SigaaRateLimitOperation
+  ): Promise<void> {
+    await transaction.$executeRaw`
+      SELECT pg_advisory_xact_lock(hashtextextended(${`sigaa:rate:${ownerId}:${operation}`}, 0))
+    `;
+  }
+
+  private async lockMatricula(transaction: Transaction, matricula: string): Promise<void> {
+    await transaction.$executeRaw`
+      SELECT pg_advisory_xact_lock(hashtextextended(${sigaaMatriculaLockKey(matricula)}, 0))
+    `;
+  }
+
+  private async lockUsuario(transaction: Transaction, ownerId: UsuarioId): Promise<void> {
+    await transaction.$queryRaw`
+      SELECT "id" FROM "Usuario" WHERE "id" = ${ownerId} FOR UPDATE
+    `;
+  }
+
+  private async lockConnection(transaction: Transaction, ownerId: UsuarioId): Promise<void> {
+    await transaction.$queryRaw`
+      SELECT "usuarioId" FROM "SigaaConnection" WHERE "usuarioId" = ${ownerId} FOR UPDATE
+    `;
+  }
+}

--- a/src/lib/server/db/implementations/prisma/prisma-usuarios-repository.ts
+++ b/src/lib/server/db/implementations/prisma/prisma-usuarios-repository.ts
@@ -6,7 +6,18 @@ import type {
   PapelPlataforma,
 } from "@/lib/server/db/interfaces/types";
 import { Prisma } from "@prisma/client";
+import { sigaaMatriculaLockKey } from "@/lib/server/services/sigaa/storage.types";
 import type { OnboardingMetadata } from "@/lib/shared/types";
+
+const isMatriculaUniqueViolation = (error: unknown): boolean => {
+  if (!(error instanceof Prisma.PrismaClientKnownRequestError) || error.code !== "P2002") {
+    return false;
+  }
+  const target = error.meta?.target;
+  return Array.isArray(target)
+    ? target.some(field => field === "matricula")
+    : typeof target === "string" && target.toLowerCase().includes("matricula");
+};
 
 export class PrismaUsuariosRepository implements IUsuariosRepository {
   /**
@@ -73,28 +84,51 @@ export class PrismaUsuariosRepository implements IUsuariosRepository {
     const baseSlug = data.eFacade ? null : this.emailToSlug(data.email ?? null);
     const slug = baseSlug ? await this.ensureUniqueSlug(baseSlug) : null;
 
-    const usuario = await prisma.usuario.create({
-      data: {
-        nome: data.nome,
-        email: data.email ? data.email.toLowerCase().trim() : null,
-        senhaHash: data.senhaHash ?? null,
-        centroId: data.centroId,
-        cursoId: data.cursoId,
-        permissoes: data.permissoes ?? [],
-        papelPlataforma: data.papelPlataforma ?? "USER",
-        eVerificado: data.eVerificado ?? false,
-        eFacade: data.eFacade ?? false,
-        urlFotoPerfil: data.urlFotoPerfil,
-        matricula: data.matricula,
-        slug,
-      },
-      include: {
-        centro: true,
-        curso: true,
-      },
-    });
+    try {
+      return await prisma.$transaction(async transaction => {
+        if (data.matricula) {
+          await transaction.$executeRaw`
+            SELECT pg_advisory_xact_lock(
+              hashtextextended(${sigaaMatriculaLockKey(data.matricula)}, 0)
+            )
+          `;
+          const existingOwner = await transaction.usuario.findFirst({
+            where: { matricula: data.matricula },
+            select: { id: true },
+          });
+          if (existingOwner) {
+            throw new Error("MATRICULA_ALREADY_IN_USE");
+          }
+        }
 
-    return usuario;
+        return transaction.usuario.create({
+          data: {
+            nome: data.nome,
+            email: data.email ? data.email.toLowerCase().trim() : null,
+            senhaHash: data.senhaHash ?? null,
+            centroId: data.centroId,
+            cursoId: data.cursoId,
+            permissoes: data.permissoes ?? [],
+            papelPlataforma: data.papelPlataforma ?? "USER",
+            eVerificado: data.eVerificado ?? false,
+            eFacade: data.eFacade ?? false,
+            urlFotoPerfil: data.urlFotoPerfil,
+            matricula: data.matricula ?? null,
+            matriculaOrigem: data.matricula ? "MANUAL" : null,
+            slug,
+          },
+          include: {
+            centro: true,
+            curso: true,
+          },
+        });
+      });
+    } catch (error) {
+      if (isMatriculaUniqueViolation(error)) {
+        throw new Error("MATRICULA_ALREADY_IN_USE");
+      }
+      throw error;
+    }
   }
 
   async findById(id: string): Promise<UsuarioWithRelations | null> {

--- a/src/lib/server/db/interfaces/sigaa-repository.interface.ts
+++ b/src/lib/server/db/interfaces/sigaa-repository.interface.ts
@@ -1,0 +1,122 @@
+import type {
+  IdempotencyKey,
+  LeaseSecret,
+  Matricula,
+  SigaaAcademicSnapshotPayload,
+  SigaaRunId,
+  SigaaSnapshotCandidate,
+  UsuarioId,
+} from "@/lib/server/services/sigaa/storage.types";
+
+export type SigaaRateLimitOperation = "REAUTH" | "SYNC" | "DISCONNECT" | "DELETE_IMPORTED_DATA";
+
+export type SigaaSyncFailureCode =
+  | "SIGAA_AUTH_FAILED"
+  | "SIGAA_IDENTITY_INVALID"
+  | "SIGAA_IDENTITY_MISMATCH"
+  | "SIGAA_TIMEOUT"
+  | "SIGAA_UNAVAILABLE"
+  | "SIGAA_RESPONSE_INVALID"
+  | "CONNECTOR_UNAVAILABLE"
+  | "CONNECTOR_MISCONFIGURED"
+  | "COURSE_MISMATCH"
+  | "LEASE_LOST"
+  | "INTERNAL_ERROR";
+
+export type SigaaRunReceipt = Readonly<{
+  id: SigaaRunId;
+  status: "RUNNING" | "SUCCEEDED" | "FAILED" | "SUPERSEDED";
+  failureCode: SigaaSyncFailureCode | null;
+  connectorRequestId: string | null;
+  startedAt: Date;
+  finishedAt: Date | null;
+}>;
+
+export type RateLimitDecision =
+  | Readonly<{ kind: "allowed"; remaining: number; resetAt: Date }>
+  | Readonly<{ kind: "rate_limited"; retryAt: Date }>;
+
+export type LeaseGrant = Readonly<{
+  runId: SigaaRunId;
+  generation: bigint;
+  secret: LeaseSecret;
+  expiresAt: Date;
+  courseIdentityToken: string;
+  expectedMatricula: Matricula | null;
+}>;
+
+export type ReserveAttemptResult =
+  | Readonly<{ kind: "reserved"; lease: LeaseGrant }>
+  | Readonly<{ kind: "replay"; run: SigaaRunReceipt }>
+  | Readonly<{ kind: "busy"; retryAt: Date }>
+  | Readonly<{ kind: "rate_limited"; retryAt: Date }>;
+
+export type CommitLatestResult =
+  | Readonly<{ kind: "committed"; run: SigaaRunReceipt; synchronizedAt: Date }>
+  | Readonly<{
+      kind: "rejected";
+      run: SigaaRunReceipt;
+      failure: "COURSE_MISMATCH" | "SIGAA_IDENTITY_MISMATCH" | "LEASE_LOST";
+    }>;
+
+export type ImportedAcademicState = Readonly<{
+  matricula: Readonly<{
+    value: string | null;
+    origin: "LEGACY" | "MANUAL" | "SIGAA" | null;
+    verifiedAt: Date | null;
+  }>;
+  connection: Readonly<{
+    status: "PENDING" | "CONNECTED" | "DISCONNECTED";
+    consentVersion: string | null;
+    consentedAt: Date | null;
+    connectedAt: Date | null;
+    disconnectedAt: Date | null;
+  }> | null;
+  snapshot: Readonly<{
+    contractVersion: string;
+    connectorObservedAt: Date;
+    synchronizedAt: Date;
+    upstreamCommit: string;
+    installedByRunId: string | null;
+    payload: SigaaAcademicSnapshotPayload;
+  }> | null;
+}>;
+
+export type DisconnectResult =
+  | Readonly<{ kind: "disconnected"; disconnectedAt: Date }>
+  | Readonly<{ kind: "rate_limited"; retryAt: Date }>;
+
+export type DeleteImportedDataResult =
+  | Readonly<{ kind: "deleted"; hadImportedData: boolean; matriculaCleared: boolean }>
+  | Readonly<{ kind: "rate_limited"; retryAt: Date }>;
+
+export type ISigaaRepository = {
+  consumeRateLimit(input: {
+    ownerId: UsuarioId;
+    operation: SigaaRateLimitOperation;
+  }): Promise<RateLimitDecision>;
+
+  reserveAttempt(input: {
+    ownerId: UsuarioId;
+    idempotencyKey: IdempotencyKey;
+    consentVersion: string;
+  }): Promise<ReserveAttemptResult>;
+
+  commitLatest(input: {
+    ownerId: UsuarioId;
+    lease: LeaseGrant;
+    candidate: SigaaSnapshotCandidate;
+  }): Promise<CommitLatestResult>;
+
+  finishAttempt(input: {
+    ownerId: UsuarioId;
+    lease: LeaseGrant;
+    failure: SigaaSyncFailureCode;
+    connectorRequestId?: string;
+  }): Promise<SigaaRunReceipt>;
+
+  readImportedState(ownerId: UsuarioId): Promise<ImportedAcademicState>;
+  disconnect(ownerId: UsuarioId): Promise<DisconnectResult>;
+  deleteImportedData(ownerId: UsuarioId): Promise<DeleteImportedDataResult>;
+  deleteExpiredRuns(): Promise<{ deleted: number }>;
+};

--- a/src/lib/server/services/sigaa/__tests__/storage.types.integration.test.ts
+++ b/src/lib/server/services/sigaa/__tests__/storage.types.integration.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseSigaaSnapshotCandidate,
+  toSigaaAcademicSnapshotPayload,
+  type SigaaSnapshotCandidate,
+} from "@/lib/server/services/sigaa/storage.types";
+
+const repeated = (character: string, length: number): string => character.repeat(length);
+const numberedText = (prefix: string, index: number, length: number): string =>
+  `${prefix}${index}`.padEnd(length, "x").slice(0, length);
+
+const component = (index = 0) => ({
+  code: numberedText("C", index, 64),
+  name: repeated("n", 256),
+  integrationType: repeated("i", 64),
+  period: 100,
+  workloadHours: 100_000,
+  required: true,
+  status: "completed" as const,
+  prerequisite: repeated("p", 256),
+  corequisite: repeated("c", 256),
+  unrecognizedSource: { status: repeated("s", 64), period: repeated("r", 32) },
+});
+
+const grade = (index = 0) => ({
+  semester: numberedText("S", index, 64),
+  code: numberedText("G", index, 64),
+  discipline: repeated("d", 256),
+  units: Array.from({ length: 16 }, (_, unit) => numberedText("U", unit, 64)),
+  exam: repeated("e", 64),
+  result: repeated("r", 64),
+  absences: repeated("a", 64),
+  status: repeated("s", 64),
+});
+
+const currentClass = (index = 0) => ({
+  sourceKey: numberedText("K", index, 64),
+  name: repeated("n", 256),
+  code: numberedText("D", index, 64),
+  room: repeated("r", 256),
+  scheduleRaw: repeated("s", 256),
+  semester: repeated("m", 64),
+});
+
+const candidate = (): SigaaSnapshotCandidate =>
+  parseSigaaSnapshotCandidate({
+    contractVersion: "1.0",
+    connectorObservedAt: new Date("2026-08-21T12:00:00Z"),
+    connectorRequestId: repeated("q", 64),
+    upstreamCommit: repeated("a", 40),
+    identity: {
+      matricula: "20260000001",
+      sourceCourse: repeated("c", 256),
+      sourceSemester: repeated("s", 64),
+    },
+    curriculum: {
+      code: repeated("c", 64),
+      maximumCompletionTerm: repeated("t", 64),
+      semesterWorkload: { minimum: 100_000, maximum: 100_000 },
+      cra: { value: "10.0000000000000", source: "academic_transcript" },
+      progress: Array.from({ length: 64 }, () => ({
+        description: repeated("p", 256),
+        completedHours: 100_000,
+        totalHours: 100_000,
+        remainingHours: 0,
+        completedPercent: 100,
+      })),
+      components: Array.from({ length: 2_048 }, (_, index) => component(index)),
+    },
+    grades: Array.from({ length: 256 }, (_, index) => grade(index)),
+    classes: Array.from({ length: 64 }, (_, index) => currentClass(index)),
+  });
+
+describe("SIGAA storage contract", () => {
+  it("accepts the transformed connector contract at every collection and field maximum", () => {
+    const parsed = candidate();
+
+    expect(parsed.curriculum.progress).toHaveLength(64);
+    expect(parsed.curriculum.components).toHaveLength(2_048);
+    expect(parsed.grades).toHaveLength(256);
+    expect(parsed.classes).toHaveLength(64);
+    expect(parsed.curriculum.progress[0].remainingHours).toBe(0);
+    expect(toSigaaAcademicSnapshotPayload(parsed)).toEqual({
+      identity: parsed.identity,
+      curriculum: parsed.curriculum,
+      grades: parsed.grades,
+      classes: parsed.classes,
+    });
+  });
+
+  it.each([
+    [
+      "progress",
+      65,
+      (value: SigaaSnapshotCandidate) => ({
+        ...value,
+        curriculum: {
+          ...value.curriculum,
+          progress: Array.from({ length: 65 }, () => value.curriculum.progress[0]),
+        },
+      }),
+    ],
+    [
+      "components",
+      2_049,
+      (value: SigaaSnapshotCandidate) => ({
+        ...value,
+        curriculum: {
+          ...value.curriculum,
+          components: Array.from({ length: 2_049 }, (_, index) => component(index)),
+        },
+      }),
+    ],
+    [
+      "grades",
+      257,
+      (value: SigaaSnapshotCandidate) => ({
+        ...value,
+        grades: Array.from({ length: 257 }, (_, index) => grade(index)),
+      }),
+    ],
+    [
+      "classes",
+      65,
+      (value: SigaaSnapshotCandidate) => ({
+        ...value,
+        classes: Array.from({ length: 65 }, (_, index) => currentClass(index)),
+      }),
+    ],
+  ] as const)("rejects the first invalid %s collection size (%d)", (_field, _size, makeInvalid) => {
+    expect(() => parseSigaaSnapshotCandidate(makeInvalid(candidate()))).toThrow();
+  });
+
+  it.each([
+    [
+      "completed hours greater than total",
+      (value: SigaaSnapshotCandidate) => ({
+        ...value,
+        curriculum: {
+          ...value.curriculum,
+          progress: [{ ...value.curriculum.progress[0], completedHours: 2, totalHours: 1 }],
+        },
+      }),
+    ],
+    [
+      "remaining hours mismatch",
+      (value: SigaaSnapshotCandidate) => ({
+        ...value,
+        curriculum: {
+          ...value.curriculum,
+          progress: [{ ...value.curriculum.progress[0], remainingHours: 1 }],
+        },
+      }),
+    ],
+    [
+      "semester workload range",
+      (value: SigaaSnapshotCandidate) => ({
+        ...value,
+        curriculum: {
+          ...value.curriculum,
+          semesterWorkload: { minimum: 2, maximum: 1 },
+        },
+      }),
+    ],
+    [
+      "hour count 100001",
+      (value: SigaaSnapshotCandidate) => ({
+        ...value,
+        curriculum: { ...value.curriculum, semesterWorkload: { minimum: 100_001, maximum: null } },
+      }),
+    ],
+    [
+      "description length 257",
+      (value: SigaaSnapshotCandidate) => ({
+        ...value,
+        curriculum: {
+          ...value.curriculum,
+          progress: [{ ...value.curriculum.progress[0], description: repeated("p", 257) }],
+        },
+      }),
+    ],
+    [
+      "integration type length 65",
+      (value: SigaaSnapshotCandidate) => ({
+        ...value,
+        curriculum: {
+          ...value.curriculum,
+          components: [{ ...value.curriculum.components[0], integrationType: repeated("i", 65) }],
+        },
+      }),
+    ],
+    [
+      "grade units length 17",
+      (value: SigaaSnapshotCandidate) => ({
+        ...value,
+        grades: [{ ...value.grades[0], units: Array.from({ length: 17 }, () => "U") }],
+      }),
+    ],
+    [
+      "period 101",
+      (value: SigaaSnapshotCandidate) => ({
+        ...value,
+        curriculum: {
+          ...value.curriculum,
+          components: [{ ...value.curriculum.components[0], period: 101 }],
+        },
+      }),
+    ],
+    [
+      "invalid CRA",
+      (value: SigaaSnapshotCandidate) => ({
+        ...value,
+        curriculum: { ...value.curriculum, cra: { value: "10.1", source: "academic_transcript" } },
+      }),
+    ],
+    [
+      "duplicate normalized component code",
+      (value: SigaaSnapshotCandidate) => ({
+        ...value,
+        curriculum: {
+          ...value.curriculum,
+          components: [value.curriculum.components[0], value.curriculum.components[0]],
+        },
+      }),
+    ],
+  ] as const)("rejects %s", (_name, makeInvalid) => {
+    expect(() => parseSigaaSnapshotCandidate(makeInvalid(candidate()))).toThrow();
+  });
+});

--- a/src/lib/server/services/sigaa/storage.types.ts
+++ b/src/lib/server/services/sigaa/storage.types.ts
@@ -1,0 +1,212 @@
+import { z } from "zod";
+
+const requiredText = (maximum: number) => z.string().min(1).max(maximum);
+const nullableText = (maximum: number) => requiredText(maximum).nullable();
+const hourCountSchema = z.number().int().min(0).max(100_000);
+const matriculaValueSchema = z.string().regex(/^\d{11}$/);
+const gitCommitValueSchema = z.string().regex(/^[0-9a-f]{40}$/);
+
+export const usuarioIdSchema = z.string().uuid().brand<"UsuarioId">();
+export const sigaaRunIdSchema = z.string().uuid().brand<"SigaaRunId">();
+export const idempotencyKeySchema = z.string().uuid().brand<"IdempotencyKey">();
+export const leaseSecretSchema = z
+  .string()
+  .regex(/^[0-9a-f]{64}$/)
+  .brand<"LeaseSecret">();
+export const matriculaSchema = matriculaValueSchema.brand<"Matricula">();
+export const gitCommitSchema = gitCommitValueSchema.brand<"GitCommit">();
+
+export type UsuarioId = z.infer<typeof usuarioIdSchema>;
+export type SigaaRunId = z.infer<typeof sigaaRunIdSchema>;
+export type IdempotencyKey = z.infer<typeof idempotencyKeySchema>;
+export type LeaseSecret = z.infer<typeof leaseSecretSchema>;
+export type Matricula = z.infer<typeof matriculaSchema>;
+export type GitCommit = z.infer<typeof gitCommitSchema>;
+
+const componentStatusSchema = z.enum(["completed", "enrolled", "pending", "unknown"]);
+
+const workloadProgressSchema = z
+  .object({
+    description: requiredText(256),
+    completedHours: hourCountSchema,
+    totalHours: hourCountSchema,
+    remainingHours: hourCountSchema,
+    completedPercent: z.number().min(0).max(100),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (value.completedHours > value.totalHours) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "completed hours exceed total hours",
+        path: ["completedHours"],
+      });
+    }
+    if (value.remainingHours !== value.totalHours - value.completedHours) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "remaining hours do not match total and completed hours",
+        path: ["remainingHours"],
+      });
+    }
+  })
+  .readonly();
+
+const unrecognizedSourceSchema = z
+  .object({
+    status: requiredText(64).optional(),
+    period: requiredText(32).optional(),
+  })
+  .strict()
+  .refine(value => value.status !== undefined || value.period !== undefined)
+  .readonly();
+
+const academicComponentSchema = z
+  .object({
+    code: requiredText(64),
+    name: requiredText(256),
+    integrationType: requiredText(64),
+    period: z.number().int().min(0).max(100).nullable(),
+    workloadHours: hourCountSchema,
+    required: z.boolean(),
+    status: componentStatusSchema,
+    prerequisite: nullableText(256),
+    corequisite: nullableText(256),
+    unrecognizedSource: unrecognizedSourceSchema.optional(),
+  })
+  .strict()
+  .readonly();
+
+const gradeSchema = z
+  .object({
+    semester: requiredText(64),
+    code: requiredText(64),
+    discipline: requiredText(256),
+    units: z.array(requiredText(64)).max(16).readonly(),
+    exam: nullableText(64),
+    result: nullableText(64),
+    absences: nullableText(64),
+    status: nullableText(64),
+  })
+  .strict()
+  .readonly();
+
+const classSchema = z
+  .object({
+    sourceKey: requiredText(64),
+    name: requiredText(256),
+    code: nullableText(64),
+    room: nullableText(256),
+    scheduleRaw: nullableText(256),
+    semester: nullableText(64),
+  })
+  .strict()
+  .readonly();
+
+const identitySchema = z
+  .object({
+    matricula: matriculaValueSchema,
+    sourceCourse: nullableText(256),
+    sourceSemester: nullableText(64),
+  })
+  .strict()
+  .readonly();
+
+const semesterWorkloadSchema = z
+  .object({
+    minimum: hourCountSchema.nullable(),
+    maximum: hourCountSchema.nullable(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (value.minimum !== null && value.maximum !== null && value.minimum > value.maximum) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "minimum semester workload exceeds maximum",
+        path: ["minimum"],
+      });
+    }
+  })
+  .readonly();
+
+const craSchema = z
+  .object({
+    value: z
+      .string()
+      .min(1)
+      .max(16)
+      .regex(/^(?:10(?:\.0+)?|[0-9](?:\.\d+)?)$/)
+      .nullable(),
+    source: z.enum(["academic_transcript", "unavailable"]),
+  })
+  .strict()
+  .readonly();
+
+const curriculumSchema = z
+  .object({
+    code: requiredText(64),
+    maximumCompletionTerm: nullableText(64),
+    semesterWorkload: semesterWorkloadSchema,
+    cra: craSchema,
+    progress: z.array(workloadProgressSchema).max(64).readonly(),
+    components: z.array(academicComponentSchema).max(2_048).readonly(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    const seenCodes = new Set<string>();
+    value.components.forEach((component, index) => {
+      if (seenCodes.has(component.code)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "duplicate normalized component code",
+          path: ["components", index, "code"],
+        });
+      }
+      seenCodes.add(component.code);
+    });
+  })
+  .readonly();
+
+const academicPayloadShape = {
+  identity: identitySchema,
+  curriculum: curriculumSchema,
+  grades: z.array(gradeSchema).max(256).readonly(),
+  classes: z.array(classSchema).max(64).readonly(),
+};
+
+export const sigaaAcademicSnapshotPayloadSchema = z
+  .object(academicPayloadShape)
+  .strict()
+  .readonly();
+
+export const sigaaSnapshotCandidateSchema = z
+  .object({
+    contractVersion: z.literal("1.0"),
+    connectorObservedAt: z.date(),
+    connectorRequestId: requiredText(64),
+    upstreamCommit: gitCommitValueSchema,
+    ...academicPayloadShape,
+  })
+  .strict()
+  .readonly();
+
+export type SigaaAcademicSnapshotPayload = z.infer<typeof sigaaAcademicSnapshotPayloadSchema>;
+export type SigaaSnapshotCandidate = z.infer<typeof sigaaSnapshotCandidateSchema>;
+
+export const parseSigaaAcademicSnapshotPayload = (value: unknown): SigaaAcademicSnapshotPayload =>
+  sigaaAcademicSnapshotPayloadSchema.parse(value);
+
+export const parseSigaaSnapshotCandidate = (value: unknown): SigaaSnapshotCandidate =>
+  sigaaSnapshotCandidateSchema.parse(value);
+
+export const toSigaaAcademicSnapshotPayload = (
+  candidate: SigaaSnapshotCandidate
+): SigaaAcademicSnapshotPayload =>
+  sigaaAcademicSnapshotPayloadSchema.parse({
+    identity: candidate.identity,
+    curriculum: candidate.curriculum,
+    grades: candidate.grades,
+    classes: candidate.classes,
+  });
+
+export const sigaaMatriculaLockKey = (matricula: string): string => `sigaa:matricula:${matricula}`;

--- a/src/lib/server/utils/__tests__/format-user-response.test.ts
+++ b/src/lib/server/utils/__tests__/format-user-response.test.ts
@@ -15,6 +15,8 @@ function makeUsuario(): UsuarioWithRelations {
     urlFotoPerfil: null,
     periodoAtual: "5",
     matricula: null,
+    matriculaOrigem: null,
+    matriculaVerificadaPeloSigaaEm: null,
     onboardingMetadata: null,
     centroId: "centro-1",
     cursoId: "curso-1",


### PR DESCRIPTION
## Stack

- Base: #246
- Este PR: fase 5, persistência SIGAA
- Próximo: #248

## Escopo

- adiciona conexão, snapshot acadêmico, tentativas de sincronização e rate limit por usuário
- mantém matrícula e proveniência sem misturar importados nas tabelas acadêmicas manuais
- implementa idempotência, lease por geração, relógio do banco, desconexão, exclusão seletiva e retenção
- adiciona migration versionada, constraints, índices e verificador da fronteira de persistência
- usa PostgreSQL 16 descartável e prova apply, reversão exata, reapply e zero drift

## Segurança de dados

- não persiste senha, cookie, HTML, PDF, token de reautenticação ou resposta bruta do conector
- mantém o último snapshot separado das tabelas manuais
- a prova de reversão preserva `Usuario.id`, matrícula e tabelas preexistentes

## Validação do head `1058a87`

- `npm run check-all`
- ciclo completo de migration: apply, zero drift, 16 testes, reversão, reapply, zero drift e mais 16 testes
- reversão remove somente o write-set de `20260821090000_add_sigaa_persistence`
- `git diff --check`

## Revisão

O achado P2 sobre rollback foi resolvido por um script SQL específico e rerunável. O PR continua draft e deve ser mergeado somente depois do #246.