### PR TITLE
fix(security): stop leaking email/password hash via public entidade endpoint

### DIFF
--- a/src/app/api/entidades/slug/[slug]/route.ts
+++ b/src/app/api/entidades/slug/[slug]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 export const dynamic = "force-dynamic";
 import { getContainer } from "@/lib/server/container";
 import { ApiError } from "@/lib/server/errors";
+import { formatPublicEntidadeResponse } from "@/lib/server/utils/format-entidade-response";
 
 type RouteContext = {
   params: Promise<{ slug: string }>;
@@ -18,7 +19,7 @@ export async function GET(_request: Request, context: RouteContext) {
       return ApiError.entidadeNotFound();
     }
 
-    return NextResponse.json(entidade);
+    return NextResponse.json(formatPublicEntidadeResponse(entidade));
   } catch {
     return ApiError.internal("Erro ao buscar entidade");
   }

--- a/src/lib/server/utils/__tests__/format-entidade-response.test.ts
+++ b/src/lib/server/utils/__tests__/format-entidade-response.test.ts
@@ -1,0 +1,118 @@
+import type { EntidadeWithRelations } from "@/lib/server/db/interfaces/types";
+import { formatPublicEntidadeResponse } from "../format-entidade-response";
+
+function makeEntidade(): EntidadeWithRelations {
+  return {
+    id: "entidade-1",
+    nome: "LOG",
+    slug: "log",
+    subtitle: "Grupo de Otimizacao e Logistica",
+    descricao: null,
+    tipo: "GRUPO",
+    urlFoto: null,
+    contato: null,
+    instagram: null,
+    linkedin: null,
+    website: null,
+    location: null,
+    foundingDate: null,
+    metadata: {},
+    centroId: "centro-1",
+    criadoEm: new Date("2026-01-01T00:00:00.000Z"),
+    atualizadoEm: new Date("2026-01-01T00:00:00.000Z"),
+    centro: {
+      id: "centro-1",
+      nome: "Centro de Informatica",
+      sigla: "CI",
+      descricao: null,
+      campusId: "campus-1",
+    },
+    cargos: [],
+    membros: [
+      {
+        id: "membro-1",
+        usuarioId: "user-1",
+        entidadeId: "entidade-1",
+        papel: "ADMIN",
+        cargoId: null,
+        startedAt: new Date("2026-01-01T00:00:00.000Z"),
+        endedAt: null,
+        cargo: null,
+        usuario: {
+          id: "user-1",
+          nome: "Test User",
+          email: "test@academico.ufpb.br",
+          slug: "test-user",
+          papelPlataforma: "MASTER_ADMIN",
+          eVerificado: true,
+          eFacade: false,
+          senhaHash: "hash",
+          permissoes: ["entidade:admin:entidade-1"],
+          urlFotoPerfil: null,
+          periodoAtual: "5",
+          matricula: "12345",
+          onboardingMetadata: null,
+          centroId: "centro-1",
+          cursoId: "curso-1",
+          criadoEm: new Date("2026-01-01T00:00:00.000Z"),
+          atualizadoEm: new Date("2026-01-01T00:00:00.000Z"),
+          curso: {
+            id: "curso-1",
+            nome: "Ciencia da Computacao",
+            centroId: "centro-1",
+            criadoEm: new Date("2026-01-01T00:00:00.000Z"),
+            atualizadoEm: new Date("2026-01-01T00:00:00.000Z"),
+          },
+        },
+      },
+    ],
+  } as unknown as EntidadeWithRelations;
+}
+
+describe("format-entidade-response", () => {
+  it("omits private user fields from each member's usuario", () => {
+    const result = formatPublicEntidadeResponse(makeEntidade());
+
+    expect(result.membros).toEqual([
+      {
+        id: "membro-1",
+        entidadeId: "entidade-1",
+        papel: "ADMIN",
+        cargoId: null,
+        startedAt: new Date("2026-01-01T00:00:00.000Z"),
+        endedAt: null,
+        cargo: null,
+        usuario: {
+          id: "user-1",
+          nome: "Test User",
+          slug: "test-user",
+          eFacade: false,
+          urlFotoPerfil: null,
+          curso: { id: "curso-1", nome: "Ciencia da Computacao" },
+        },
+      },
+    ]);
+
+    const membro = result.membros?.[0]?.usuario as Record<string, unknown>;
+    expect(membro).not.toHaveProperty("email");
+    expect(membro).not.toHaveProperty("senhaHash");
+    expect(membro).not.toHaveProperty("papelPlataforma");
+    expect(membro).not.toHaveProperty("eVerificado");
+    expect(membro).not.toHaveProperty("permissoes");
+    expect(membro).not.toHaveProperty("matricula");
+  });
+
+  it("keeps top-level entidade fields untouched", () => {
+    const result = formatPublicEntidadeResponse(makeEntidade());
+
+    expect(result.nome).toBe("LOG");
+    expect(result.slug).toBe("log");
+    expect(result.centro).toEqual({
+      id: "centro-1",
+      nome: "Centro de Informatica",
+      sigla: "CI",
+      descricao: null,
+      campusId: "campus-1",
+    });
+  });
+});

