### PR TITLE
feat(sigaa): olho para mostrar/esconder senhas no connect

### DIFF
--- a/src/components/sigaa/sigaa-connect-flow.tsx
+++ b/src/components/sigaa/sigaa-connect-flow.tsx
@@ -4,6 +4,7 @@ import { useEffect, useId, useRef, useState } from "react";
 import { Check, LoaderCircle } from "lucide-react";
 
 import { trackEvent } from "@/analytics/posthog-client";
+import { PasswordInput } from "@/components/auth/password-input";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -568,10 +569,9 @@ export function useSigaaConnectFlowContent({
           </div>
           <div className="space-y-2" hidden={isPending}>
             <Label htmlFor={sigaaPasswordId}>Senha do SIGAA</Label>
-            <Input
+            <PasswordInput
               id={sigaaPasswordId}
               name="sigaaPassword"
-              type="password"
               autoComplete="current-password"
               data-1p-ignore="true"
               required
@@ -581,10 +581,9 @@ export function useSigaaConnectFlowContent({
           </div>
           <div className="space-y-2" hidden={isPending}>
             <Label htmlFor={aquarioPasswordId}>Senha do Aquário</Label>
-            <Input
+            <PasswordInput
               id={aquarioPasswordId}
               name="aquarioPassword"
-              type="password"
               autoComplete="current-password"
               data-1p-ignore="true"
               required


### PR DESCRIPTION
## 📝 Descrição

No formulário de conectar/sincronizar o SIGAA, os campos **Senha do SIGAA** e **Senha do Aquário** usavam `Input` simples sem toggle de visibilidade.

Reaproveitei o `PasswordInput` já usado em login/registro/reset, para manter o mesmo padrão de UX (ícone de olho mostrar/esconder).

## 🔗 Issue Relacionada

N/A

## 🧪 Testes

- [x] Testes unitários passam
- [ ] Testes de integração passam
- [ ] Testes E2E passam
- [ ] Testes manuais concluídos

Checklist rápido sugerido:
- [ ] Abrir o dialog de conectar SIGAA e confirmar o olho nos dois campos de senha
- [ ] Alternar visibilidade e enviar o form normalmente

## 📸 Screenshots (se aplicável)

N/A — mudança pequena de UI no form existente.

## 📋 Checklist

- [x] Código segue as diretrizes de estilo do projeto
- [x] Revisão própria concluída
- [x] Código está devidamente comentado
- [x] Nenhum console.log deixado no código
- [ ] Todos os testes passam localmente
- [ ] Build passa sem erros

## 🚀 Notas de Deploy

Nenhuma.

## 📚 Contexto Adicional

Diff mínimo: só troca `Input type="password"` por `PasswordInput` em `sigaa-connect-flow.tsx`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated SIGAA and Aquário password fields to use the standardized password input control.
  * Preserved existing validation, autocomplete, security, and disabled-state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->