### PR TITLE
fix(sigaa): accept sigaa-tools upstream in connector V1 contract

### DIFF
--- a/src/lib/server/services/sigaa/connector/__tests__/connector-contract-v1.test.ts
+++ b/src/lib/server/services/sigaa/connector/__tests__/connector-contract-v1.test.ts
@@ -139,9 +139,8 @@ describe("SIGAA connector V1 contract", () => {
   it("keeps the fixture literal and sanitized instead of replacing placeholders at runtime", () => {
     const fixture = fixtureValue();
 
-    expect(fixture.source.upstream_repository).toBe(
-      "https://github.com/PucaVaz/sigaa-for-ai-agents.git"
-    );
+    expect(fixture.source.upstream_repository).toBe("https://github.com/PucaVaz/sigaa-tools.git");
+    expect(fixture.source.adapter).toBe("sigaa-tools");
     expect(fixture.source.upstream_commit).toBe("0123456789abcdef0123456789abcdef01234567");
     expect(fixture.student.name).toBe("Pessoa de Teste");
     expect(fixture.student.email).toBe("pessoa@example.test");

--- a/src/lib/server/services/sigaa/connector/connector-contract-v1.ts
+++ b/src/lib/server/services/sigaa/connector/connector-contract-v1.ts
@@ -10,7 +10,7 @@ import type {
 } from "./sigaa-connector.port";
 import { SigaaConnectorError, type SigaaConnectorFailureCode } from "./sigaa-connector.error";
 
-const UPSTREAM_REPOSITORY = "https://github.com/PucaVaz/sigaa-for-ai-agents.git";
+const UPSTREAM_REPOSITORY = "https://github.com/PucaVaz/sigaa-tools.git";
 
 const usernameSchema = z
   .string()
@@ -46,7 +46,7 @@ const syncRequestSchema = z
 const sourceSchema = z
   .object({
     system: z.literal("SIGAA_UFPB"),
-    adapter: z.literal("sigaa-for-ai-agents"),
+    adapter: z.literal("sigaa-tools"),
     upstream_repository: z.literal(UPSTREAM_REPOSITORY),
     upstream_commit: z.string().regex(/^[0-9a-f]{40}$/),
   })

--- a/src/lib/server/services/sigaa/connector/fixtures/sync-response-v1.json
+++ b/src/lib/server/services/sigaa/connector/fixtures/sync-response-v1.json
@@ -3,8 +3,8 @@
   "observed_at": "2026-08-21T12:00:00Z",
   "source": {
     "system": "SIGAA_UFPB",
-    "adapter": "sigaa-for-ai-agents",
-    "upstream_repository": "https://github.com/PucaVaz/sigaa-for-ai-agents.git",
+    "adapter": "sigaa-tools",
+    "upstream_repository": "https://github.com/PucaVaz/sigaa-tools.git",
     "upstream_commit": "0123456789abcdef0123456789abcdef01234567"
   },
   "student": {


### PR DESCRIPTION
Staging sync returned 200 from the connector but Aquário rejected the payload as SIGAA_RESPONSE_INVALID because source.adapter still expected the old sigaa-for-ai-agents literals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Updated connector metadata to reference the `sigaa-tools` adapter and its corresponding upstream repository.
  - Updated synchronized response validation and examples to use the revised connector identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->