### PR TITLE
feat(sigaa): nudge de conexão após onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Nudge de conexão SIGAA**: Depois do onboarding, contas autenticadas sem SIGAA veem um modal leve pedindo para conectar. "Deixar pra depois", o X e o clique fora gravam o dismiss por usuário.
+
 ## [1.12.1] - 2026-08-27
 
 ### Fixed

--- a/src/analytics/posthog-events.ts
+++ b/src/analytics/posthog-events.ts
@@ -127,8 +127,17 @@ type SigaaEvent =
         | "mobile_user_menu"
         | "desktop_resources"
         | "mobile_resources"
-        | "landing";
+        | "landing"
+        | "connect_nudge";
       connection_state: SigaaDiscoveryConnectionState;
+    }
+  | {
+      name: "sigaa_connect_nudge_viewed";
+      connection_state: "never_connected" | "disconnected";
+    }
+  | {
+      name: "sigaa_connect_nudge_dismissed";
+      connection_state: "never_connected" | "disconnected";
     }
   | { name: "sigaa_highlight_viewed" }
   | {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { ReactQueryProvider } from "@/providers/react-query-provider";
 import { PostHogProvider } from "@/providers/posthog-provider";
 import { Toaster } from "@/components/ui/sonner";
 import { OnboardingProvider } from "@/components/onboarding/onboarding-provider";
+import { SigaaConnectNudgeProvider } from "@/components/sigaa/sigaa-connect-nudge-provider";
 import { DevToolsPanel } from "@/components/dev/dev-tools-panel";
 
 const outfit = Outfit({
@@ -61,6 +62,7 @@ export default function RootLayout({
                     <NavWrapper />
                     <div className="pt-0">{children}</div>
                   </div>
+                  <SigaaConnectNudgeProvider />
                 </OnboardingProvider>
                 <Toaster />
                 <DevToolsPanel />

--- a/src/components/onboarding/onboarding-provider.tsx
+++ b/src/components/onboarding/onboarding-provider.tsx
@@ -1,16 +1,9 @@
 "use client";
 
 import { usePathname } from "next/navigation";
+import { AUTH_ROUTES } from "@/lib/client/auth-routes";
 import { useOnboarding } from "@/lib/client/hooks/use-onboarding";
 import { OnboardingModal } from "./onboarding-modal";
-
-const AUTH_ROUTES: ReadonlySet<string> = new Set([
-  "/login",
-  "/registro",
-  "/esqueci-senha",
-  "/resetar-senha",
-  "/verificar-email",
-]);
 
 export function OnboardingProvider({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();

--- a/src/components/sigaa/__tests__/sigaa-connect-nudge-provider.integration.test.tsx
+++ b/src/components/sigaa/__tests__/sigaa-connect-nudge-provider.integration.test.tsx
@@ -67,9 +67,7 @@ describe("SigaaConnectNudgeProvider", () => {
   it("mounts the modal when every gate passes", async () => {
     render(<SigaaConnectNudgeProvider />);
 
-    expect(
-      await screen.findByRole("dialog", { name: "Conecte com o SIGAA" })
-    ).toBeInTheDocument();
+    expect(await screen.findByRole("dialog", { name: "Conecte com o SIGAA" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Conectar agora" })).toHaveAttribute(
       "href",
       "/me/academico?connect=1"

--- a/src/components/sigaa/__tests__/sigaa-connect-nudge-provider.integration.test.tsx
+++ b/src/components/sigaa/__tests__/sigaa-connect-nudge-provider.integration.test.tsx
@@ -1,0 +1,148 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { usePathname } from "next/navigation";
+import { useAuth } from "@/contexts/auth-context";
+import { useOnboarding } from "@/lib/client/hooks/use-onboarding";
+import { useOwnSigaaAcademicState } from "@/lib/client/hooks/use-sigaa";
+import { sigaaConnectNudgeStorageKey } from "@/lib/client/sigaa/connect-nudge";
+
+import { SigaaConnectNudgeProvider } from "../sigaa-connect-nudge-provider";
+
+vi.mock("next/navigation", () => ({ usePathname: vi.fn() }));
+vi.mock("@/contexts/auth-context", () => ({ useAuth: vi.fn() }));
+vi.mock("@/lib/client/hooks/use-onboarding", () => ({ useOnboarding: vi.fn() }));
+vi.mock("@/lib/client/hooks/use-sigaa", () => ({ useOwnSigaaAcademicState: vi.fn() }));
+vi.mock("@/analytics/posthog-client", () => ({ trackEvent: vi.fn() }));
+
+const mockUsePathname = vi.mocked(usePathname);
+const mockUseAuth = vi.mocked(useAuth);
+const mockUseOnboarding = vi.mocked(useOnboarding);
+const mockUseSigaa = vi.mocked(useOwnSigaaAcademicState);
+
+function stubReadyGates(pathname = "/") {
+  mockUsePathname.mockReturnValue(pathname);
+  mockUseAuth.mockReturnValue({
+    isAuthenticated: true,
+    isLoading: false,
+    userId: "user-1",
+    token: "token",
+    login: vi.fn(),
+    logout: vi.fn(),
+  });
+  mockUseOnboarding.mockReturnValue({
+    shouldShow: false,
+    isLoading: false,
+    currentStep: null,
+    steps: [],
+    allSteps: [],
+    completedCount: 0,
+    totalCount: 0,
+    completeStep: vi.fn(),
+    skipStep: vi.fn(),
+    isMutating: false,
+    semestreAtivo: undefined,
+    paasAvailable: false,
+    isComplete: true,
+  });
+  mockUseSigaa.mockReturnValue({
+    data: {
+      matricula: { value: null, origin: null, verifiedAt: null },
+      connection: null,
+      snapshot: null,
+    },
+    isLoading: false,
+    isError: false,
+  } as ReturnType<typeof useOwnSigaaAcademicState>);
+}
+
+describe("SigaaConnectNudgeProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    stubReadyGates();
+  });
+
+  it("mounts the modal when every gate passes", async () => {
+    render(<SigaaConnectNudgeProvider />);
+
+    expect(
+      await screen.findByRole("dialog", { name: "Conecte com o SIGAA" })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Conectar agora" })).toHaveAttribute(
+      "href",
+      "/me/academico?connect=1"
+    );
+  });
+
+  it.each(["/login", "/registro", "/esqueci-senha", "/resetar-senha", "/verificar-email"])(
+    "does not mount on the auth route %s",
+    async pathname => {
+      stubReadyGates(pathname);
+      render(<SigaaConnectNudgeProvider />);
+      await waitFor(() => {
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      });
+    }
+  );
+
+  it("does not mount on /me/academico", async () => {
+    stubReadyGates("/me/academico");
+    render(<SigaaConnectNudgeProvider />);
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  it("does not mount while onboarding is open", async () => {
+    stubReadyGates();
+    mockUseOnboarding.mockReturnValue({
+      shouldShow: true,
+      isLoading: false,
+      currentStep: {
+        id: "welcome",
+        title: "Bem-vindo",
+        description: "Configuração inicial",
+        isSkippable: false,
+        isCompleted: false,
+      },
+      steps: [],
+      allSteps: [],
+      completedCount: 0,
+      totalCount: 1,
+      completeStep: vi.fn(),
+      skipStep: vi.fn(),
+      isMutating: false,
+      semestreAtivo: undefined,
+      paasAvailable: false,
+      isComplete: false,
+    });
+
+    render(<SigaaConnectNudgeProvider />);
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  it("does not remount after a stored dismissal", async () => {
+    localStorage.setItem(
+      sigaaConnectNudgeStorageKey("user-1"),
+      JSON.stringify({ dismissedAt: "2026-09-02T12:00:00.000Z" })
+    );
+    render(<SigaaConnectNudgeProvider />);
+    await expect(screen.findByRole("dialog", {}, { timeout: 150 })).rejects.toThrow();
+  });
+
+  it("persists dismiss per user and hides the modal", async () => {
+    const user = userEvent.setup();
+    render(<SigaaConnectNudgeProvider />);
+
+    await user.click(await screen.findByRole("button", { name: "Deixar pra depois" }));
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(localStorage.getItem(sigaaConnectNudgeStorageKey("user-1"))).toEqual(
+      expect.stringContaining("dismissedAt")
+    );
+  });
+});

--- a/src/components/sigaa/sigaa-connect-nudge-card.tsx
+++ b/src/components/sigaa/sigaa-connect-nudge-card.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import Link from "next/link";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { ShieldCheck, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogDescription,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/client/utils";
+
+const SIGAA_CONNECT_HREF = "/me/academico?connect=1";
+
+const pressableClassName =
+  "motion-safe:transition-transform motion-safe:duration-150 motion-safe:ease-out motion-safe:active:scale-[0.97]";
+
+type SigaaConnectNudgeCardProps = Readonly<{
+  onConnect: () => void;
+  onDismiss: () => void;
+}>;
+
+export function SigaaConnectNudgeCard({ onConnect, onDismiss }: SigaaConnectNudgeCardProps) {
+  return (
+    <Dialog
+      open
+      onOpenChange={open => {
+        if (!open) {
+          onDismiss();
+        }
+      }}
+    >
+      <DialogPortal>
+        <DialogOverlay className="bg-slate-900/40" />
+        <DialogPrimitive.Content
+          aria-labelledby="sigaa-connect-nudge-title"
+          aria-describedby="sigaa-connect-nudge-description"
+          className={cn(
+            "fixed left-4 right-4 top-[50%] z-50 grid w-auto max-w-[400px] translate-y-[-50%] gap-0 rounded-3xl border border-sky-200 bg-white p-6 shadow-[0_24px_60px_rgba(15,23,42,0.25)]",
+            "dark:border-sky-800 dark:bg-slate-900",
+            "duration-[260ms] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:left-[50%] sm:right-auto sm:w-full sm:-translate-x-1/2",
+            "motion-safe:ease-out"
+          )}
+        >
+          <DialogPrimitive.Close
+            className={cn(
+              "absolute right-2 top-2 flex h-10 w-10 items-center justify-center rounded-sm text-slate-400 opacity-70",
+              "[@media(hover:hover)]:hover:bg-sky-50 [@media(hover:hover)]:hover:text-aquario-primary [@media(hover:hover)]:hover:opacity-100",
+              "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+              "dark:text-slate-500 dark:[@media(hover:hover)]:hover:bg-sky-950/60 dark:[@media(hover:hover)]:hover:text-sky-200",
+              pressableClassName
+            )}
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+            <span className="sr-only">Fechar</span>
+          </DialogPrimitive.Close>
+
+          <div
+            aria-hidden="true"
+            className="mb-4 flex h-[52px] w-[52px] items-center justify-center rounded-2xl bg-sky-50 text-aquario-primary dark:bg-sky-950/70 dark:text-sky-200"
+          >
+            <ShieldCheck className="h-6 w-6" />
+          </div>
+
+          <p className="mb-2 text-[11px] font-bold uppercase tracking-[0.12em] text-aquario-primary dark:text-sky-200">
+            Novidade no Aquário
+          </p>
+          <DialogTitle
+            id="sigaa-connect-nudge-title"
+            className="text-left text-[22px] font-bold leading-tight text-aquario-primary dark:text-sky-100"
+          >
+            Conecte com o SIGAA
+          </DialogTitle>
+          <DialogDescription
+            id="sigaa-connect-nudge-description"
+            className="mt-2 text-left text-sm leading-relaxed text-slate-500 dark:text-slate-400"
+          >
+            Sua conta já tá pronta. Falta só puxar os dados acadêmicos. Dá pra fazer agora, e a senha
+            não fica salva.
+          </DialogDescription>
+
+          <div className="mt-5 flex flex-col gap-2">
+            <Button
+              asChild
+              className={cn(
+                "h-auto w-full rounded-full bg-aquario-primary px-4 py-3 text-sm font-semibold text-white",
+                "[@media(hover:hover)]:hover:bg-aquario-primary/90",
+                pressableClassName
+              )}
+            >
+              <Link href={SIGAA_CONNECT_HREF} onClick={onConnect}>
+                Conectar agora
+              </Link>
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={onDismiss}
+              className={cn(
+                "h-auto w-full rounded-full bg-slate-100 px-4 py-3 text-sm font-semibold text-slate-700",
+                "[@media(hover:hover)]:hover:bg-slate-200",
+                "dark:bg-slate-800 dark:text-slate-200 dark:[@media(hover:hover)]:hover:bg-slate-700",
+                pressableClassName
+              )}
+            >
+              Deixar pra depois
+            </Button>
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPortal>
+    </Dialog>
+  );
+}

--- a/src/components/sigaa/sigaa-connect-nudge-card.tsx
+++ b/src/components/sigaa/sigaa-connect-nudge-card.tsx
@@ -79,8 +79,8 @@ export function SigaaConnectNudgeCard({ onConnect, onDismiss }: SigaaConnectNudg
             id="sigaa-connect-nudge-description"
             className="mt-2 text-left text-sm leading-relaxed text-slate-500 dark:text-slate-400"
           >
-            Sua conta já tá pronta. Falta só puxar os dados acadêmicos. Dá pra fazer agora, e a senha
-            não fica salva.
+            Sua conta já tá pronta. Falta só puxar os dados acadêmicos. Dá pra fazer agora, e a
+            senha não fica salva.
           </DialogDescription>
 
           <div className="mt-5 flex flex-col gap-2">

--- a/src/components/sigaa/sigaa-connect-nudge-provider.tsx
+++ b/src/components/sigaa/sigaa-connect-nudge-provider.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { usePathname } from "next/navigation";
+
+import { trackEvent } from "@/analytics/posthog-client";
+import { SigaaConnectNudgeCard } from "@/components/sigaa/sigaa-connect-nudge-card";
+import { useAuth } from "@/contexts/auth-context";
+import { useOnboarding } from "@/lib/client/hooks/use-onboarding";
+import { useOwnSigaaAcademicState } from "@/lib/client/hooks/use-sigaa";
+import { resolveSigaaAccessState } from "@/lib/client/sigaa/access-state";
+import {
+  decideSigaaConnectNudge,
+  getSigaaConnectNudgeConnectionState,
+  readSigaaConnectNudgeDismissed,
+  writeSigaaConnectNudgeDismissed,
+} from "@/lib/client/sigaa/connect-nudge";
+import { IS_DEV } from "@/lib/shared/config/env";
+
+export function SigaaConnectNudgeProvider() {
+  const pathname = usePathname();
+  const auth = useAuth();
+  const onboarding = useOnboarding();
+  const sigaaQuery = useOwnSigaaAcademicState(auth.isAuthenticated);
+  const accessState = resolveSigaaAccessState({
+    isAuthenticated: auth.isAuthenticated,
+    isAuthLoading: auth.isLoading,
+    isConnectionLoading: sigaaQuery.isLoading,
+    isConnectionError: sigaaQuery.isError,
+    importedState: sigaaQuery.data,
+  });
+
+  const [dismissed, setDismissed] = useState<boolean | null>(null);
+  const [forcePreview, setForcePreview] = useState(false);
+  const viewedForUserRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!IS_DEV) {
+      return;
+    }
+    setForcePreview(new URLSearchParams(window.location.search).get("sigaaNudgePreview") === "1");
+  }, [pathname]);
+
+  useEffect(() => {
+    if (!auth.userId) {
+      setDismissed(false);
+      return;
+    }
+    setDismissed(readSigaaConnectNudgeDismissed(auth.userId));
+  }, [auth.userId]);
+
+  const decision = decideSigaaConnectNudge({
+    auth: { isAuthenticated: auth.isAuthenticated, isLoading: auth.isLoading },
+    onboarding: { shouldShow: onboarding.shouldShow, isLoading: onboarding.isLoading },
+    accessState,
+    pathname,
+    dismissed: dismissed === true,
+  });
+  const show = forcePreview || (decision.show && dismissed !== null);
+  const connectionState =
+    getSigaaConnectNudgeConnectionState(accessState) ??
+    (forcePreview ? "never_connected" : null);
+
+  useEffect(() => {
+    if (!show || !connectionState || !auth.userId) {
+      return;
+    }
+    if (viewedForUserRef.current === auth.userId) {
+      return;
+    }
+    viewedForUserRef.current = auth.userId;
+    trackEvent("sigaa_connect_nudge_viewed", { connection_state: connectionState });
+  }, [auth.userId, connectionState, show]);
+
+  const handleConnect = () => {
+    if (!connectionState) {
+      return;
+    }
+    trackEvent("sigaa_entrypoint_clicked", {
+      location: "connect_nudge",
+      connection_state: connectionState,
+    });
+  };
+
+  const handleDismiss = () => {
+    if (auth.userId) {
+      writeSigaaConnectNudgeDismissed(auth.userId);
+    }
+    setDismissed(true);
+    if (connectionState) {
+      trackEvent("sigaa_connect_nudge_dismissed", { connection_state: connectionState });
+    }
+  };
+
+  if (!show) {
+    return null;
+  }
+
+  return <SigaaConnectNudgeCard onConnect={handleConnect} onDismiss={handleDismiss} />;
+}

--- a/src/components/sigaa/sigaa-connect-nudge-provider.tsx
+++ b/src/components/sigaa/sigaa-connect-nudge-provider.tsx
@@ -58,8 +58,7 @@ export function SigaaConnectNudgeProvider() {
   });
   const show = forcePreview || (decision.show && dismissed !== null);
   const connectionState =
-    getSigaaConnectNudgeConnectionState(accessState) ??
-    (forcePreview ? "never_connected" : null);
+    getSigaaConnectNudgeConnectionState(accessState) ?? (forcePreview ? "never_connected" : null);
 
   useEffect(() => {
     if (!show || !connectionState || !auth.userId) {

--- a/src/lib/client/auth-routes.ts
+++ b/src/lib/client/auth-routes.ts
@@ -1,0 +1,11 @@
+export const AUTH_ROUTES: ReadonlySet<string> = new Set([
+  "/login",
+  "/registro",
+  "/esqueci-senha",
+  "/resetar-senha",
+  "/verificar-email",
+]);
+
+export function isAuthRoute(pathname: string): boolean {
+  return AUTH_ROUTES.has(pathname);
+}

--- a/src/lib/client/sigaa/__tests__/connect-nudge.test.ts
+++ b/src/lib/client/sigaa/__tests__/connect-nudge.test.ts
@@ -1,0 +1,254 @@
+import type { SigaaAccessState } from "../access-state";
+import {
+  decideSigaaConnectNudge,
+  getSigaaConnectNudgeConnectionState,
+  readSigaaConnectNudgeDismissed,
+  sigaaConnectNudgeStorageKey,
+  writeSigaaConnectNudgeDismissed,
+  type SigaaConnectNudgeInput,
+  type SigaaConnectNudgeStorage,
+} from "../connect-nudge";
+
+const neverConnected: SigaaAccessState = {
+  availability: "available",
+  connection: { status: "ready", view: { kind: "never_connected" } },
+};
+
+const disconnected: SigaaAccessState = {
+  availability: "available",
+  connection: {
+    status: "ready",
+    view: { kind: "disconnected", synchronizedAt: "2026-08-01T00:00:00.000Z" },
+  },
+};
+
+function readyInput(overrides: Partial<SigaaConnectNudgeInput> = {}): SigaaConnectNudgeInput {
+  return {
+    auth: { isAuthenticated: true, isLoading: false },
+    onboarding: { shouldShow: false, isLoading: false },
+    accessState: neverConnected,
+    pathname: "/",
+    dismissed: false,
+    ...overrides,
+  };
+}
+
+describe("decideSigaaConnectNudge", () => {
+  it("shows for a signed-in user who finished onboarding and never connected", () => {
+    expect(decideSigaaConnectNudge(readyInput())).toEqual({ show: true });
+  });
+
+  it("shows after a disconnect", () => {
+    expect(decideSigaaConnectNudge(readyInput({ accessState: disconnected }))).toEqual({
+      show: true,
+    });
+  });
+
+  it("hides while auth is loading", () => {
+    expect(
+      decideSigaaConnectNudge(readyInput({ auth: { isAuthenticated: false, isLoading: true } }))
+    ).toEqual({ show: false, reason: "loading" });
+  });
+
+  it("hides when the user is signed out", () => {
+    expect(
+      decideSigaaConnectNudge(readyInput({ auth: { isAuthenticated: false, isLoading: false } }))
+    ).toEqual({ show: false, reason: "auth" });
+  });
+
+  it("hides while onboarding metadata is loading", () => {
+    expect(
+      decideSigaaConnectNudge(readyInput({ onboarding: { shouldShow: false, isLoading: true } }))
+    ).toEqual({ show: false, reason: "loading" });
+  });
+
+  it("hides while onboarding is still open", () => {
+    expect(
+      decideSigaaConnectNudge(readyInput({ onboarding: { shouldShow: true, isLoading: false } }))
+    ).toEqual({ show: false, reason: "onboarding" });
+  });
+
+  it("hides while SIGAA availability is checking", () => {
+    expect(
+      decideSigaaConnectNudge(readyInput({ accessState: { availability: "checking" } }))
+    ).toEqual({ show: false, reason: "loading" });
+  });
+
+  it("never treats sign_in_required as a connect nudge", () => {
+    expect(
+      decideSigaaConnectNudge(
+        readyInput({
+          auth: { isAuthenticated: true, isLoading: false },
+          accessState: { availability: "sign_in_required" },
+        })
+      )
+    ).toEqual({ show: false, reason: "auth" });
+  });
+
+  it("hides while the SIGAA connection is checking", () => {
+    expect(
+      decideSigaaConnectNudge(
+        readyInput({
+          accessState: { availability: "available", connection: { status: "checking" } },
+        })
+      )
+    ).toEqual({ show: false, reason: "loading" });
+  });
+
+  it("hides when the SIGAA connection is in error", () => {
+    expect(
+      decideSigaaConnectNudge(
+        readyInput({
+          accessState: { availability: "available", connection: { status: "error" } },
+        })
+      )
+    ).toEqual({ show: false, reason: "unavailable" });
+  });
+
+  it("hides when the SIGAA connection is pending", () => {
+    expect(
+      decideSigaaConnectNudge(
+        readyInput({
+          accessState: {
+            availability: "available",
+            connection: { status: "ready", view: { kind: "pending" } },
+          },
+        })
+      )
+    ).toEqual({ show: false, reason: "unavailable" });
+  });
+
+  it("hides when SIGAA is already connected", () => {
+    expect(
+      decideSigaaConnectNudge(
+        readyInput({
+          accessState: {
+            availability: "available",
+            connection: {
+              status: "ready",
+              view: {
+                kind: "connected",
+                synchronizedAt: "2026-08-01T00:00:00.000Z",
+                matricula: "20210000000",
+              },
+            },
+          },
+        })
+      )
+    ).toEqual({ show: false, reason: "connected" });
+  });
+
+  it.each(["/login", "/registro", "/esqueci-senha", "/resetar-senha", "/verificar-email"])(
+    "hides on the auth route %s",
+    pathname => {
+      expect(decideSigaaConnectNudge(readyInput({ pathname }))).toEqual({
+        show: false,
+        reason: "route",
+      });
+    }
+  );
+
+  it("hides on /me/academico and its prefixes", () => {
+    expect(decideSigaaConnectNudge(readyInput({ pathname: "/me/academico" }))).toEqual({
+      show: false,
+      reason: "route",
+    });
+    expect(decideSigaaConnectNudge(readyInput({ pathname: "/me/academico/historico" }))).toEqual({
+      show: false,
+      reason: "route",
+    });
+  });
+
+  it("hides after the user dismissed the nudge", () => {
+    expect(decideSigaaConnectNudge(readyInput({ dismissed: true }))).toEqual({
+      show: false,
+      reason: "dismissed",
+    });
+  });
+});
+
+describe("getSigaaConnectNudgeConnectionState", () => {
+  it("returns the ready disconnected or never-connected kind", () => {
+    expect(getSigaaConnectNudgeConnectionState(neverConnected)).toBe("never_connected");
+    expect(getSigaaConnectNudgeConnectionState(disconnected)).toBe("disconnected");
+  });
+
+  it("returns null when the connection is not eligible", () => {
+    expect(getSigaaConnectNudgeConnectionState({ availability: "checking" })).toBeNull();
+    expect(getSigaaConnectNudgeConnectionState({ availability: "sign_in_required" })).toBeNull();
+  });
+});
+
+describe("sigaa connect nudge storage", () => {
+  function memoryStorage(initial: Record<string, string> = {}): SigaaConnectNudgeStorage & {
+    store: Record<string, string>;
+  } {
+    const store = { ...initial };
+    return {
+      store,
+      getItem(key) {
+        return store[key] ?? null;
+      },
+      setItem(key, value) {
+        store[key] = value;
+      },
+    };
+  }
+
+  it("versions the key per user", () => {
+    expect(sigaaConnectNudgeStorageKey("user-1")).toBe("sigaa-connect-nudge:v1:user-1");
+  });
+
+  it("reads a stored dismissal", () => {
+    const storage = memoryStorage({
+      "sigaa-connect-nudge:v1:user-1": JSON.stringify({ dismissedAt: "2026-09-02T12:00:00.000Z" }),
+    });
+
+    expect(readSigaaConnectNudgeDismissed("user-1", storage)).toBe(true);
+    expect(readSigaaConnectNudgeDismissed("user-2", storage)).toBe(false);
+  });
+
+  it("writes a dismissal that later reads as dismissed", () => {
+    const storage = memoryStorage();
+    writeSigaaConnectNudgeDismissed("user-1", "2026-09-02T12:00:00.000Z", storage);
+
+    expect(storage.store["sigaa-connect-nudge:v1:user-1"]).toBe(
+      JSON.stringify({ dismissedAt: "2026-09-02T12:00:00.000Z" })
+    );
+    expect(readSigaaConnectNudgeDismissed("user-1", storage)).toBe(true);
+  });
+
+  it("treats invalid or missing payloads as not dismissed", () => {
+    const storage = memoryStorage({
+      "sigaa-connect-nudge:v1:user-1": "{not-json",
+      "sigaa-connect-nudge:v1:user-2": JSON.stringify({ dismissedAt: 12 }),
+      "sigaa-connect-nudge:v1:user-3": JSON.stringify({ dismissedAt: "" }),
+    });
+
+    expect(readSigaaConnectNudgeDismissed("user-1", storage)).toBe(false);
+    expect(readSigaaConnectNudgeDismissed("user-2", storage)).toBe(false);
+    expect(readSigaaConnectNudgeDismissed("user-3", storage)).toBe(false);
+    expect(readSigaaConnectNudgeDismissed("user-4", storage)).toBe(false);
+  });
+
+  it("swallows getItem and setItem failures", () => {
+    const throwingStorage: SigaaConnectNudgeStorage = {
+      getItem() {
+        throw new Error("blocked");
+      },
+      setItem() {
+        throw new Error("blocked");
+      },
+    };
+
+    expect(readSigaaConnectNudgeDismissed("user-1", throwingStorage)).toBe(false);
+    expect(() =>
+      writeSigaaConnectNudgeDismissed("user-1", undefined, throwingStorage)
+    ).not.toThrow();
+  });
+
+  it("treats a missing storage adapter as not dismissed", () => {
+    expect(readSigaaConnectNudgeDismissed("user-1", null)).toBe(false);
+    expect(() => writeSigaaConnectNudgeDismissed("user-1", undefined, null)).not.toThrow();
+  });
+});

--- a/src/lib/client/sigaa/connect-nudge.ts
+++ b/src/lib/client/sigaa/connect-nudge.ts
@@ -109,9 +109,7 @@ export function writeSigaaConnectNudgeDismissed(
   try {
     const value: SigaaConnectNudgeDismissal = { dismissedAt };
     storage.setItem(sigaaConnectNudgeStorageKey(userId), JSON.stringify(value));
-  } catch {
-    return;
-  }
+  } catch {}
 }
 
 type SigaaNudgeEligibility =

--- a/src/lib/client/sigaa/connect-nudge.ts
+++ b/src/lib/client/sigaa/connect-nudge.ts
@@ -1,0 +1,183 @@
+import { isAuthRoute } from "@/lib/client/auth-routes";
+import type { SigaaAccessState } from "@/lib/client/sigaa/access-state";
+
+export type SigaaConnectNudgeHideReason =
+  | "auth"
+  | "loading"
+  | "onboarding"
+  | "connected"
+  | "route"
+  | "dismissed"
+  | "unavailable";
+
+export type SigaaConnectNudgeDecision =
+  | { show: false; reason: SigaaConnectNudgeHideReason }
+  | { show: true };
+
+export type SigaaConnectNudgeInput = Readonly<{
+  auth: Readonly<{ isAuthenticated: boolean; isLoading: boolean }>;
+  onboarding: Readonly<{ shouldShow: boolean; isLoading: boolean }>;
+  accessState: SigaaAccessState;
+  pathname: string;
+  dismissed: boolean;
+}>;
+
+export type SigaaConnectNudgeConnectionState = "never_connected" | "disconnected";
+
+export type SigaaConnectNudgeDismissal = Readonly<{ dismissedAt: string }>;
+
+export type SigaaConnectNudgeStorage = Pick<Storage, "getItem" | "setItem">;
+
+export const SIGAA_CONNECT_NUDGE_STORAGE_VERSION = "v1";
+
+export function sigaaConnectNudgeStorageKey(userId: string): string {
+  return `sigaa-connect-nudge:${SIGAA_CONNECT_NUDGE_STORAGE_VERSION}:${userId}`;
+}
+
+export function isSigaaAcademicRoute(pathname: string): boolean {
+  return pathname === "/me/academico" || pathname.startsWith("/me/academico/");
+}
+
+export function decideSigaaConnectNudge(input: SigaaConnectNudgeInput): SigaaConnectNudgeDecision {
+  if (input.auth.isLoading) {
+    return { show: false, reason: "loading" };
+  }
+
+  if (!input.auth.isAuthenticated) {
+    return { show: false, reason: "auth" };
+  }
+
+  if (input.onboarding.isLoading) {
+    return { show: false, reason: "loading" };
+  }
+
+  if (input.onboarding.shouldShow) {
+    return { show: false, reason: "onboarding" };
+  }
+
+  const eligibility = resolveSigaaNudgeEligibility(input.accessState);
+  if (!eligibility.eligible) {
+    return { show: false, reason: eligibility.reason };
+  }
+
+  if (isAuthRoute(input.pathname) || isSigaaAcademicRoute(input.pathname)) {
+    return { show: false, reason: "route" };
+  }
+
+  if (input.dismissed) {
+    return { show: false, reason: "dismissed" };
+  }
+
+  return { show: true };
+}
+
+export function getSigaaConnectNudgeConnectionState(
+  accessState: SigaaAccessState
+): SigaaConnectNudgeConnectionState | null {
+  const eligibility = resolveSigaaNudgeEligibility(accessState);
+  return eligibility.eligible ? eligibility.connectionState : null;
+}
+
+export function readSigaaConnectNudgeDismissed(
+  userId: string,
+  storage: SigaaConnectNudgeStorage | null = getLocalStorage()
+): boolean {
+  if (!storage) {
+    return false;
+  }
+
+  try {
+    const raw = storage.getItem(sigaaConnectNudgeStorageKey(userId));
+    if (!raw) {
+      return false;
+    }
+    return parseDismissal(raw) !== null;
+  } catch {
+    return false;
+  }
+}
+
+export function writeSigaaConnectNudgeDismissed(
+  userId: string,
+  dismissedAt: string = new Date().toISOString(),
+  storage: SigaaConnectNudgeStorage | null = getLocalStorage()
+): void {
+  if (!storage) {
+    return;
+  }
+
+  try {
+    const value: SigaaConnectNudgeDismissal = { dismissedAt };
+    storage.setItem(sigaaConnectNudgeStorageKey(userId), JSON.stringify(value));
+  } catch {
+    return;
+  }
+}
+
+type SigaaNudgeEligibility =
+  | {
+      eligible: false;
+      reason: Extract<
+        SigaaConnectNudgeHideReason,
+        "auth" | "loading" | "connected" | "unavailable"
+      >;
+    }
+  | { eligible: true; connectionState: SigaaConnectNudgeConnectionState };
+
+function resolveSigaaNudgeEligibility(accessState: SigaaAccessState): SigaaNudgeEligibility {
+  if (accessState.availability === "checking") {
+    return { eligible: false, reason: "loading" };
+  }
+
+  if (accessState.availability === "sign_in_required") {
+    return { eligible: false, reason: "auth" };
+  }
+
+  if (accessState.connection.status === "checking") {
+    return { eligible: false, reason: "loading" };
+  }
+
+  if (accessState.connection.status === "error") {
+    return { eligible: false, reason: "unavailable" };
+  }
+
+  const view = accessState.connection.view;
+  switch (view.kind) {
+    case "never_connected":
+    case "disconnected":
+      return { eligible: true, connectionState: view.kind };
+    case "connected":
+      return { eligible: false, reason: "connected" };
+    case "pending":
+      return { eligible: false, reason: "unavailable" };
+    default: {
+      const _exhaustive: never = view;
+      return _exhaustive;
+    }
+  }
+}
+
+function parseDismissal(raw: string): SigaaConnectNudgeDismissal | null {
+  const parsed: unknown = JSON.parse(raw);
+  if (typeof parsed !== "object" || parsed === null || !("dismissedAt" in parsed)) {
+    return null;
+  }
+
+  const dismissedAt = parsed.dismissedAt;
+  if (typeof dismissedAt !== "string" || dismissedAt.length === 0) {
+    return null;
+  }
+
+  return { dismissedAt };
+}
+
+function getLocalStorage(): SigaaConnectNudgeStorage | null {
+  try {
+    if (typeof window === "undefined") {
+      return null;
+    }
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## 📝 Descrição

Contas antigas que já passaram pelo onboarding (ou pularam o passo SIGAA) não voltam a ver o fluxo de conexão. Este PR adiciona um **modal leve** pedindo para conectar o SIGAA quando:

1. o usuário está logado
2. o onboarding já foi concluído
3. o SIGAA ainda não está conectado (ou foi desconectado)

O CTA abre `/me/academico?connect=1` (fluxo existente). Dismiss via "Deixar pra depois", X ou clique fora persiste por `userId` no `localStorage`.

## 🔗 Issue Relacionada

N/A

## 🧪 Testes

- [x] Testes unitários passam (`connect-nudge.test.ts`, 27 casos)
- [x] Testes de integração passam (`sigaa-connect-nudge-provider.integration.test.tsx`, 10 casos)
- [ ] Testes E2E passam
- [x] Testes manuais concluídos (preview `?sigaaNudgePreview=1` em dev)

## 📸 Screenshots (se aplicável)

Modal centrado com eyebrow "Novidade no Aquário", título "Conecte com o SIGAA", CTA "Conectar agora" e secundário "Deixar pra depois".

## 📋 Checklist

- [x] Código segue as diretrizes de estilo do projeto
- [x] Revisão própria concluída
- [x] Código está devidamente comentado
- [x] Nenhum console.log deixado no código
- [x] Todos os testes passam localmente
- [ ] Build passa sem erros

## 🚀 Notas de Deploy

Nenhuma. Feature client-only; dismiss é local ao browser.

## 📚 Contexto Adicional

- Gate puro em `decideSigaaConnectNudge` (reasons tipados).
- `AUTH_ROUTES` compartilhado com o onboarding.
- Preview só em `NODE_ENV=development` via `?sigaaNudgePreview=1`.