### PR TITLE
fix(sigaa): recognize CI portal course labels in alias allowlist

### DIFF
--- a/src/lib/server/db/implementations/prisma/__tests__/prisma-sigaa-repository.integration.test.ts
+++ b/src/lib/server/db/implementations/prisma/__tests__/prisma-sigaa-repository.integration.test.ts
@@ -792,7 +792,7 @@ describe("PrismaSigaaRepository on PostgreSQL", () => {
       usuarioId: ownerId,
       expectedMatricula: "20260000020",
       state: "PENDING",
-      aliasVersion: "ufpb-2026-08-22",
+      aliasVersion: "ufpb-2026-09-02",
     });
 
     const replay = await repository.reserveAttempt({

--- a/src/lib/server/services/sigaa/__tests__/course-aliases.test.ts
+++ b/src/lib/server/services/sigaa/__tests__/course-aliases.test.ts
@@ -6,19 +6,28 @@ import {
 
 describe("versioned SIGAA course aliases", () => {
   it("publishes an explicit version for review and rollback", () => {
-    expect(SIGAA_COURSE_ALIASES_VERSION).toBe("ufpb-2026-08-22");
+    expect(SIGAA_COURSE_ALIASES_VERSION).toBe("ufpb-2026-09-02");
   });
 
   it.each([
     ["Ciência da Computação", " CIÊNCIA   DA COMPUTAÇÃO "],
     ["Ciência da Computação", "Ciencia da Computacao"],
     ["Ciência da Computação", "Ciência da Computação (Bacharelado)"],
+    ["Ciência da Computação", "Ciência da Computação - Graduação"],
     ["Ciência da Computação", "COMPUTACAO - GRADUACAO"],
+    ["Ciência da Computação", "CIÊNCIA DA COMPUTAÇÃO (BACHARELADO)/CI - João Pessoa"],
     ["Engenharia da Computação", "Engenharia de Computação"],
     ["Engenharia da Computação", "Engenharia da Computação - Graduação"],
     ["Engenharia da Computação", "Engenharia de Computação - Graduação"],
+    ["Engenharia da Computação", "ENGENHARIA DA COMPUTAÇÃO (BACHARELADO)/CI - João Pessoa"],
     ["Ciência de Dados e Inteligência Artificial", "Ciência de Dados e IA"],
+    [
+      "Ciência de Dados e Inteligência Artificial",
+      "CIÊNCIA DE DADOS E INTELIGÊNCIA ARTIFICIAL (BACHARELADO)/CI - João Pessoa",
+    ],
     ["Engenharia de Robôs", "Engenharia de Robos"],
+    ["Engenharia de Robôs", "Engenharia de Robôs - Graduação"],
+    ["Engenharia de Robôs", "ENGENHARIA DE ROBÔS (BACHARELADO)/CI - João Pessoa"],
   ])("accepts the approved profile and SIGAA pair %s / %s", (profile, sigaa) => {
     expect(matchesVersionedSigaaCourseAlias(profile, sigaa)).toBe(true);
   });
@@ -28,6 +37,11 @@ describe("versioned SIGAA course aliases", () => {
     ["Outro", "Ciência da Computação"],
     ["Curso Experimental", "Curso Experimental"],
     ["Curso Experimental", "Curso Experimental Noturno"],
+    // Other campuses / modalities must stay fail-closed.
+    ["Ciência da Computação", "CIÊNCIA DA COMPUTAÇÃO (BACHARELADO)/CT - Campina Grande"],
+    ["Ciência da Computação", "CIÊNCIA DA COMPUTAÇÃO (LICENCIATURA)/CCAE - Rio Tinto"],
+    ["Ciência da Computação", "COMPUTAÇÃO (LICENCIATURA)/CI - João Pessoa - EAD"],
+    ["Engenharia de Robôs", "ENGENHARIA DE ENERGIAS RENOVÁVEIS (BACHARELADO)/CEAR - João Pessoa"],
   ])("fails closed for an unknown or divergent pair %s / %s", (profile, sigaa) => {
     expect(matchesVersionedSigaaCourseAlias(profile, sigaa)).toBe(false);
   });
@@ -54,6 +68,24 @@ describe("versioned SIGAA course aliases", () => {
       kind: "resolved",
       canonicalName: "Engenharia da Computação",
       target: { id: "course-1" },
+    });
+  });
+
+  it("resolves the SIGAA portal label for Ciência da Computação at CI", () => {
+    expect(
+      resolveVersionedSigaaCourse("CIÊNCIA DA COMPUTAÇÃO (BACHARELADO)/CI - João Pessoa", [
+        {
+          id: "course-cc",
+          name: "Ciência da Computação",
+          centerId: "center-1",
+          centerName: "Centro de Informática",
+          centerAcronym: "CI",
+        },
+      ])
+    ).toMatchObject({
+      kind: "resolved",
+      canonicalName: "Ciência da Computação",
+      target: { id: "course-cc" },
     });
   });
 });

--- a/src/lib/server/services/sigaa/course-aliases.ts
+++ b/src/lib/server/services/sigaa/course-aliases.ts
@@ -1,6 +1,6 @@
 import { createHash } from "crypto";
 
-export const SIGAA_COURSE_ALIASES_VERSION = "ufpb-2026-08-22";
+export const SIGAA_COURSE_ALIASES_VERSION = "ufpb-2026-09-02";
 
 export type SigaaCatalogCourse = Readonly<{
   id: string;
@@ -26,6 +26,15 @@ export type SigaaCanonicalCourseResolution =
 export const normalizeSigaaCourseName = (value: string): string =>
   value.normalize("NFKC").trim().replace(/\s+/gu, " ").toLocaleUpperCase("pt-BR");
 
+/**
+ * SIGAA portal labels look like:
+ * `CIÊNCIA DA COMPUTAÇÃO (BACHARELADO)/CI - João Pessoa`
+ *
+ * Only the CI / João Pessoa suffix is recognized so Campina Grande, Rio Tinto,
+ * Licenciatura EAD, etc. stay fail-closed.
+ */
+const CI_JOAO_PESSOA_PORTAL_SUFFIX = normalizeSigaaCourseName("/CI - João Pessoa");
+
 const aliasGroups = [
   {
     canonicalName: "Ciência da Computação",
@@ -33,9 +42,15 @@ const aliasGroups = [
       "Ciência da Computação",
       "Ciencia da Computacao",
       "Ciência da Computação (Bacharelado)",
+      "Ciencia da Computacao (Bacharelado)",
       "Ciência da Computação - Bacharelado",
+      "Ciencia da Computacao - Bacharelado",
+      "Ciência da Computação - Graduação",
+      "Ciencia da Computacao - Graduacao",
       "Computação - Graduação",
       "Computacao - Graduacao",
+      "CIÊNCIA DA COMPUTAÇÃO (BACHARELADO)/CI - João Pessoa",
+      "CIENCIA DA COMPUTACAO (BACHARELADO)/CI - Joao Pessoa",
     ],
   },
   {
@@ -43,25 +58,53 @@ const aliasGroups = [
     aliases: [
       "Engenharia da Computação",
       "Engenharia de Computação",
+      "Engenharia da Computacao",
+      "Engenharia de Computacao",
       "Engenharia da Computação (Bacharelado)",
       "Engenharia de Computação (Bacharelado)",
+      "Engenharia da Computacao (Bacharelado)",
+      "Engenharia de Computacao (Bacharelado)",
+      "Engenharia da Computação - Bacharelado",
+      "Engenharia de Computação - Bacharelado",
       "Engenharia da Computação - Graduação",
       "Engenharia de Computação - Graduação",
       "Engenharia da Computacao - Graduacao",
       "Engenharia de Computacao - Graduacao",
+      "ENGENHARIA DA COMPUTAÇÃO (BACHARELADO)/CI - João Pessoa",
+      "ENGENHARIA DE COMPUTAÇÃO (BACHARELADO)/CI - João Pessoa",
+      "ENGENHARIA DA COMPUTACAO (BACHARELADO)/CI - Joao Pessoa",
+      "ENGENHARIA DE COMPUTACAO (BACHARELADO)/CI - Joao Pessoa",
     ],
   },
   {
     canonicalName: "Ciência de Dados e Inteligência Artificial",
     aliases: [
       "Ciência de Dados e Inteligência Artificial",
+      "Ciencia de Dados e Inteligencia Artificial",
       "Ciência de Dados e IA",
+      "Ciencia de Dados e IA",
       "Ciência de Dados e Inteligência Artificial (Bacharelado)",
+      "Ciencia de Dados e Inteligencia Artificial (Bacharelado)",
+      "Ciência de Dados e Inteligência Artificial - Bacharelado",
+      "Ciência de Dados e Inteligência Artificial - Graduação",
+      "Ciencia de Dados e Inteligencia Artificial - Graduacao",
+      "CIÊNCIA DE DADOS E INTELIGÊNCIA ARTIFICIAL (BACHARELADO)/CI - João Pessoa",
+      "CIENCIA DE DADOS E INTELIGENCIA ARTIFICIAL (BACHARELADO)/CI - Joao Pessoa",
     ],
   },
   {
     canonicalName: "Engenharia de Robôs",
-    aliases: ["Engenharia de Robôs", "Engenharia de Robos", "Engenharia de Robôs (Bacharelado)"],
+    aliases: [
+      "Engenharia de Robôs",
+      "Engenharia de Robos",
+      "Engenharia de Robôs (Bacharelado)",
+      "Engenharia de Robos (Bacharelado)",
+      "Engenharia de Robôs - Bacharelado",
+      "Engenharia de Robôs - Graduação",
+      "Engenharia de Robos - Graduacao",
+      "ENGENHARIA DE ROBÔS (BACHARELADO)/CI - João Pessoa",
+      "ENGENHARIA DE ROBOS (BACHARELADO)/CI - Joao Pessoa",
+    ],
   },
 ] as const;
 
@@ -78,9 +121,30 @@ for (const group of aliasGroups) {
 
 const digest = (value: string): string => createHash("sha256").update(value).digest("hex");
 
+const stripCiJoaoPessoaPortalSuffix = (normalized: string): string | null => {
+  if (!normalized.endsWith(CI_JOAO_PESSOA_PORTAL_SUFFIX)) {
+    return null;
+  }
+  const stripped = normalized.slice(0, -CI_JOAO_PESSOA_PORTAL_SUFFIX.length).trim();
+  return stripped.length > 0 ? stripped : null;
+};
+
 const canonicalNameFor = (value: string): string | null => {
-  const matches = canonicalNamesByAlias.get(normalizeSigaaCourseName(value));
-  return matches?.size === 1 ? [...matches][0] : null;
+  const normalized = normalizeSigaaCourseName(value);
+  const direct = canonicalNamesByAlias.get(normalized);
+  if (direct?.size === 1) {
+    return [...direct][0];
+  }
+
+  const withoutPortalSuffix = stripCiJoaoPessoaPortalSuffix(normalized);
+  if (withoutPortalSuffix) {
+    const stripped = canonicalNamesByAlias.get(withoutPortalSuffix);
+    if (stripped?.size === 1) {
+      return [...stripped][0];
+    }
+  }
+
+  return null;
 };
 
 export const sigaaTargetCatalogToken = (course: SigaaCatalogCourse): string =>


### PR DESCRIPTION
## Summary
- Expande a allowlist versionada de aliases SIGAA (`ufpb-2026-09-02`) para reconhecer rótulos do portal CI João Pessoa e formas `- Graduação` / `- Bacharelado` de CC, EC, CDIA e ER.
- Corrige `SIGAA_COURSE_MISMATCH` / `source_unrecognized` reportado no sync de Ciência da Computação (EC já tinha cobertura de Graduação; CC não).
- Mantém fail-closed para outros campi/modalidades (Campina Grande, Rio Tinto, Licenciatura EAD, Energias Renováveis).

## Test plan
- [x] `npx jest src/lib/server/services/sigaa/__tests__/course-aliases.test.ts` (29 passing)
- [ ] Sync SIGAA real em staging com conta de Ciência da Computação
- [ ] Smoke: EC / CDIA / Engenharia de Robôs ainda resolvem
- [ ] Confirmar que rótulos `/CT - Campina Grande` e Licenciatura EAD continuam bloqueados