### PR TITLE
fix(ci): pass --schema to prisma db execute on staging purge

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -143,7 +143,7 @@ jobs:
           DATABASE_URL: ${{ steps.db-url.outputs.url }}
 
       - name: Purge inherited SIGAA data
-        run: npx prisma db execute --file scripts/sql/clear-sigaa-staging.sql
+        run: npx prisma db execute --schema prisma/schema.prisma --file scripts/sql/clear-sigaa-staging.sql
         env:
           DATABASE_URL: ${{ steps.db-url.outputs.url }}
 


### PR DESCRIPTION
## Summary
- Staging purge falhou: prisma db execute precisa de --schema
## Test plan
- [ ] Re-run Staging Deployment após merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the staging deployment data-purge step by explicitly selecting the database schema, ensuring the command runs against the intended schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->