### PR TITLE
fix(projetos): correct two distinct project cover image bugs

### DIFF
--- a/src/app/projetos/[id]/editar/page.tsx
+++ b/src/app/projetos/[id]/editar/page.tsx
@@ -688,7 +688,7 @@ export default function EditarProjetoPage() {
             <Button
               type="button"
               onClick={handleSave}
-              disabled={isSaving || isOverLimit || isPeriodoInvalid}
+              disabled={isSaving || isOverLimit || isPeriodoInvalid || isUploadingCover}
               className="bg-aquario-primary text-white hover:bg-aquario-primary/90"
             >
               {isSaving ? "Salvando..." : "Salvar alterações"}

--- a/src/app/projetos/[id]/projeto-detail-client.tsx
+++ b/src/app/projetos/[id]/projeto-detail-client.tsx
@@ -211,6 +211,7 @@ export default function ProjetoDetailClient({ slug, initialData }: Props) {
                 src={projeto.imagem}
                 alt={projeto.nome}
                 fill
+                unoptimized
                 className="object-cover object-center"
               />
             ) : (

--- a/src/app/projetos/novo/page.tsx
+++ b/src/app/projetos/novo/page.tsx
@@ -574,7 +574,7 @@ export default function NovoProjetoPage() {
             <Button
               type="button"
               onClick={handleSave}
-              disabled={isSaving || isOverLimit || isPeriodoInvalid}
+              disabled={isSaving || isOverLimit || isPeriodoInvalid || isUploadingCover}
               className="bg-aquario-primary text-white hover:bg-aquario-primary/90"
             >
               {isSaving ? "Salvando..." : "Continuar"}

--- a/src/components/shared/project-card.tsx
+++ b/src/components/shared/project-card.tsx
@@ -111,6 +111,7 @@ const ProjectCard = ({ projeto }: ProjectCardProps) => {
             src={projeto.imagem}
             alt={projeto.nome}
             fill
+            unoptimized
             className="object-cover transition-transform duration-300 group-hover:scale-[1.02]"
           />
         ) : (


### PR DESCRIPTION
## Problem

Reported: some recently-uploaded project cover photos show only the description text with no image at all; others show the default Aquário placeholder icon instead of the real photo.

## Root causes (two distinct bugs)

**1. Broken image (no image at all)**

`project-card.tsx` and `projeto-detail-client.tsx` render the project cover via a plain `next/image` **without `unoptimized`** — unlike every other user-uploaded avatar/logo in the app. #245 already added `unoptimized` to entity/user avatars specifically because Vercel's image optimizer can transiently fail to fetch a freshly-uploaded blob, and `next/image` has no visible fallback when that happens (just renders nothing). The main project cover image was left out of that fix, so it's exposed to the same failure mode — which also explains why older covers "fixed themselves" over time (the optimizer's cache eventually succeeds on retry) while newer ones stay broken.

**2. Default placeholder icon shown (image never saved)**

The "Salvar"/"Continuar" button on both `/projetos/novo` and `/projetos/[id]/editar` wasn't disabled while the cover upload was still in flight — `isUploadingCover` was already used to disable the file picker itself, but missing from the save button's `disabled` condition. A user who picks a cover and clicks save before the upload promise resolves ends up with `urlImagem: null` persisted, showing the placeholder icon despite having picked a real photo.

## Fix

- `src/components/shared/project-card.tsx` — added `unoptimized` to the cover `<Image>`
- `src/app/projetos/[id]/projeto-detail-client.tsx` — same
- `src/app/projetos/novo/page.tsx` — added `isUploadingCover` to the save button's `disabled` condition
- `src/app/projetos/[id]/editar/page.tsx` — same

## Testing

- `npx next lint` on all four changed files → no errors

## Not covered by this PR

Projects that were already saved with `urlImagem: null` due to bug #2 (before this fix) won't self-heal — affected users will need to re-upload their cover via edit. Happy to help identify/message affected projects if useful, but that needs a DB query to enumerate them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Save buttons are now disabled while a project cover image is uploading, preventing incomplete submissions.
  * Project cover images now display reliably without automatic image optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->