--- a/src/lib/server/utils/format-entidade-response.ts
+++ b/src/lib/server/utils/format-entidade-response.ts
@@ -1,0 +1,58 @@
+import type { Cargo } from "@prisma/client";
+import type { EntidadeWithRelations } from "@/lib/server/db/interfaces/types";
+
+export type PublicEntidadeResponse = Omit<EntidadeWithRelations, "membros"> & {
+  membros?: Array<{
+    id: string;
+    entidadeId: string;
+    papel: string;
+    cargoId: string | null;
+    startedAt: Date;
+    endedAt: Date | null;
+    cargo: Cargo | null;
+    usuario: {
+      id: string;
+      nome: string;
+      slug: string | null;
+      eFacade: boolean;
+      urlFotoPerfil: string | null;
+      curso: { id: string; nome: string } | null;
+    };
+  }>;
+};
+
+/**
+ * Strips private account fields (email, senhaHash, papelPlataforma,
+ * eVerificado, permissoes, matricula, ...) from each member's nested
+ * `usuario` before an entidade is returned by a public/unauthenticated
+ * endpoint. The entidade repository's Prisma `include` pulls the full
+ * Usuario row for each member — only the fields actually rendered by the
+ * entity page (name, slug, avatar, curso) should ever leave the API.
+ */
+export function formatPublicEntidadeResponse(
+  entidade: EntidadeWithRelations
+): PublicEntidadeResponse {
+  const { membros, ...rest } = entidade;
+  return {
+    ...rest,
+    membros: membros?.map(membro => ({
+      id: membro.id,
+      entidadeId: membro.entidadeId,
+      papel: membro.papel,
+      cargoId: membro.cargoId,
+      startedAt: membro.startedAt,
+      endedAt: membro.endedAt,
+      cargo: membro.cargo ?? null,
+      usuario: {
+        id: membro.usuario.id,
+        nome: membro.usuario.nome,
+        slug: membro.usuario.slug,
+        eFacade: membro.usuario.eFacade,
+        urlFotoPerfil: membro.usuario.urlFotoPerfil,
+        curso: membro.usuario.curso
+          ? { id: membro.usuario.curso.id, nome: membro.usuario.curso.nome }
+          : null,
+      },
+    })),
+  };
+}


### PR DESCRIPTION
## Severity: High — please merge and release ASAP

## Problem

`GET /api/entidades/slug/[slug]` (public, unauthenticated, powers `/entidade/[slug]`) returns the raw repository object from `entidadesRepository.findBySlug()` with no sanitization. That query includes each member's full `Usuario` row via Prisma `include`, which contains `email` and `senhaHash` (bcrypt) — both silently serialized into the JSON response for every member of every entity, to anyone, without logging in.

Confirmed no frontend component reads `.email` from entidade member data (grepped all of `src/components/pages/entidades/`), so nothing depended on it being there.

## Fix

Added `formatPublicEntidadeResponse()` (`src/lib/server/utils/format-entidade-response.ts`), which strips each member's `usuario` down to only the fields the entity page actually renders (`id`, `nome`, `slug`, `eFacade`, `urlFotoPerfil`, `curso.{id,nome}`) before the route returns it. Same pattern `formatPublicUserResponse()` already established in #235 — this endpoint just wasn't covered by that pass.

## Scope check

Verified this is the only public leak surface:
- `entidadesRepository.findMany()` (public entity listing) doesn't include `membros` at all — not affected.
- `/api/entidades/[id]/route.ts` only has `PUT` (auth-protected, returns just a success message) — no `GET`.
- `/api/entidades/[id]/membros/route.ts` only has `POST` — no `GET`.

## Testing

- `npx next lint` on all three changed files → no errors
- `npx tsc --noEmit` → no new errors
- `npx jest src/lib/server/utils/__tests__/format-entidade-response.test.ts` → both new tests pass, asserting `email`/`senhaHash`/`papelPlataforma`/`eVerificado`/`permissoes`/`matricula` are absent from the response

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Public entity responses now include only appropriate member and course information.
  * Private account details are excluded from entity data returned by the public API.

* **Bug Fixes**
  * Improved protection of sensitive user information in entity responses.

* **Tests**
  * Added coverage verifying public fields are preserved and private fields are omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->