### PR TITLE
fix(onboarding): keep cursando step usable on mobile Safari

### DIFF
--- a/src/components/onboarding/onboarding-modal.tsx
+++ b/src/components/onboarding/onboarding-modal.tsx
@@ -253,9 +253,12 @@ export function OnboardingModal({
           onEscapeKeyDown={e => e.preventDefault()}
           onInteractOutside={e => e.preventDefault()}
           className={cn(
-            "fixed bottom-[max(0.5rem,env(safe-area-inset-bottom))] left-[max(0.5rem,env(safe-area-inset-left))] right-[max(0.5rem,env(safe-area-inset-right))] top-[max(0.5rem,env(safe-area-inset-top))] z-50",
+            // Mobile uses svh so the sticky footer stays above Safari's toolbar.
+            // top+bottom insets against the layout viewport put "Pular" under the chrome.
+            "fixed left-[max(0.5rem,env(safe-area-inset-left))] right-[max(0.5rem,env(safe-area-inset-right))] top-[max(0.5rem,env(safe-area-inset-top))] z-50",
+            "h-[calc(100svh-1rem)] max-h-[calc(100dvh-1rem)]",
             "flex min-h-0 w-auto max-w-6xl flex-col overflow-x-hidden overscroll-none rounded-lg border bg-background shadow-lg duration-200",
-            "sm:bottom-auto sm:left-[50%] sm:right-auto sm:top-[50%] sm:h-[min(94dvh,56rem)] sm:max-h-[calc(100dvh-2rem)] sm:w-full sm:-translate-x-1/2 sm:-translate-y-1/2",
+            "sm:left-[50%] sm:right-auto sm:top-[50%] sm:h-[min(94dvh,56rem)] sm:max-h-[calc(100dvh-2rem)] sm:w-full sm:-translate-x-1/2 sm:-translate-y-1/2",
             "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
             "motion-reduce:animate-none motion-reduce:transition-none"
           )}
@@ -288,8 +291,7 @@ export function OnboardingModal({
             </div>
           </div>
 
-          {/* Sticky footer — always visible */}
-          <div className="flex shrink-0 items-center justify-between gap-2 rounded-b-lg border-t bg-background p-3 sm:p-4">
+          <div className="flex shrink-0 items-center justify-between gap-2 rounded-b-lg border-t bg-background p-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] sm:p-4 sm:pb-4">
             <div>
               {canGoBack && (
                 <Button

--- a/src/components/pages/grades-curriculares/__tests__/curriculum-graph.test.tsx
+++ b/src/components/pages/grades-curriculares/__tests__/curriculum-graph.test.tsx
@@ -339,6 +339,20 @@ describe("CurriculumGraph — seleção por período", () => {
     // Texto visível é prefixo do nome acessível (WCAG 2.5.3)
     expect(botoes[0]).toHaveTextContent("Marcar obrigatórias");
   });
+
+  it("marca concluídas em verde na lista mobile e orienta quando nada está selecionado", () => {
+    renderGraph({
+      mobileLayout: "list",
+      completedDisciplinaIds: new Set(["disc-calculo"]),
+    });
+
+    expect(screen.getByText("Toque nas disciplinas abaixo para selecionar.")).toBeInTheDocument();
+
+    const mobileList = within(screen.getByTestId("mobile-curriculum-list"));
+    const concluida = mobileList.getByRole("button", { name: /Cálculo I/ });
+    expect(concluida.className).toMatch(/emerald/);
+    expect(within(concluida).getByText("Concluída")).toBeInTheDocument();
+  });
 });
 
 describe("CurriculumGraph — ações de salvar conforme a seleção", () => {

--- a/src/components/pages/grades-curriculares/curriculum-graph.tsx
+++ b/src/components/pages/grades-curriculares/curriculum-graph.tsx
@@ -544,7 +544,7 @@ export function CurriculumGraph({
         <Button
           size="sm"
           disabled={isSaving || !hasSelection || noActionAvailable}
-          className="min-h-11 gap-1.5 md:min-h-9"
+          className="min-h-11 w-full gap-1.5 sm:w-auto md:min-h-9"
           onClick={() => singleStatus && void handleSaveAs(singleStatus)}
         >
           <DirectIcon aria-hidden="true" className="w-3.5 h-3.5" />
@@ -559,7 +559,7 @@ export function CurriculumGraph({
           <Button
             size="sm"
             disabled={isSaving || !hasSelection}
-            className="min-h-11 gap-1.5 md:min-h-9"
+            className="min-h-11 w-full gap-1.5 sm:w-auto md:min-h-9"
           >
             <Save aria-hidden="true" className="w-3.5 h-3.5" />
             {isSaving ? "Salvando…" : "Salvar"}
@@ -717,13 +717,18 @@ export function CurriculumGraph({
 
         {/* Progress bar + Selection action */}
         {selectionMode && progressStats && (
-          <div className="mb-4 p-3 rounded-lg bg-slate-50 dark:bg-slate-800/50 border border-slate-200 dark:border-white/10">
-            <div className="flex items-center justify-between mb-2 flex-wrap gap-2">
-              <div className="flex flex-wrap items-center gap-4 text-sm">
+          <div className="mb-4 space-y-3 rounded-lg border border-slate-200 bg-slate-50 p-3 dark:border-white/10 dark:bg-slate-800/50">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-sm">
                 <span className="flex items-center gap-1.5">
-                  <CheckCircle2 className="w-4 h-4 text-green-600 dark:text-green-400" />
-                  <strong>{progressStats.completedObrigatorias}</strong>/
-                  {progressStats.obrigatorias} obrigatórias ({progressStats.percentObrigatorias}%)
+                  <CheckCircle2
+                    aria-hidden="true"
+                    className="h-4 w-4 shrink-0 text-green-600 dark:text-green-400"
+                  />
+                  <span>
+                    <strong>{progressStats.completedObrigatorias}</strong>/
+                    {progressStats.obrigatorias} obrigatórias ({progressStats.percentObrigatorias}%)
+                  </span>
                 </span>
                 <span className="text-muted-foreground">
                   {progressStats.totalHorasCompleted}h / {progressStats.totalHoras}h
@@ -735,9 +740,22 @@ export function CurriculumGraph({
                   </span>
                 )}
               </div>
-              {onSaveWithStatus && <SaveActions />}
+              {onSaveWithStatus && (
+                <div className="flex w-full flex-col gap-1.5 sm:w-auto sm:items-end">
+                  <SaveActions />
+                  {!hasSelection && (
+                    <p className="text-xs text-muted-foreground sm:text-right">
+                      Toque nas disciplinas abaixo para selecionar.
+                    </p>
+                  )}
+                </div>
+              )}
             </div>
-            <Progress value={progressStats.percentObrigatorias} className="h-2" />
+            <Progress
+              value={progressStats.percentObrigatorias}
+              className="h-1.5 bg-slate-200 dark:bg-slate-700"
+              indicatorClassName="bg-emerald-500 dark:bg-emerald-400"
+            />
           </div>
         )}
 
@@ -833,10 +851,18 @@ export function CurriculumGraph({
                           }}
                           className={cn(
                             "min-h-11 w-full rounded-md border bg-card px-3 py-2 text-left",
-                            "touch-manipulation transition-[border-color,background-color,box-shadow]",
+                            "touch-manipulation transition-[border-color,background-color,box-shadow,transform]",
                             "hover:border-aquario-primary/50 hover:bg-accent/50",
+                            "active:scale-[0.98]",
                             "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                            "motion-reduce:transition-none",
+                            "motion-reduce:transition-none motion-reduce:active:scale-100",
+                            isCompleted &&
+                              !isSelected &&
+                              "border-emerald-500/35 bg-emerald-50/80 dark:border-emerald-400/30 dark:bg-emerald-950/30",
+                            isCursando &&
+                              !isSelected &&
+                              !isCompleted &&
+                              "border-purple-500/35 bg-purple-50/80 dark:border-purple-400/30 dark:bg-purple-950/30",
                             isSelected &&
                               "border-aquario-primary bg-aquario-primary/10 ring-2 ring-aquario-primary/30"
                           )}
@@ -851,7 +877,16 @@ export function CurriculumGraph({
                               </span>
                             </span>
                             {(isCompleted || isCursando || isSelected) && (
-                              <span className="shrink-0 text-xs font-medium text-muted-foreground">
+                              <span
+                                className={cn(
+                                  "shrink-0 text-xs font-medium",
+                                  isSelected
+                                    ? "text-aquario-primary"
+                                    : isCompleted
+                                      ? "text-emerald-700 dark:text-emerald-300"
+                                      : "text-purple-700 dark:text-purple-300"
+                                )}
+                              >
                                 {isSelected
                                   ? "Selecionada"
                                   : isCompleted

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -7,15 +7,17 @@ import { cn } from "@/lib/client/utils";
 
 const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
->(({ className, value, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root> & {
+    indicatorClassName?: string;
+  }
+>(({ className, indicatorClassName, value, ...props }, ref) => (
   <ProgressPrimitive.Root
     ref={ref}
     className={cn("relative h-4 w-full overflow-hidden rounded-full bg-secondary", className)}
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
+      className={cn("h-full w-full flex-1 bg-primary transition-all", indicatorClassName)}
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>


### PR DESCRIPTION
## Why
Students got stuck on **Disciplinas do Semestre** on iPhone. The Save button stays disabled until a selection exists, and **Pular** sat under Safari's bottom toolbar because the modal used top+bottom insets against the layout viewport. The selection chrome also read as broken: progress used near-black `--primary`, and concluídas did not show green in the mobile list even though the copy promised that.

## Scope
- `OnboardingModal`: size the mobile dialog with `100svh` and safe-area footer padding so Voltar/Pular stay above browser chrome.
- `CurriculumGraph` selection chrome: stack actions on small screens, emerald progress fill via `indicatorClassName`, hint when nothing is selected, green/purple status on mobile list cards, press scale on cards.
- `Progress`: optional `indicatorClassName`.
- Test for green concluídas + selection hint on mobile list.

## Tradeoffs
`svh` leaves a small gap when Safari hides its toolbar. That is better than burying the only escape hatch under the chrome.

## Blast Radius
Touches every onboarding step's shell on mobile, plus any screen that uses `CurriculumGraph` selection chrome. Desktop modal path still uses the existing `sm:` centered sizing.

## Verification
- Repro harness at `.scratch/mobile-cursando-repro/`: before `skipOccludedBySafari: true` and `progressFill: rgb(23,23,23)`; after `pass: true`, `footerVisibleRatio: 1`, `progressFill: rgb(16,185,129)`.
- `npx jest src/components/pages/grades-curriculares/__tests__/curriculum-graph.test.tsx` → 22 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved onboarding dialog sizing and safe-area handling on mobile devices.
  - Updated curriculum views with more responsive mobile layouts, full-width save controls, clearer progress guidance, and improved touch feedback.
  - Added distinct visual states and labels for completed and in-progress disciplines.
  - Enhanced progress indicators with more flexible styling options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->