### PR TITLE
chore: prepare release v1.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.1] - 2026-08-27
+
+### Fixed
+- **Segurança – vazamento de e-mail e hash de senha via endpoint público de entidades**: `GET /api/entidades/slug/[slug]` (público, sem autenticação) retornava o resultado bruto do repositório, que inclui a linha completa de `Usuario` de cada membro via Prisma `include` — expondo `email` e `senhaHash` (bcrypt) de qualquer membro de qualquer entidade para qualquer pessoa. Nenhum componente do frontend lia esses campos. Adicionado `formatPublicEntidadeResponse()`, que reduz o `usuario` de cada membro apenas aos campos realmente renderizados pela página da entidade, mesmo padrão do `formatPublicUserResponse()` já usado desde o hardening do #235.
+
 ## [1.12.0] - 2026-08-27
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aquario",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aquario",
-      "version": "1.12.0",
+      "version": "1.12.1",
       "hasInstallScript": true,
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^7.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquario",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## What

Version bump (patch) and CHANGELOG entry for v1.12.1.

## Why

Publishes #257 — a high-severity security fix (public endpoint leaking member email/password hash) — to production as fast as possible.

## Changes

- `CHANGELOG.md` — new `[1.12.1] - 2026-08-27` section
- `package.json` / `package-lock.json` — version bumped `1.12.0` → `1.12.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)