### PR TITLE
chore: prepare release v1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-08-27
+
 ### Added
 - **Grade curricular – seleção em lote por período**: No modo seleção, o cabeçalho de cada período vira um botão que marca de uma vez todas as obrigatórias daquele período e, num segundo clique, as tira da seleção (tooltip "Marcar/Desmarcar todas as obrigatórias" no desktop, botão equivalente na lista mobile). Vale tanto para `/grades-curriculares` quanto para os passos "Disciplinas Concluídas" e "Cursando" do onboarding.
 - **Admin Audit Logs**: Nova tabela `AuditLog`, API interna `GET /api/admin/audit-logs` e tela `/admin/audit-logs` para `MASTER_ADMIN` acompanhar ações administrativas sensíveis. Mutações administrativas de usuários agora registram criação/mescla de facade, alteração de role, edição de centro/curso/slug e deleção.
@@ -31,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Build com migrações**: `scripts/build-with-migrations.js` agora falha o build quando `prisma migrate deploy` falha.
 - **Imagens de entidades em produção**: Logos de entidades servidas por `/api/content-images` (lidas do submódulo `content/aquario-entidades` em tempo de execução) não apareciam em produção porque o Next.js não conseguia rastrear estaticamente o caminho dinâmico do arquivo e excluía os assets do bundle da função serverless. Adicionado `outputFileTracingIncludes` em `next.config.mjs` para incluir `content/**/*` explicitamente. Todos os usos de `next/image` para fotos de entidade/usuário (card de projeto, grupos/laboratórios da home, busca, seletores de coautor/entidade em projetos e vagas, membros de entidade, vínculos e timeline do perfil) passaram a usar `unoptimized`, já que são ícones pequenos e não precisam passar pelo otimizador de imagens da Vercel.
 - **Dependências**: Atualizadas versões de Scalar API Reference, PostHog e Vitest para remover vulnerabilidades críticas/altas reportadas pelo `npm audit`.
+- **Fotos de capa de projeto**: Duas causas distintas corrigidas. (1) A capa não usava `unoptimized` no `next/image`, diferente dos avatares/logos já corrigidos no PR #245 — sujeita à mesma falha transitória do otimizador de imagens da Vercel ao buscar um blob recém-enviado, sem fallback visível quando falha (a foto simplesmente não aparecia). (2) O botão de salvar em `/projetos/novo` e `/projetos/[id]/editar` não esperava o upload da capa terminar antes de permitir salvar, podendo gravar o projeto com `urlImagem: null` mesmo com uma foto selecionada (aparecia o ícone padrão do Aquário no lugar).
 
 ## [1.11.1] - 2026-07-06
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aquario",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aquario",
-      "version": "1.11.1",
+      "version": "1.12.0",
       "hasInstallScript": true,
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^7.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquario",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## What

Version bump (minor) and CHANGELOG entry for v1.12.0.

## Why

Publishes everything accumulated since v1.11.1: seleção em lote na grade curricular, Admin Audit Logs, remoção da Copa do Mundo 2026, hardening de segurança (permissões de entidade, privacidade de usuários, cadastro em produção sem email), correções de acessibilidade no onboarding, fix de imagens de entidade em produção (#245), and the project cover image fixes just merged (#254).

## Changes

- `CHANGELOG.md` — `[Unreleased]` moved into `[1.12.0] - 2026-08-27`
- `package.json` / `package-lock.json` — version bumped `1.11.1` → `1.12.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)